### PR TITLE
Punch list 15

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -319,51 +319,35 @@ html body[data-scroll-locked] {
 }
 
 /* A collection CARD, called out while its child-timeline row's folder is
-   hovered (PL10-001, replacing PL9-002's glow): one elastic grow that
-   overshoots and springs back to rest. A one-shot, not a loop — the pointer
-   sits on a folder for as long as the user is reading the tree, and a throb
-   for all of that is noise.
+   hovered.
 
-   TRANSFORM only. Never the element's opacity (see the trash note above),
-   and never a width/height/margin: these cards sit in a virtualized strip
-   where a box-model change would shove every neighbour. A scale composites
-   on its own layer and moves nothing else on the board — which is exactly
-   why this one is allowed where the box change the old comment forbade is
-   not. */
-@keyframes collection-paired-callout {
-  0% {
-    transform: scale(1);
-  }
-  /* Out fast... */
-  40% {
-    transform: scale(1.06);
-  }
-  /* ...then past rest, and settle. The undershoot is what reads as elastic;
-     without it the card just inflates and deflates. */
-  68% {
-    transform: scale(0.985);
-  }
-  86% {
-    transform: scale(1.012);
-  }
-  100% {
-    transform: scale(1);
-  }
+   A STEADY GLOW, HELD WHILE THE ROW IS HOVERED (PL15-009). It was an elastic
+   SCALE — one grow that overshot and sprang back (PL10-001, itself replacing
+   PL9-002's glow) — and the jiggle is what was asked to go.
+
+   The glow is not a new invention: it is PL9-002's, which survived this whole
+   time inside `prefers-reduced-motion` as the version "for exactly the users
+   who cannot see the new one". Removing the animation promotes it to
+   everyone, so what the mark SAYS is unchanged and only how it says it is.
+
+   ON `.is-called-out-card`, which until now carried no rule at all and was a
+   bare e2e handle. The animation class is gone rather than emptied: a class
+   named `animate-` that animates nothing is a trap for the next reader.
+
+   NO LAYOUT, for the reason the old comment gave and which still holds —
+   these cards sit in a virtualized strip where a box-model change would shove
+   every neighbour. A box-shadow paints outside the box and takes no part in
+   layout or scroll size, which is a stronger version of the guarantee a
+   composited transform gave. */
+.is-called-out-card {
+  box-shadow: 0 0 16px 3px rgba(56, 189, 248, 0.5);
+  transition: box-shadow 150ms ease-out;
 }
 
-.animate-collection-paired-callout {
-  /* 320ms is COLLECTION_CALLOUT_KEYFRAMES_MS in graph-collection-hover.tsx.
-     Change one, change the other.
-
-     The class is held on for LONGER than this on purpose (see
-     COLLECTION_CALLOUT_MS there). Holding it for exactly this long looks
-     right and is not: the hold timer starts when the class is applied, the
-     animation starts a frame later, so an equal hold cancels the final
-     frames of the settle. */
-  animation: collection-paired-callout 320ms cubic-bezier(0.34, 1.56, 0.64, 1);
-  /* Grow from the card's middle, so a card at either end of the strip pushes
-     out symmetrically instead of sliding off its own origin. */
-  transform-origin: center center;
+@media (prefers-reduced-motion: reduce) {
+  .is-called-out-card {
+    transition: none;
+  }
 }
 
 /* The trim view's grow-from-the-card (PL10-008). The browser morphs the
@@ -385,17 +369,8 @@ html body[data-scroll-locked] {
 @media (prefers-reduced-motion: reduce) {
   .animate-trash-arrival,
   .animate-trash-armed-pulse,
-  .animate-trash-hover-attention,
-  .animate-collection-paired-callout {
+  .animate-trash-hover-attention {
     animation: none;
-  }
-
-  /* The connection still has to READ without motion: with the scale off,
-     hold a steady glow for as long as the row is hovered instead. This is
-     the old PL9-002 call-out, kept for exactly the users who cannot see the
-     new one. */
-  .animate-collection-paired-callout {
-    box-shadow: 0 0 16px 3px rgba(56, 189, 248, 0.5);
   }
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -2478,12 +2478,20 @@ export function GraphBoard({
                     shape of what is drawn, not its contents: whether this run
                     is grouped into its collections, and whether the nested
                     timelines draw below it. */}
-                {/* INVERTED against the state it drives. The strip opens flat
-                    (see `flatOn`'s default), so the thing left to offer is the
-                    nesting, and `active` is `!flatOn` — pressed means you have
-                    left the flat run for the collections. Writing it the other
-                    way round would give the strip a control that is lit on
-                    arrival and whose job is to turn itself off.
+                {/* INVERTED against the state it drives: `active` is
+                    `!flatOn`, so lit means you are IN collections and the
+                    press takes you to the flat run.
+
+                    THIS COMMENT USED TO ARGUE THE OPPOSITE, and the reason it
+                    changed is the default, not the reasoning. The strip opened
+                    flat, so the thing left to offer was the nesting, and the
+                    objection to writing it the other way round was that it
+                    would leave "a control that is lit on arrival and whose job
+                    is to turn itself off". The strip opens in COLLECTIONS now
+                    (PL15-003), which makes lit-on-arrival simply true — the
+                    control reports the posture you are in rather than dangling
+                    an unused offer, and the alternative would be a toggle
+                    wearing the collection mark to mean "not collections".
 
                     Strip only: grid keeps its nesting, so there is nothing to
                     flatten there. */}

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-trim.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-trim.tsx
@@ -118,24 +118,31 @@ export const GraphTrimHandle = memo(function GraphTrimHandle({
         // the outer edge — so the grip below, at a measured 50%, still read as
         // off-centre. The bar was never the problem; the field around it was.
         //
-        // QUIET AT REST, and the armed state below is what pays for it. This
-        // was a solid `white/85` — what an affordance looks like when it has
-        // to announce itself unaided, on every clip, forever. It no longer
-        // does: a press on the strip has to settle before it trims (the same
-        // drag is how the strip pans), so the handle now has a MOMENT to speak
-        // at, and at rest it can recede into the clip instead of sitting on
-        // six edges shouting. GREY rather than a dimmer white because it has
-        // to hold against a bright frame as well as a dark one, and because
-        // grey is the one value here that is not already a state — blue is
-        // selection everywhere on this board (the ring, the check, the count)
-        // and amber reads as a third accent.
-        "bg-zinc-400/45",
-        // ARMED: the press settled, and the next pull edits rather than
-        // scrolls. Those two outcomes are far enough apart that the handle has
-        // to say which one it is holding — the one moment it goes full
-        // strength. Colour only, no geometry: it must not move under the
-        // finger already on it.
-        "transition-colors group-data-[trim-armed=true]/trim:bg-white/95",
+        // WHITE AT REST (PL15-004). It was `bg-zinc-400/45` — grey, chosen so
+        // the handle could recede into the clip and let the armed state carry
+        // the announcement. The call now is the other way: a handle should
+        // read as a handle before you touch it, and it wears the same white
+        // arming used to promote it to.
+        //
+        // The grey had a reason worth keeping in view rather than deleting:
+        // it holds against a bright frame as well as a dark one, and it was
+        // the one value here that is not already a state (blue is selection
+        // everywhere on this board — the ring, the check, the count — and
+        // amber reads as a third accent). White at 95% is opaque enough to
+        // hold on a blown-out frame; that is the case to look at first if this
+        // ever reads badly.
+        "bg-white/95",
+        // ARMING IS THE GRIP'S JOB NOW, and it has to be, because the collar
+        // has no colour change left to make — it is already at full strength
+        // before the press settles.
+        //
+        // That distinction still matters: the same drag pans the strip, so a
+        // settled press means the next pull EDITS rather than scrolls, and the
+        // handle has one moment to say which it is holding. The grip below
+        // says it — `h-5` to full height, `black/45` to `black/70` — a
+        // geometry and ink change INSIDE the handle rather than to it, so
+        // nothing moves under the finger already on it.
+        "transition-colors",
         side === "left" ? "rounded-l-md" : "rounded-r-md",
       ].join(" ")}
     >

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -158,7 +158,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           // between folders drops it off one card and adds it to the next, so
           // the animation re-fires without a counter or a manual restart, and
           // re-entering the same folder replays it.
-          calledOut ? "is-called-out-card animate-collection-paired-callout" : "",
+          calledOut ? "is-called-out-card" : "",
         ].join(" ")}
       >
         {muted && <DisabledChip inherited={node.disabled !== true} />}

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-hover.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-hover.tsx
@@ -3,9 +3,7 @@
 import {
   createContext,
   useContext,
-  useEffect,
   useMemo,
-  useState,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -109,49 +107,36 @@ export function useCollectionHoverSource(collectionId: string): Readonly<{
   );
 }
 
-/**
- * How long the card's call-out keyframes run. MUST stay in sync with
- * `collection-paired-callout` in globals.css.
+/*
+ * TWO DURATIONS USED TO LIVE HERE and both are gone with the animation
+ * (PL15-009): `COLLECTION_CALLOUT_KEYFRAMES_MS`, which had to stay equal to
+ * the keyframes in globals.css, and `COLLECTION_CALLOUT_MS`, which was
+ * deliberately LONGER so a hold could outlast them.
+ *
+ * The second one is worth remembering even though nothing needs it now. A hold
+ * equal to the animation's own duration expired a frame or two BEFORE the
+ * animation ended — the timer started when the class was applied and the
+ * animation only started the frame after — so it dropped the class mid-flight
+ * and cancelled precisely the settle it existed to protect, on roughly half of
+ * runs. Any future "hold a class for exactly as long as its animation" has the
+ * same bug waiting in it.
  */
-const COLLECTION_CALLOUT_KEYFRAMES_MS = 320;
-
-/**
- * How long the class is HELD on the card, which is deliberately longer.
- *
- * The hold must OUTLAST the keyframes, not merely match them. This timer
- * starts when the class is set; the animation does not start until the frame
- * AFTER the browser has applied it. So a hold equal to the duration expires a
- * frame or two BEFORE the animation ends, drops the class mid-flight, and
- * cancels precisely what the hold exists to protect — the last frames of the
- * elastic settle. The old value was exactly 320 and did this on roughly half
- * of runs, reporting `cancelled` instead of `finished`.
- *
- * That is also why the e2e asserts on the animation's own outcome rather than
- * on the class still being present: presence is a race, `finished` vs
- * `cancelled` is the actual question.
- *
- * The margin is a few frames at 60Hz — enough to absorb a couple of slow ones,
- * and imperceptible because the class does nothing once the keyframes have
- * ended (no fill mode, so the card is already back at rest).
- */
-export const COLLECTION_CALLOUT_MS = COLLECTION_CALLOUT_KEYFRAMES_MS + 80;
 
 /**
  * The TARGET end, for a collection card: whether its row is being hovered
- * right now. Drives a one-shot call-out on the card (see
- * `graph-item-content`), so what matters is the transition into true.
+ * right now.
  *
- * It HOLDS past the pointer leaving. The call-out is an animation, and the
- * card only carries it for as long as this returns true — so a flick across a
- * folder used to start the elastic scale and then kill it a frame or two in,
- * leaving a card that twitched and stopped. Once triggered it now plays out,
+ * IT FOLLOWS THE POINTER EXACTLY, and that is a change of kind rather than a
+ * simplification (PL15-009). This used to HOLD past the pointer leaving,
+ * because the call-out was a one-shot animation: a flick across a folder
+ * started the elastic scale and then killed it a frame or two in, leaving a
+ * card that twitched and stopped, so once triggered it was made to play out
  * whether or not the pointer stayed.
  *
- * The hold is timed from the FIRST trigger, not extended by later ones: it
- * tracks the animation that is already running, so re-entering the same folder
- * mid-play lets that play finish rather than restarting it (a wiggle over one
- * row shouldn't strobe). Re-entering after it ends drops the class and re-adds
- * it, which is what restarts the animation.
+ * A steady glow wants the opposite. There is no play to protect, and a
+ * highlight that outlived the pointer by a third of a second would read as
+ * lag — the card staying lit after you have moved on, which is exactly the
+ * complaint a hold was invented to cure in the other direction.
  */
 export function useCollectionHoverTarget(collectionId: string): boolean {
   const channel = useContext(CollectionHoverContext);
@@ -161,26 +146,5 @@ export function useCollectionHoverTarget(collectionId: string): boolean {
     () => false,
   );
 
-  const [holding, setHolding] = useState(false);
-  const [wasHovered, setWasHovered] = useState(hovered);
-
-  // Latch on the RISING edge, adjusted during render (the repo's
-  // cascading-render-safe pattern — a synchronous setState in an effect trips
-  // the lint). Edge-triggered, not level-triggered: latching on every render
-  // where `hovered` is true would re-arm the timer forever while the pointer
-  // rests on a folder.
-  if (hovered !== wasHovered) {
-    setWasHovered(hovered);
-    if (hovered) setHolding(true);
-  }
-
-  useEffect(() => {
-    if (!holding) return;
-    // Deliberately NOT keyed on `hovered`: the whole point is that the pointer
-    // leaving must not cancel this timer.
-    const timer = window.setTimeout(() => setHolding(false), COLLECTION_CALLOUT_MS);
-    return () => window.clearTimeout(timer);
-  }, [holding]);
-
-  return hovered || holding;
+  return hovered;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -460,7 +460,17 @@ function openBarSettings(): void {
   // opens, so every helper below then looked for its group inside content that
   // was not there and failed on a null that had nothing to do with the group.
   fireEvent.pointerDown(trigger!, { button: 0, isPrimary: true });
-  expect(document.querySelector("[data-seam-settings-content]")).not.toBeNull();
+  const content = document.querySelector<HTMLElement>("[data-seam-settings-content]");
+  expect(content).not.toBeNull();
+
+  // AND IT IS IN FRONT OF THE MODAL. Radix portals this to `document.body`, so
+  // the menu is a SIBLING of the details view rather than a descendant — and
+  // the view is `z-[80]` while `DropdownMenuContent` defaults to `z-50`. It
+  // opened, in the right place, behind the scrim: a gear that visibly did
+  // nothing. Asserted as a NUMBER rather than a class, because the class is
+  // merged with the component's default and which of the two wins is the
+  // actual question.
+  expect(Number(getComputedStyle(content!).zIndex)).toBeGreaterThan(80);
 }
 
 function framesTo(label: string): void {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2875,6 +2875,21 @@ export const TheBarMarksTheEndsOfTheProject: Story = {
       .getBoundingClientRect();
     expect(endCap.left).toBeGreaterThanOrEqual(last.right - 0.5);
 
+    // AND EACH STOP SAYS WHICH END IT IS (PL15-014), in the room the widened
+    // gap makes for it — between the stop and the film, not on top of either.
+    const startLabel = document.querySelector<HTMLElement>('[data-seam-cap-label="start"]')!;
+    const endLabel = document.querySelector<HTMLElement>('[data-seam-cap-label="end"]')!;
+    expect(startLabel.textContent).toBe("Start");
+    expect(endLabel.textContent).toBe("End");
+
+    // THE GAP IS BIGGER THAN THE ONE BETWEEN TWO BOXES, which is the whole
+    // point of the item: at the old inset the stop read as another clip's edge.
+    // Measured against this scene's own box gap rather than a literal, so the
+    // assertion survives a change to either number.
+    const boxGap = seamBoxes()[1]!.getBoundingClientRect().left - first.right;
+    expect(first.left - startCap.right).toBeGreaterThan(boxGap);
+    expect(endCap.left - last.right).toBeGreaterThan(boxGap);
+
     // CROPPED AT BOTH ENDS: the subject is ten clips in and five either side
     // reaches neither, so neither stop is true and neither is drawn.
     reachTo("5");

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1328,6 +1328,51 @@ export const TagsAreAddedFromAnIcon: Story = {
  * What did change discontinuously was HEIGHT — see the neighbour branch in
  * `graph-item-details-panel`. That is what the second assertion is for.
  */
+/**
+ * THE FILM CAN BE DRAWN TALLER (PL15-022).
+ *
+ * `sm` is the height the bar has always used, so the control changes nothing
+ * until it is pressed. What makes it worth a story is the part that is not
+ * obvious from the label: a filmstrip CELL IS SQUARE, so the height also sets
+ * how many frames a clip's box is cut into — a taller film is a coarser
+ * filmstrip as well as a bigger one.
+ */
+export const TheFilmCanBeDrawnTaller: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+
+    const lane = () =>
+      document.querySelector<HTMLElement>("[data-seam-boxes]")?.getBoundingClientRect().height ??
+      0;
+    const press = (label: string) => {
+      openBarSettings();
+      const group = document.querySelector<HTMLElement>("[data-details-bar-size]")!;
+      const button = Array.from(group.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.trim() === label,
+      )!;
+      fireEvent.click(button);
+    };
+
+    const small = lane();
+    expect(small).toBeGreaterThan(0);
+
+    press("MD");
+    await waitFor(() => expect(lane()).toBeGreaterThan(small));
+    const medium = lane();
+
+    press("LG");
+    await waitFor(() => expect(lane()).toBeGreaterThan(medium));
+
+    // PUT IT BACK. Like the reach and the view count, this is remembered at
+    // module scope for the session — a story that leaves the film tall hands
+    // it to whichever story runs next in the same browser.
+    press("SM");
+    await waitFor(() => expect(lane()).toBe(small));
+  },
+};
+
 export const ChangingTheCountResizesTheSamePanels: Story = {
   // A LONG scene on purpose. `TRIMMED_SCENE` holds three clips, so "show five"
   // has nothing to show and the step this story is about cannot happen at all.

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -4127,6 +4127,16 @@ export const TheTransportSitsOnTheControlRow: Story = {
       return box.top + box.height / 2;
     };
     const transport = centreY("[data-seam-transport]");
+    // THE CLOCK IS ON THE LEFT NOW (PL15-021), where the settings used to be.
+    // Asserted against the transport rather than as a pixel: it has to be left
+    // of the thing it reports on, and the row is a grid so the two cannot be
+    // compared by class.
+    const clockBox = document.querySelector<HTMLElement>("[data-seam-clock]")!;
+    const transportBox = document.querySelector<HTMLElement>("[data-seam-transport]")!;
+    expect(clockBox.getBoundingClientRect().right).toBeLessThan(
+      transportBox.getBoundingClientRect().left,
+    );
+
     // WHAT IS LEFT IN THE ROW, which is now reach and the gear (PL15-006).
     // Frames, card and fit are inside the gear's menu and are no longer on
     // this line at all, so asking them to share its centre would be asserting

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -439,7 +439,32 @@ function centreBox(): HTMLElement {
  * scope for the session, so a story that leaves frames on hands them to
  * whichever story runs next in the same browser.
  */
+/**
+ * Open the bar's settings gear, if its contents are not already showing.
+ *
+ * FRAMES, CARD AND FIT LIVE BEHIND IT NOW (PL15-006) — they were three
+ * labelled groups strung along the controls row and are one menu. Every story
+ * that presses one of their segments has to open the menu first, and a handle
+ * behind an unopened trigger fails as a TIMEOUT rather than an assertion, so
+ * this exists to be called rather than each story remembering.
+ *
+ * Idempotent on purpose: several of these helpers are called in sequence, and
+ * a second click on an open trigger would close it again.
+ */
+function openBarSettings(): void {
+  if (document.querySelector("[data-seam-settings-content]") !== null) return;
+  const trigger = document.querySelector<HTMLButtonElement>("[data-seam-settings-menu]");
+  expect(trigger).not.toBeNull();
+  // POINTERDOWN, NOT `click()`. Radix opens a dropdown on the pointer going
+  // DOWN — a synthetic `click()` dispatches only the click and the menu never
+  // opens, so every helper below then looked for its group inside content that
+  // was not there and failed on a null that had nothing to do with the group.
+  fireEvent.pointerDown(trigger!, { button: 0, isPrimary: true });
+  expect(document.querySelector("[data-seam-settings-content]")).not.toBeNull();
+}
+
 function framesTo(label: string): void {
+  openBarSettings();
   const group = document.querySelector<HTMLElement>("[data-details-bar-frames]");
   expect(group).not.toBeNull();
   const button = Array.from(group!.querySelectorAll("button")).find(
@@ -2765,6 +2790,7 @@ export const ThePlaybarOpensAsFilm: Story = {
 
     // The control says so too, which is what makes the bar's state readable
     // rather than merely true.
+    openBarSettings();
     const group = document.querySelector<HTMLElement>("[data-details-bar-frames]")!;
     const badges = Array.from(group.querySelectorAll("button"));
     expect(badges.map((badge) => badge.textContent?.trim())).toEqual([
@@ -2872,7 +2898,10 @@ export const TheTwoBarsAreAdjacent: Story = {
 
     // ── AND EVERYTHING ELSE IS IN THAT ROW WITH IT ────────────────────────
     const row = document.querySelector<HTMLElement>("[data-seam-controls]")!;
-    expect(row.querySelector("[data-details-bar-frames]")).not.toBeNull();
+    // THE SETTINGS ARE BEHIND THE GEAR, NOT IN THE ROW (PL15-006) — what is
+    // left in it is what you drive while reading the bar.
+    expect(row.querySelector("[data-seam-settings-menu]")).not.toBeNull();
+    expect(row.querySelector("[data-details-bar-frames]")).toBeNull();
     expect(row.querySelector("[data-details-bar-reach]")).not.toBeNull();
     expect(row.querySelector("[data-seam-transport]")).not.toBeNull();
     // The clock, which used to sit at the far right of the scrub bar itself.
@@ -2881,9 +2910,12 @@ export const TheTwoBarsAreAdjacent: Story = {
     // because the left half MOVES and the second decimal is a blur at
     // playback speed.
     expect(row.textContent).toMatch(/\d+:\d\d\.\d\s*\/\s*\d+:\d\d\.\d/);
-    // And the fit control, which shares the row for the same reason the reach
-    // does: both are questions about how much of the bar you are looking at.
-    expect(row.querySelector("[data-seam-fit]")).not.toBeNull();
+    // FIT WENT INTO THE GEAR WITH THE OTHER TWO and reach did not, which is
+    // the whole distinction this item drew: reach changes how much of the
+    // sequence is on the bar, so you reach for it while reading; fit is a
+    // scale you set. Asserted here because "everything is in the row" is no
+    // longer the claim.
+    expect(row.querySelector("[data-seam-fit]")).toBeNull();
 
     // ── AND THE TRACK GOT THE WIDTH THE TRANSPORT AND CLOCK GAVE UP ───────
     // They were siblings of the track, so the bar was as wide as the modal
@@ -3482,7 +3514,8 @@ export const FitRescalesTheBar: Story = {
     const scale = () => Number(track.getAttribute("data-seam-pps"));
     const button = (label: string) =>
       Array.from(
-        document.querySelectorAll<HTMLButtonElement>("[data-seam-fit] button"),
+        (openBarSettings(),
+        document.querySelectorAll<HTMLButtonElement>("[data-seam-fit] button")),
       ).find((found) => found.textContent?.trim() === label)!;
 
     // It opens fitted to the subject's own collection, so that is what is lit.
@@ -3572,6 +3605,7 @@ export const TheHoverCardCanBePinned: Story = {
 
     const lane = document.querySelector<HTMLElement>("[data-seam-boxes]")!;
     const press = (label: string) => {
+      openBarSettings();
       const group = document.querySelector<HTMLElement>("[data-details-bar-card]")!;
       Array.from(group.querySelectorAll("button"))
         .find((button) => button.textContent?.trim() === label)!
@@ -4083,11 +4117,13 @@ export const TheTransportSitsOnTheControlRow: Story = {
       return box.top + box.height / 2;
     };
     const transport = centreY("[data-seam-transport]");
+    // WHAT IS LEFT IN THE ROW, which is now reach and the gear (PL15-006).
+    // Frames, card and fit are inside the gear's menu and are no longer on
+    // this line at all, so asking them to share its centre would be asserting
+    // the geometry of a popover against the row that opens it.
     for (const group of [
-      "[data-details-bar-frames]",
-      "[data-details-bar-card]",
-      "[data-seam-fit]",
       "[data-details-bar-reach]",
+      "[data-seam-settings-menu]",
     ]) {
       expect(`${group} offset ${Math.round(centreY(group) - transport)}`).toBe(
         `${group} offset 0`,

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2158,6 +2158,37 @@ export const TheMinimapMovesTheWindow: Story = {
     const ink = marked.backgroundColor.match(/[\d.]+/g)!.slice(0, 3).map(Number);
     expect(Math.min(...ink)).toBeGreaterThan(200);
 
+    // AND A CARET UNDER IT (PL15-017) — the bar's own mark at map scale,
+    // pointing up at the segment instead of down at the film.
+    //
+    // ONE, and inside the marked segment. Being a CHILD is not decoration in
+    // the test either: it is how the caret finds the segment's centre at all.
+    // The segments are flex items sized by duration with a margin at every
+    // collection seam, so their centres are not a percentage of the run —
+    // asserting containment is asserting that nothing has quietly gone back
+    // to positioning it by arithmetic.
+    const carets = document.querySelectorAll<HTMLElement>("[data-seam-mini-active-mark]");
+    expect(carets.length).toBe(1);
+    expect(live[0]!.contains(carets[0]!)).toBe(true);
+
+    // CENTRED ON THE SEGMENT, and hanging directly beneath it. Half a pixel of
+    // slack on each: the segment's width is a flex fraction of a duration, so
+    // both numbers land on subpixels routinely.
+    const caretBox = carets[0]!.getBoundingClientRect();
+    const liveBox = live[0]!.getBoundingClientRect();
+    expect(Math.abs((caretBox.left + caretBox.right) / 2 - (liveBox.left + liveBox.right) / 2))
+      .toBeLessThanOrEqual(0.5);
+    expect(Math.abs(caretBox.top - liveBox.bottom)).toBeLessThanOrEqual(0.5);
+
+    // IT STAYS INSIDE THE RAIL. The caret is wider than the narrowest possible
+    // segment, so a short clip at either end is where it would hang off — and
+    // a mark drawn past the end of the map is not reporting a position, for
+    // the same reason the bar's own mark is clamped.
+    const rail = minimap.getBoundingClientRect();
+    expect(caretBox.left).toBeGreaterThanOrEqual(rail.left - 0.5);
+    expect(caretBox.right).toBeLessThanOrEqual(rail.right + 0.5);
+    expect(caretBox.bottom).toBeLessThanOrEqual(rail.bottom + 0.5);
+
     // ── AND THE PANELS EITHER SIDE, ONE TIER DOWN ────────────────────────
     //
     // The map marks what is ON SCREEN, the same set the film strip draws

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -3050,6 +3050,20 @@ export const TheBarMarksTheEndsOfTheProject: Story = {
       .getBoundingClientRect();
     expect(endCap.left).toBeGreaterThanOrEqual(last.right - 0.5);
 
+    // THE SUBJECT'S COLUMN RUNS PAST THE FILM (PL15-026). The ruler tinted the
+    // active clip's stretch of scale and stopped at its own band, so the clip
+    // being worked on was marked ABOVE the film and nowhere else. The block
+    // continues down through it now, into the space before the minimap.
+    const column = document.querySelector<HTMLElement>("[data-seam-active-column]")!;
+    const columnBox = column.getBoundingClientRect();
+    const laneBox = document.querySelector<HTMLElement>("[data-seam-boxes]")!.getBoundingClientRect();
+    // PAST the film, not merely as tall as it — the point of the item is the
+    // space underneath.
+    expect(columnBox.bottom).toBeGreaterThan(laneBox.bottom);
+    // And it is the SUBJECT's width, not the whole track's.
+    expect(columnBox.width).toBeLessThan(laneBox.width);
+    expect(columnBox.width).toBeGreaterThan(0);
+
     // AND EACH STOP SAYS WHICH END IT IS (PL15-014), in the room the widened
     // gap makes for it — between the stop and the film, not on top of either.
     const startLabel = document.querySelector<HTMLElement>('[data-seam-cap-label="start"]')!;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1274,6 +1274,94 @@ export const TagsAreAddedFromAnIcon: Story = {
  * the panel fits its picture instead of holding two thirds of the screen with
  * most of it black.
  */
+/**
+ * A COUNT CHANGE IS A RESIZE, NOT A REPLACEMENT (PL15-005).
+ *
+ * Switching 3 to 5 read as the three panels animating off and five animating
+ * on. Nothing is actually being replaced: the subject is the same clip and its
+ * neighbours are the same clips, so what should happen is that the panels on
+ * screen shrink into their new width and two more arrive at the edges.
+ *
+ * IT WAS NEVER A KEYING PROBLEM, which is what made it worth pinning here. The
+ * row renders every id in the flat order keyed by `id`, and mounts real panels
+ * within `MOUNTED_RADIUS = floor(count / 2) + 1` — so at three the visible set
+ * is centre +/-1 and the mounted set is centre +/-2, and at five the visible
+ * set is centre +/-2. The two panels that BECOME visible were already mounted;
+ * React never threw anything away. The identity assertion below states that,
+ * so a future "fix" that starts remounting them fails here.
+ *
+ * What did change discontinuously was HEIGHT — see the neighbour branch in
+ * `graph-item-details-panel`. That is what the second assertion is for.
+ */
+export const ChangingTheCountResizesTheSamePanels: Story = {
+  // A LONG scene on purpose. `TRIMMED_SCENE` holds three clips, so "show five"
+  // has nothing to show and the step this story is about cannot happen at all.
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    const panels = () =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-item-details-panel]"));
+    await waitFor(() => expect(panels().length).toBeGreaterThanOrEqual(3));
+
+    const press = async (label: string) => {
+      const button = Array.from(
+        document.querySelectorAll<HTMLButtonElement>("[data-details-view-count] button"),
+      ).find((b) => b.textContent?.trim() === label)!;
+      fireEvent.click(button);
+      await waitFor(() => expect(button.getAttribute("aria-pressed")).toBe("true"));
+    };
+
+    // The ELEMENTS, held across the step. Identity, not a count or a name — a
+    // replacement would satisfy either of those and is exactly what is being
+    // ruled out.
+    const before = panels();
+    const heightsBefore = before.map((panel) => Math.round(panel.getBoundingClientRect().height));
+
+    await press("5");
+    // MOUNTED, not visible: the row keeps a spare panel either side of what can
+    // be seen, so the count is `min(ids, count + 2)` rather than the count.
+    // What matters here is that it GREW — five-up mounts more than three-up —
+    // and the identity assertions below carry the actual claim.
+    await waitFor(() => expect(panels().length).toBeGreaterThan(before.length));
+
+    const after = panels();
+    for (const panel of before) {
+      expect(after).toContain(panel);
+    }
+
+    // AND A NEIGHBOUR'S HEIGHT IS A RULE, NOT ITS PICTURE'S.
+    //
+    // The height used to be a container query on the panel's own WIDTH — a
+    // definite 38.9vh over 30rem, `h-auto` under it — and a count change walks
+    // straight across that threshold: measured at 1920, a neighbour is 490px
+    // at three-up and 314px at five-up. `auto` cannot be interpolated, so
+    // every neighbour's height jumped in one frame while its width eased,
+    // which is most of what read as a replacement.
+    //
+    // ASSERTED AS THE VALUE, not as a before/after delta, and that distinction
+    // was learned the hard way here: this story's viewport is far narrower
+    // than 1880, so BOTH counts fall under 30rem and both were `h-auto`
+    // together. A delta comparison passed against the unfixed code — it was
+    // measuring a threshold neither state crossed. The rule itself is
+    // width-independent and holds at any viewport.
+    const neighbourHeight = () => {
+      const neighbour = panels().find(
+        (panel) => panel.getAttribute("data-item-details-panel") === "neighbour",
+      )!;
+      return neighbour.getBoundingClientRect().height;
+    };
+    expect(neighbourHeight()).toBeCloseTo(window.innerHeight * 0.389, 0);
+    expect(heightsBefore.length).toBeGreaterThan(0);
+
+    // Back again, and every panel that remains was one of the originals — the
+    // return trip is a resize too, not a fresh set.
+    await press("3");
+    await waitFor(() => expect(panels().length).toBe(before.length));
+    for (const panel of panels()) {
+      expect(before).toContain(panel);
+    }
+  },
+};
+
 export const NarrowPanelsShedTheirControlsAndStayAligned: Story = {
   render: () => <SeamHarness scene={TRIMMED_SCENE} />,
   play: async () => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -803,7 +803,38 @@ function DetailsFilmstripModal({
   // the same shape on all three and only ever felt on the first.
   const hasPrevious = centre > 0;
   const hasNext = centre >= 0 && centre < ids.length - 1;
-  const [dragPx, setDragPx] = useState(0);
+  /**
+   * THE DRAG OFFSET IS NOT REACT STATE (PL15-016), and the ref beside it
+   * explains why it should never have been.
+   *
+   * That ref's own comment already said it: "this changes on nearly every
+   * pointer move and only the ROW's transform cares. A re-render per move to
+   * store a start coordinate would re-render three live panels — video
+   * elements included — sixty times a second for the duration of a swipe."
+   * Exactly right, and then the OFFSET was `useState` and did the very thing
+   * one level up — `setDragPx` per move, read by `rowTransform`, which is
+   * built in this component's render. So every pointer move re-rendered the
+   * whole modal, which mounts up to `MOUNTED_RADIUS * 2 + 1` panels, each a
+   * video element, a trim strip and a tag editor.
+   *
+   * A CSS VARIABLE, WRITTEN STRAIGHT TO THE ELEMENT. The transform reads
+   * `var(--drag-px, 0px)`, and the move handler sets that property on the row
+   * itself — so a pan touches one style property on one element and React is
+   * not involved at all. A custom property also survives an unrelated
+   * re-render: React only writes the style keys it manages, so a playhead tick
+   * mid-swipe cannot clobber the offset the way rebuilding `transform` from
+   * state would.
+   *
+   * `dragging` stays state because the ROW's transition is keyed to it, and
+   * that flips exactly twice per gesture rather than sixty times a second.
+   */
+  const [dragging, setDragging] = useState(false);
+  // Written to `stripRef` — the row element itself, which already has a ref
+  // for the landing effect. A second ref on the same node would be two names
+  // for one thing and an invitation to attach one of them and not the other.
+  const setDragOffset = useCallback((px: number) => {
+    stripRef.current?.style.setProperty("--drag-px", `${px}px`);
+  }, []);
   // Not state: this changes on nearly every pointer move and only the ROW's
   // transform cares. A re-render per move to store a start coordinate would
   // re-render three live panels — video elements included — sixty times a
@@ -848,18 +879,22 @@ function DetailsFilmstripModal({
           if (Math.abs(dx) < 8 || Math.abs(dx) <= Math.abs(dy)) return;
           drag.committed = true;
           swipedRef.current = true;
+          // ONE render for the whole gesture: the row drops its transition
+          // here and takes it back on release.
+          setDragging(true);
           try {
             event.currentTarget.setPointerCapture(drag.pointerId);
           } catch {
             /* untrusted pointer — moves over the picture still arrive */
           }
         }
-        setDragPx(swipeOffset(dx, hasPrevious, hasNext));
+        setDragOffset(swipeOffset(dx, hasPrevious, hasNext));
       },
       onPointerUp: (event) => {
         const drag = dragRef.current;
         dragRef.current = null;
-        setDragPx(0);
+        setDragOffset(0);
+        setDragging(false);
         if (drag === null || event.pointerId !== drag.pointerId || !drag.committed) return;
         const intent = swipeIntent({
           dx: event.clientX - drag.x,
@@ -874,7 +909,8 @@ function DetailsFilmstripModal({
       },
       onPointerCancel: () => {
         dragRef.current = null;
-        setDragPx(0);
+        setDragOffset(0);
+        setDragging(false);
       },
       // A SWIPE MUST NOT ALSO COUNT AS A TAP. The picture's click brings a
       // neighbour to the middle, and a swipe that ended on a neighbour would
@@ -888,7 +924,7 @@ function DetailsFilmstripModal({
         event.preventDefault();
       },
     }),
-    [centre, hasNext, hasPrevious, ids, onOpenNeighbour],
+    [centre, hasNext, hasPrevious, ids, onOpenNeighbour, setDragOffset],
   );
 
   // WHERE THE PLAYHEAD IS, read across from the clock. The clock says "this
@@ -903,7 +939,7 @@ function DetailsFilmstripModal({
   })();
 
   const rowTransform =
-    `translateX(calc(-1 * ${offset} * (${panelWidth} + ${PANEL_GAP}) + ${dragPx}px))`;
+    `translateX(calc(-1 * ${offset} * (${panelWidth} + ${PANEL_GAP}) + var(--drag-px, 0px)))`;
 
   return createPortal(
     <div
@@ -1231,7 +1267,7 @@ function DetailsFilmstripModal({
           //
           // A BAR LANDING has no transition at all, which the layout effect
           // above does to the node rather than from here.
-          dragPx === 0
+          !dragging
             ? "transition-[transform,opacity] motion-reduce:transition-none"
             : "",
           // BACK, WHILE THE PREVIEW IS UP.
@@ -1257,7 +1293,7 @@ function DetailsFilmstripModal({
           // finished resizing — see `detailsSlideTransition`. Opacity is not
           // part of the choreography (it is the hover-preview fade), so it
           // keeps the plain step timing and starts immediately.
-          transition: dragPx === 0 ? detailsStepTransition("transform, opacity") : undefined,
+          transition: dragging ? undefined : detailsStepTransition("transform, opacity"),
         }}
       >
         {ids.map((id, index) => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -79,6 +79,13 @@ import {
   type PreviewAnchor,
 } from "./graph-seam-preview-anchor";
 import {
+  LANE_SIZES,
+  laneHeightFor,
+  lastLaneSize,
+  rememberLaneSize,
+  type LaneSize,
+} from "./graph-seam-lane-size";
+import {
   BAR_REACHES,
   barReachLabel,
   barReachWindow,
@@ -288,6 +295,10 @@ function DetailsFilmstripModal({
   // panels are on screen: the row is what you are working on, the bar is how
   // much of the sequence you can get to without leaving it.
   const [reach, setReach] = useState<BarReach>(lastBarReach());
+  // HOW TALL THE FILM IS DRAWN (PL15-022). Remembered for the session like the
+  // reach and the view count, and for the same reason: a working posture, not
+  // a preference.
+  const [laneSize, setLaneSize] = useState<LaneSize>(lastLaneSize());
   // WHAT THE BOXES DRAW, kept beside the reach because it is the same kind of
   // question — how much this control shows you, and of what. Seeded from
   // module scope so it survives the modal being closed and reopened.
@@ -589,6 +600,11 @@ function DetailsFilmstripModal({
   const chooseReach = useCallback((next: BarReach) => {
     rememberBarReach(next);
     setReach(next);
+  }, []);
+
+  const chooseLaneSize = useCallback((next: LaneSize) => {
+    rememberLaneSize(next);
+    setLaneSize(next);
   }, []);
 
   const chooseViewCount = useCallback((next: ViewCount) => {
@@ -1097,6 +1113,34 @@ function DetailsFilmstripModal({
                       can make twice rather than a choice you re-enter. That is
                       the whole reason the two are stored apart even though
                       they are pressed together. */}
+                  {/* HOW TALL THE FILM IS. In the gear with the other
+                      settings rather than in the row, because it is a posture
+                      you set and then work — the same test that put frames,
+                      card and fit there (PL15-006).
+
+                      A CELL IS SQUARE, so this also changes how many frames a
+                      clip is cut into: a taller film is a coarser filmstrip as
+                      well as a bigger one. That is the actual trade and it is
+                      why three sizes are offered rather than a slider — the
+                      in-between values buy nothing and cost a decision. */}
+                  <SegmentedControl
+                    label="size"
+                    ariaLabel="How tall the film is drawn"
+                    groupAttribute="data-details-bar-size"
+                    segments={LANE_SIZES.map((option) => ({
+                      value: option,
+                      label: option.toUpperCase(),
+                      title:
+                        option === "sm"
+                          ? "A compact film"
+                          : option === "md"
+                            ? "Tall enough to recognise a shot"
+                            : "Tall enough to judge a frame",
+                      active: option === laneSize,
+                    }))}
+                    onSelect={chooseLaneSize}
+                  />
+
                   <SegmentedControl
                     label="frames"
                     ariaLabel="What the bar's boxes draw"
@@ -1149,6 +1193,7 @@ function DetailsFilmstripModal({
                   />
                 </>
               }
+              laneHeight={laneHeightFor(laneSize)}
               settingsRight={
                 <SegmentedControl
                   label="reach"

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -639,7 +639,32 @@ export function DetailsPanel({
             // where it renders, so both axes finish together because they finish
             // at all.
             ? "@min-[30rem]:h-[68vh] h-auto"
-            : "@min-[30rem]:h-[38.9vh] h-auto",
+            // THE NEIGHBOUR'S HEIGHT NO LONGER DEPENDS ON ITS WIDTH
+            // (PL15-005), and dropping that query fixes two things at once.
+            //
+            // It was `@min-[30rem]:h-[38.9vh] h-auto`: a definite height when
+            // the panel is wide, and fitted to its own picture when it is not.
+            //
+            // ONE — the query was defeating the rule directly above it at
+            // exactly five-up. Measured at 1920: three-up makes a neighbour
+            // 490px, over the 30rem threshold, so it takes the fixed height;
+            // five-up makes it 314px, under it, so all four fall back to
+            // fitting their own pictures — which is precisely the "four
+            // neighbours at four different heights, which reads as a broken
+            // row" that the fixed height was introduced to prevent. The rule
+            // only held in the layout that needed it least.
+            //
+            // TWO — it is why changing the count read as a replacement rather
+            // than a resize. Crossing 30rem swaps `h-auto` for a vh value, and
+            // `auto` cannot be interpolated, so every neighbour's height
+            // JUMPED in one frame while its width eased over the step. That is
+            // the same fault the height was added to this transition list to
+            // cure, arriving by a different route: one dimension gliding while
+            // the other teleports. With one definite height in both counts the
+            // height simply does not change across a step, and what is left is
+            // a width easing and two panels arriving — which is what a count
+            // change actually is.
+            : "h-[38.9vh]",
         ].join(" ")}
         onPointerDown={(event) => event.stopPropagation()}
       >

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-chrome.tsx
@@ -20,15 +20,37 @@ export function acceptsNativeDrag(event: DragEvent<HTMLElement>): boolean {
 
 /**
  * The drop-zone affordance: every eligible target outlines itself for the
- * duration of the drag, and the one under the pointer is filled in. Ring and
- * background only — nothing here may change the box, or arming the affordance
- * would reflow the strips mid-drag and move the very gaps being aimed at.
+ * duration of the drag, and the one under the pointer is filled in.
+ *
+ * NOTHING HERE MAY CHANGE THE BOX. Arming the affordance mid-drag must not
+ * reflow the strips, or it would move the very gaps being aimed at — so the
+ * edge is painted outside the box (an outline; a ring before it) and never as
+ * a border.
+ *
+ * DASHED AND GREY (PL15-012). It was solid `sky-400` — a bright blue edge over
+ * a blue wash, on every eligible surface, for the whole drag. Loud for
+ * something that is only saying "you could let go here": the drag already has
+ * one thing worth shouting, and it is the insertion bar below, which says
+ * where the thing will actually LAND. Ambient state gives up the accent; the
+ * precise signal keeps it.
+ *
+ * AN OUTLINE, NOT A RING, and that is forced rather than chosen. Tailwind's
+ * `ring-*` is a box-shadow and a box-shadow cannot be dashed. `outline` can,
+ * and shares the property that matters here: it is painted outside the box and
+ * takes no part in layout, so the rule above still holds. A `border` would
+ * not — it would add to the box and do exactly the reflow this must not do.
+ *
+ * The two states stay two states: the surface under the pointer has to be
+ * plainly the one that will take the drop, so it goes brighter and doubles the
+ * dash's weight rather than differing only in tint.
  */
 export function dropZoneClassName(armed: boolean, hovered: boolean): string {
   if (!armed) return "relative rounded-lg";
   return [
-    "relative rounded-lg ring-1 transition-colors duration-150 motion-reduce:transition-none",
-    hovered ? "bg-sky-400/10 ring-2 ring-sky-400" : "bg-sky-400/[0.03] ring-sky-400/40",
+    "relative rounded-lg outline-dashed transition-colors duration-150 motion-reduce:transition-none",
+    hovered
+      ? "bg-zinc-300/[0.07] outline-2 outline-zinc-300/70"
+      : "bg-zinc-300/[0.02] outline-1 outline-zinc-400/35",
   ].join(" ");
 }
 
@@ -70,5 +92,8 @@ export function NativeDropStatus({ upload }: Readonly<{ upload: DropSummary | nu
  * from the wrapper's ORIGIN, so without the anchor the line draws in the wrong
  * place entirely. z-30 clears the grid's own overlay tier as well as its cards.
  */
+/* IT KEEPS THE ACCENT, and now it is the only thing in a drag that has one —
+ * see `dropZoneClassName`. The zone says "this surface would take it"; this
+ * says "it lands HERE", which is the answer actually being aimed at. */
 export const DROP_INDICATOR_CLASS =
   "pointer-events-none absolute left-0 z-30 w-0.5 rounded bg-blue-500 shadow-[0_0_6px_rgba(59,130,246,0.9)]";

--- a/apps/timeline-gstudio001/components/graph-view/graph-project-menu.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-project-menu.stories.tsx
@@ -1,12 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 
-import { Toaster } from "@/components/core/sonner";
-
 import { GraphProjectMenu } from "./graph-project-menu";
 
-// The project `⋮` beside Select: export the project to a JSON file, load one
-// back.
+// The project `⋮` beside Select: export the project to a JSON file.
 //
 // Rendered DIRECTLY rather than through a harness — unlike the render-format
 // group next door, this owns its own trigger and menu and reads no store, so
@@ -14,13 +11,14 @@ import { GraphProjectMenu } from "./graph-project-menu";
 //
 // NO NETWORK, per the storybook workspace's rule. Export is a plain `<a
 // download>` and is never activated here (a story that clicked it would ask the
-// browser to save a file). Load's fetch is stubbed per story, which is the only
-// way to reach the failure toasts — the states worth covering, since a load that
-// is refused server-side is the likely outcome until offline mode is set up.
+// browser to save a file), so the assertion is on the href instead.
 //
-// The TOASTER IS MOUNTED HERE because the app mounts it in the root layout, and
-// failures are reported through it. Without it the component would appear to do
-// nothing on failure and the stories would pass by asserting nothing.
+// LOAD USED TO LIVE HERE and its stories with it (PL15-002). The failure
+// coverage did NOT go with the menu item — `loadProjectFromFile` is still live
+// code reached from the library page, so `components/projects/
+// load-project-button.stories.tsx` carries the refused-load and bad-JSON cases
+// now. Deleting them alongside the menu item would have dropped the only
+// coverage of a corrupt export.
 
 const meta = {
   title: "Graph view/Project menu",
@@ -30,7 +28,6 @@ const meta = {
     (Story) => (
       <div className="graph-view-theme flex min-h-[320px] items-start justify-end bg-zinc-950 p-4">
         <Story />
-        <Toaster />
       </div>
     ),
   ],
@@ -43,7 +40,7 @@ type Story = StoryObj<typeof meta>;
 /** At rest: one 32px ghost square, matching the toggles it sits beside. */
 export const Closed: Story = {};
 
-/** Open, showing both verbs. */
+/** Open, showing the one verb it now holds. */
 export const Open: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -51,84 +48,15 @@ export const Open: Story = {
     // Radix portals the content, so it is outside the canvas element.
     const menu = within(document.body);
     await waitFor(() => expect(menu.getByText("Export project…")).toBeInTheDocument());
-    await expect(menu.getByText("Load project from file…")).toBeInTheDocument();
     // The export item is a real link — that is what makes right-click and
     // middle-click work, and a button would silently lose both.
     await expect(menu.getByText("Export project…").closest("a")).toHaveAttribute(
       "href",
       "/api/timelines/project-toon-town/export",
     );
-  },
-};
-
-/**
- * A refused load: the server says no (offline mode off, or the target being a
- * generated fixture) and the reason has to reach the user.
- *
- * This story is why the message is a TOAST. It was first rendered inside the
- * menu, and uploading fires a real pointerdown on the file input — which Radix
- * treats as an outside press and dismisses the content, taking the only report
- * of the failure with it. A toast outlives the control that started it.
- */
-export const LoadRefused: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const original = window.fetch;
-    window.fetch = (async () =>
-      new Response(
-        JSON.stringify({
-          error: "scale-probe.json is a generated fixture and will not be overwritten.",
-        }),
-        { status: 409, headers: { "content-type": "application/json" } },
-      )) as typeof window.fetch;
-
-    try {
-      await userEvent.click(canvas.getByRole("button", { name: "Project options" }));
-      const menu = within(document.body);
-      await waitFor(() => expect(menu.getByText("Load project from file…")).toBeInTheDocument());
-
-      // Straight at the input rather than through the menu item: clicking that
-      // opens the OS file picker, which a story cannot answer.
-      const input = document.querySelector<HTMLInputElement>("[data-project-import-input]");
-      await expect(input).not.toBeNull();
-      await userEvent.upload(
-        input as HTMLInputElement,
-        new File(['{"documents":{}}'], "toon-town.json", { type: "application/json" }),
-      );
-
-      await waitFor(() =>
-        expect(menu.getByText(/generated fixture/)).toBeInTheDocument(),
-      );
-    } finally {
-      window.fetch = original;
-    }
-  },
-};
-
-/**
- * A `.json` file whose contents are not JSON — answered locally, with no
- * request made at all.
- *
- * The file is NAMED `.json` on purpose: `userEvent.upload` enforces the input's
- * `accept` list exactly as a browser does, so handing it a `.txt` discarded the
- * file silently and the story asserted against a component that had never been
- * given anything. Which is also the honest scenario — the picker only offers
- * JSON, so the way to arrive here is a corrupt or truncated export, not a text
- * file.
- */
-export const LoadNotJson: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", { name: "Project options" }));
-    const menu = within(document.body);
-    await waitFor(() => expect(menu.getByText("Load project from file…")).toBeInTheDocument());
-
-    const input = document.querySelector<HTMLInputElement>("[data-project-import-input]");
-    await userEvent.upload(
-      input as HTMLInputElement,
-      new File(["{ truncated…"], "toon-town.json", { type: "application/json" }),
-    );
-
-    await waitFor(() => expect(menu.getByText(/is not valid JSON/)).toBeInTheDocument());
+    // AND NOTHING ELSE. Asserted rather than left implied: the whole of
+    // PL15-002 is that this menu holds one verb, and a story that only checks
+    // the survivor would pass just as happily with load still listed.
+    await expect(menu.queryByText(/Load project/)).toBeNull();
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-project-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-project-menu.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRef, useState } from "react";
 import { EllipsisVertical } from "lucide-react";
 
 import { Button } from "@/components/core/button";
@@ -12,118 +11,72 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/core/dropdown-menu";
-import { loadProjectFromFile } from "@/components/projects/load-project";
 import { cn } from "@/lib/utils";
 
 /**
- * The project's `⋮` — export the open project, or swap it for one from a file.
+ * The project's `⋮` — export the open project as one JSON file.
  *
- * Export writes the whole project (root plus every collection under it) as one
- * JSON file in the FIXTURE format, and Load reads that file back into the
+ * Export writes the whole project (root plus every collection under it) in the
+ * FIXTURE format, which the library page's "Load Project" reads back into the
  * offline store. The pair is a save/load loop that touches Firebase once, at
  * export: from then on a project can be reloaded, edited and reloaded again for
  * nothing, which is the point of it — the free tier is 50,000 reads a day and
  * entering a board spends one per collection.
  *
- * NOT the gear beside it. "Board options" holds settings you set once and leave
- * (thumbnail size, render format); these are two verbs that act on the project
- * as a whole and produce a file. Same row, different question — which is also
- * why this is a `⋮` and that is a `⚙`: an ellipsis says "more things to DO
- * here", a cog says "how this is configured".
+ * LOAD IS NOT HERE, and used to be (PL15-002). The argument for keeping it in
+ * both places was that deciding to swap projects usually happens while looking
+ * at one. The argument against, and the one that won: loading replaces the
+ * WHOLE offline board, so it acts on the project SET rather than on the project
+ * you have open — a library verb that happened to be reachable from inside a
+ * board. It lives on the projects page, once. Export stays because it genuinely
+ * is a board action: it exports the project in front of you.
  *
- * LOAD IS ALSO ON THE LIBRARY PAGE, and that is the more important of the two
- * homes: this menu only exists inside a board, so offering load only here meant
- * you had to create a throwaway project before you could load one — which is
- * exactly how it was first shipped, and wrong. It stays here as well because
- * deciding to swap projects usually happens while looking at one.
+ * NOT the gear beside it. "Board options" holds settings you set once and leave
+ * (thumbnail size, render format); this is a verb that acts on the project as a
+ * whole and produces a file. Same row, different question — which is also why
+ * this is a `⋮` and that is a `⚙`: an ellipsis says "more things to DO here", a
+ * cog says "how this is configured".
  *
  * The other `⋮` in this header belongs to select mode, which REPLACES this row
  * while a selection is being assembled, so the two are never on screen together.
  */
 export function GraphProjectMenu({ projectId }: Readonly<{ projectId: string }>) {
-  const fileRef = useRef<HTMLInputElement | null>(null);
-  const [busy, setBusy] = useState(false);
-
-  // Load is a DEV affordance: the endpoint it calls writes the offline fixture
-  // file and 404s in production, so a button that could only ever fail there
-  // should not be on screen. `NODE_ENV` is inlined into the client bundle by
-  // Next, so this needs no public env var of its own.
-  const loadable = process.env.NODE_ENV !== "production";
-
   return (
-    <>
-      <input
-        ref={fileRef}
-        type="file"
-        accept="application/json,.json"
-        tabIndex={-1}
-        aria-hidden="true"
-        data-project-import-input
-        className="sr-only"
-        onChange={(event) => {
-          const file = event.target.files?.[0];
-          // Reset BEFORE handing off so picking the same file twice running
-          // fires `change` again — an input compares against its own value and
-          // an unchanged one is silently inert.
-          event.target.value = "";
-          if (!file) return;
-          setBusy(true);
-          void loadProjectFromFile(file).finally(() => setBusy(false));
-        }}
-      />
-      {/* Non-modal, for the reason the other menus in this header are: Radix's
-          modal default puts pointer-events:none on the body, which stops the
-          trigger receiving the click that should close its own menu. */}
-      <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="Project options"
-            title="Project — export or load"
-            data-project-menu
-            className={cn("h-8 w-8 shrink-0", "text-zinc-400 hover:text-zinc-100")}
-          >
-            <EllipsisVertical aria-hidden className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent side="bottom" align="end" className="w-64 p-2">
-          <DropdownMenuLabel className="px-0.5 pb-2 pt-0.5">Project</DropdownMenuLabel>
-          <DropdownMenuGroup>
-            {/* A real link, so it downloads through the browser's own machinery
-                — right-click, middle-click and keyboard activation all behave,
-                and the response's Content-Disposition does the rest. Fetching
-                it into a blob would buy nothing and break all three. */}
-            <DropdownMenuItem asChild>
-              <a
-                href={`/api/timelines/${encodeURIComponent(projectId)}/export`}
-                download
-                data-project-export
-              >
-                Export project…
-              </a>
-            </DropdownMenuItem>
-            {loadable ? (
-              <DropdownMenuItem
-                data-project-load
-                disabled={busy}
-                // Kept open on select so the picker opens over a menu that is
-                // still there to retry from. Failures are reported by toast, so
-                // nothing depends on this menu surviving — an earlier version
-                // rendered the error inside it, and picking a file dismissed the
-                // menu and the message with it.
-                onSelect={(event) => {
-                  event.preventDefault();
-                  fileRef.current?.click();
-                }}
-              >
-                {busy ? "Loading…" : "Load project from file…"}
-              </DropdownMenuItem>
-            ) : null}
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </>
+    /* Non-modal, for the reason the other menus in this header are: Radix's
+       modal default puts pointer-events:none on the body, which stops the
+       trigger receiving the click that should close its own menu. */
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Project options"
+          title="Project — export"
+          data-project-menu
+          className={cn("h-8 w-8 shrink-0", "text-zinc-400 hover:text-zinc-100")}
+        >
+          <EllipsisVertical aria-hidden className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="bottom" align="end" className="w-64 p-2">
+        <DropdownMenuLabel className="px-0.5 pb-2 pt-0.5">Project</DropdownMenuLabel>
+        <DropdownMenuGroup>
+          {/* A real link, so it downloads through the browser's own machinery
+              — right-click, middle-click and keyboard activation all behave,
+              and the response's Content-Disposition does the rest. Fetching
+              it into a blob would buy nothing and break all three. */}
+          <DropdownMenuItem asChild>
+            <a
+              href={`/api/timelines/${encodeURIComponent(projectId)}/export`}
+              download
+              data-project-export
+            >
+              Export project…
+            </a>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane-size.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane-size.ts
@@ -1,0 +1,50 @@
+// How tall the bar's film strip is drawn, and the three sizes offered.
+//
+// Its own module for the reason the view count and the reach have one: the
+// height is a layout decision shared by the thing that draws the film and the
+// picker that sets it, and neither should own the other's constant.
+
+import { SEAM_LANE_HEIGHT_PX } from "./graph-seam-metrics";
+
+export const LANE_SIZES = ["sm", "md", "lg"] as const;
+export type LaneSize = (typeof LANE_SIZES)[number];
+
+/**
+ * The pixel height of each size.
+ *
+ * `sm` IS THE EXISTING NUMBER, not a new small one — the bar has always drawn
+ * a 48px film and that stays exactly what it was, so adding this control
+ * changes nothing until it is used. The other two are the sizes worth having
+ * rather than a scale: 64 is enough to recognise a face in a box, and 88 is
+ * enough to judge a frame without leaving the bar for the panels below.
+ *
+ * A CELL IS SQUARE (see `FILMSTRIP_CELL_PX`), so the height also sets how many
+ * frames a clip's box is cut into — a taller film is a coarser filmstrip, not
+ * just a bigger one. That is the trade this control actually makes.
+ */
+const LANE_HEIGHTS: Readonly<Record<LaneSize, number>> = {
+  sm: SEAM_LANE_HEIGHT_PX,
+  md: 64,
+  lg: 88,
+};
+
+export function laneHeightFor(size: LaneSize): number {
+  return LANE_HEIGHTS[size];
+}
+
+/**
+ * The last size chosen, kept at module scope.
+ *
+ * Deliberately NOT persisted, for the same reason as the reach and the view
+ * count: it is a working posture for a session rather than a preference, and a
+ * board reopened tomorrow should start at the compact reading.
+ */
+let rememberedSize: LaneSize = "sm";
+
+export function lastLaneSize(): LaneSize {
+  return rememberedSize;
+}
+
+export function rememberLaneSize(size: LaneSize): void {
+  rememberedSize = size;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -160,7 +160,11 @@ export { BOX_INSET_PX, SEAM_LANE_HEIGHT_PX, SEAM_PREVIEW_GAP_PX };
 const SOFTENED_PANEL_FRAME_OPACITY = 0.8;
 
 /** One cell per bar-height, so a filmstrip cell reads as a square. */
-const FILMSTRIP_CELL_PX = SEAM_LANE_HEIGHT_PX;
+/** A filmstrip cell is SQUARE, so the lane's height is also its cell width —
+ *  which means a taller film is a coarser filmstrip as well as a bigger one.
+ *  Passed rather than read from the constant now that the height is a setting
+ *  (PL15-022); the constant remains the `sm` value and the default. */
+const filmstripCellPx = (laneHeight: number) => laneHeight;
 /** Past this the cells stretch rather than multiply — see `SegmentFrames`. */
 const MAX_FILMSTRIP_CELLS = 12;
 
@@ -174,6 +178,7 @@ const MAX_FILMSTRIP_CELLS = 12;
  * dozen image lists per box per frame is exactly the cost this is not worth.
  */
 function SegmentFrames({
+  laneHeight,
   clipId,
   clip,
   posterSrc,
@@ -195,6 +200,8 @@ function SegmentFrames({
    * colour stays exactly the tone the rest of the run is.
    */
   opacity?: number;
+  /** The lane's height, which is also a filmstrip cell's width. */
+  laneHeight?: number;
 }>) {
   // HOW MANY CELLS FIT, at roughly one per bar-height so each reads as a
   // square. Capped, because a long clip at a high zoom is a box thousands of
@@ -206,14 +213,14 @@ function SegmentFrames({
     if (style !== "filmstrip" || clip?.posterSrcs === undefined) return null;
     const wanted = Math.min(
       MAX_FILMSTRIP_CELLS,
-      Math.max(1, Math.round(widthPx / FILMSTRIP_CELL_PX)),
+      Math.max(1, Math.round(widthPx / filmstripCellPx(laneHeight ?? SEAM_LANE_HEIGHT_PX))),
     );
     const urls = videoFrameUrls(clip.posterSrcs, wanted, {
       trimInSeconds: clip.trimInSeconds ?? 0,
       effectiveSeconds: clip.showingSeconds,
     });
     return urls.length === 0 ? null : urls;
-  }, [clip, style, widthPx]);
+  }, [clip, style, widthPx, laneHeight]);
 
   /**
    * THE ONE FRAME, TAKEN AFTER THE TRIM RATHER THAN BEFORE IT.
@@ -463,6 +470,7 @@ export type SeamHover = Readonly<{
  * cannot read exactly when you need it.
  */
 export function SeamLane({
+  laneHeight = SEAM_LANE_HEIGHT_PX,
   laneRef,
   strip,
   clips,
@@ -479,6 +487,9 @@ export function SeamLane({
   atEnd,
 }: Readonly<{
   /** The element the bar attaches its non-passive wheel listener to. */
+  /** The film's drawn height, and therefore its filmstrip cell size — a
+   *  cell is square. Defaults to the `sm` value the bar has always used. */
+  laneHeight?: number;
   laneRef: React.RefObject<HTMLDivElement | null>;
   strip: SeamStrip;
   clips: readonly SeamBarClip[];
@@ -622,7 +633,7 @@ export function SeamLane({
       // have to escape it: a time chip drawn INSIDE the boxes covers the frames
       // it is reporting on, which is the one thing you are looking at while you
       // drag.
-      style={{ height: SEAM_LANE_HEIGHT_PX }}
+      style={{ height: laneHeight }}
       className="relative cursor-ew-resize touch-none select-none"
     >
       <div className="absolute inset-0 overflow-hidden">
@@ -720,6 +731,7 @@ export function SeamLane({
               >
                 {framed ? (
                   <SegmentFrames
+                    laneHeight={laneHeight}
                     clipId={segment.clipId}
                     clip={clipById.get(segment.clipId)}
                     posterSrc={segment.posterSrc}
@@ -954,6 +966,7 @@ export function SeamLane({
           find out — the thing a bar of anonymous boxes cannot do. */}
       {hover !== null && (
         <SeamPreviewCard
+          laneHeight={laneHeight}
           hover={hover}
           previewAnchor={previewAnchor}
           leftPx={viewportX(hover.x)}
@@ -978,6 +991,7 @@ export function SeamLane({
  * there is no effect and nothing to keep in step.
  */
 function SeamPreviewCard({
+  laneHeight = SEAM_LANE_HEIGHT_PX,
   hover,
   previewAnchor,
   leftPx,
@@ -986,6 +1000,8 @@ function SeamPreviewCard({
   previewAnchor: PreviewAnchor;
   /** Where the card points, already in the lane's coordinates. */
   leftPx: number;
+  /** The film's height, which is what this card hangs below. */
+  laneHeight?: number;
 }>) {
   // WHETHER THE CARD HAS A PICTURE TO BE THE SIZE OF YET.
   //
@@ -1039,7 +1055,7 @@ function SeamPreviewCard({
       // block, which IS the track, so the bound follows a resize with no
       // observer and no re-render. 9rem is half the card.
       style={{
-        top: SEAM_LANE_HEIGHT_PX + SEAM_PREVIEW_GAP_PX,
+        top: laneHeight + SEAM_PREVIEW_GAP_PX,
         left:
           previewAnchor === "pinned"
             ? "50%"

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -47,6 +47,22 @@ const SEAM_MOVE_CLAIM_MS = 120;
 const CAP_WIDTH_PX = 6;
 
 /**
+ * How far the stop sits from the film, and the room its label sits in.
+ *
+ * ITS OWN NUMBER, and that is the change (PL15-014). This used to be
+ * `BOX_INSET_PX` — 2.5px, the same inset the gap between two boxes is made of,
+ * chosen so the stop sat "at the distance the eye already reads as next thing
+ * along". Which is exactly why it read as another clip's edge rather than as
+ * the end of the film. Sharing the number is what made the two look the same,
+ * so a multiplier of it would put the next reader back here; this is separate
+ * on purpose.
+ *
+ * 40px because the LABEL lives in it. The gap is not decoration now — it is
+ * the space the word occupies, between the stop and the first or last box.
+ */
+const CAP_GAP_PX = 40;
+
+/**
  * WHERE THE PROJECT ENDS, drawn just outside the first and last boxes.
  *
  * The bar is a window: at most reaches it shows a stretch with more either
@@ -66,27 +82,60 @@ const CAP_WIDTH_PX = 6;
  * about the project, and the two are not in the same place at most zooms.
  */
 function SeamEndCap({ side, atPx }: Readonly<{ side: "start" | "end"; atPx: number }>) {
+  // NO CLAMP, and that was a wrong turn worth leaving written down.
+  //
+  // Clamping the pair to `max(0px, …)` looked like the same care the
+  // active-clip triangle takes to stay inside the bar. It is not: THIS lane's
+  // coordinate space begins at the FILM's start, so `atPx` is 0 for the first
+  // box and the stop belongs at a negative offset by construction. `max(0px, …)`
+  // therefore forbade the only position the start stop can occupy and parked it
+  // on top of the first clip — caught by the story that asserts the stop sits
+  // outside the boxes rather than over them.
+  //
+  // The label sits in the GAP, between the stop and the film, so it is the
+  // stop that moves outboard and the word that stays beside the picture.
+  const capLeft =
+    side === "start" ? atPx - CAP_WIDTH_PX - CAP_GAP_PX : atPx + CAP_GAP_PX;
+  const labelLeft = side === "start" ? atPx - CAP_GAP_PX : atPx;
+
   return (
-    <span
-      data-seam-cap={side}
-      aria-hidden="true"
-      style={{
-        // Just outside the box's own edge, using the same inset the gap
-        // between two boxes is made of — so the stop sits at the distance the
-        // eye already reads as "next thing along".
-        left: side === "start" ? atPx - CAP_WIDTH_PX - BOX_INSET_PX : atPx + BOX_INSET_PX,
-        width: CAP_WIDTH_PX,
-      }}
-      className={[
-        "absolute inset-y-1 rounded-[2px]",
-        // The gradient runs AWAY from the film: solid against the last frame,
-        // gone by the outer edge. A flat bar would read as one more clip in a
-        // colour nobody chose.
-        side === "start"
-          ? "bg-gradient-to-l from-zinc-300/85 to-zinc-300/0"
-          : "bg-gradient-to-r from-zinc-300/85 to-zinc-300/0",
-      ].join(" ")}
-    />
+    <>
+      <span
+        data-seam-cap={side}
+        aria-hidden="true"
+        style={{ left: capLeft, width: CAP_WIDTH_PX }}
+        className={[
+          "absolute inset-y-1 rounded-[2px]",
+          // The gradient runs AWAY from the film: solid against the last frame,
+          // gone by the outer edge. A flat bar would read as one more clip in a
+          // colour nobody chose.
+          side === "start"
+            ? "bg-gradient-to-l from-zinc-300/85 to-zinc-300/0"
+            : "bg-gradient-to-r from-zinc-300/85 to-zinc-300/0",
+        ].join(" ")}
+      />
+      {/* THE WORD (PL15-014). A bare mark left "is this the end or just where
+          the boxes ran out" to be inferred, and the bar cannot answer that from
+          its boxes — a window cropped at the reach looks identical to one that
+          has reached the real end. The stop is only drawn when it HAS, so
+          saying which end it is costs nothing and settles it.
+
+          NOT `aria-hidden`, unlike the mark beside it. The mark is a graphic
+          restating what the boxes say; this is content, and hiding readable
+          text from assistive tech to keep an attribute the graphic needed would
+          be the wrong way round.
+
+          A FIXED WIDTH so the clamps above can be arithmetic rather than a
+          measurement, and `text-center` so the word sits in the middle of the
+          room the gap makes for it. */}
+      <span
+        data-seam-cap-label={side}
+        style={{ left: labelLeft, width: CAP_GAP_PX }}
+        className="pointer-events-none absolute inset-y-0 flex items-center justify-center text-[8px] font-semibold tracking-[0.08em] text-zinc-400 uppercase select-none"
+      >
+        {side === "start" ? "Start" : "End"}
+      </span>
+    </>
   );
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -147,6 +147,7 @@ function SeamEndCap({ side, atPx }: Readonly<{ side: "start" | "end"; atPx: numb
 // re-export is so nothing that already imported them from the lane had to
 // move.
 export { BOX_INSET_PX, SEAM_LANE_HEIGHT_PX, SEAM_PREVIEW_GAP_PX };
+export { CAP_GAP_PX, CAP_WIDTH_PX };
 
 /**
  * How strongly a NON-ACTIVE on-screen clip draws its picture in grey-box mode.

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
@@ -7,6 +7,24 @@ import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
 
 /**
+ * The active segment's caret — half its width, and its height.
+ *
+ * ITS OWN NUMBERS, not the bar's `MARK_HALF_PX` / `MARK_HEIGHT_PX`. That mark
+ * is 10px across and sits above a 44px band; the same glyph here would be
+ * wider than most segments and taller than the gap under them. Same idiom, one
+ * scale down — which is the relationship the white already has with the bar's
+ * white.
+ *
+ * 3 and 3 is what the rail has room for, and the room is the constraint rather
+ * than taste: the rail is 14px, the run sits at `top-1` and is 6px, and the
+ * active segment grows a pixel each way (`-my-px`) — so the segments occupy
+ * y=3 to y=11 and there are exactly three pixels beneath them. The caret takes
+ * those three and stops flush with the bottom of the rail.
+ */
+const MINI_MARK_HALF_PX = 3;
+const MINI_MARK_HEIGHT_PX = 3;
+
+/**
  * THE WHOLE SEQUENCE, IN MINIATURE — and the only thing on screen that is.
  *
  * The bar above it is a window: it zooms, it pans, and at any useful scale
@@ -182,6 +200,11 @@ export function SeamMinimap({
               }}
               className={[
                 "min-w-px flex-shrink rounded-[1px]",
+                // `relative` ONLY so the caret below can anchor to this
+                // segment. It is a flex item either way and its size is
+                // unchanged; see the caret for why it hangs off the segment
+                // rather than off the rail.
+                isCentre ? "relative" : "",
                 // Full strength as well, so the white is white rather than a
                 // 70% wash of it against the dimmed run either side.
                 //
@@ -204,7 +227,43 @@ export function SeamMinimap({
                     ? "opacity-100"
                     : "opacity-70",
               ].join(" ")}
-            />
+            >
+              {/* A CARET UNDER THE ACTIVE ONE — the bar's mark at this scale.
+                  The bar marks its active clip with a white triangle above the
+                  film pointing down at it; this is the same claim said the
+                  same way one size smaller, pointing up.
+
+                  A CHILD OF THE SEGMENT, not a mark positioned over the rail,
+                  and that is the whole reason this is cheap. The segments are
+                  flex items sized by `flexGrow: showingSeconds` with a 3px
+                  margin wherever a collection changes, so a segment's centre
+                  is NOT a percentage of total duration — which is exactly how
+                  the window and the playhead above are placed, and why they
+                  can be. Hanging the caret off the segment lets flex answer
+                  "where is its middle" instead of re-deriving the layout in
+                  arithmetic that would drift the moment a seam gap changed.
+
+                  `top: 100%` is the segment's own bottom edge, so the caret
+                  starts where the run ends however tall the run is drawn —
+                  including the extra pixel this segment has for being the
+                  subject. */}
+              {isCentre && (
+                <span
+                  data-seam-mini-active-mark={clip.id}
+                  aria-hidden="true"
+                  style={{
+                    top: "100%",
+                    left: "50%",
+                    borderLeft: `${MINI_MARK_HALF_PX}px solid transparent`,
+                    borderRight: `${MINI_MARK_HALF_PX}px solid transparent`,
+                    // Pointing UP: the solid edge is the BOTTOM one, so the
+                    // tip is at the top, against the segment it names.
+                    borderBottom: `${MINI_MARK_HEIGHT_PX}px solid rgb(250, 250, 250)`,
+                  }}
+                  className="pointer-events-none absolute -translate-x-1/2"
+                />
+              )}
+            </span>
           );
         })}
       </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -54,7 +54,7 @@ const RULER_BLOCK_COLOUR = "rgba(250, 250, 250, 0.16)";
  * It is the only saturated thing up here, which is what makes it findable at a
  * glance on a bar of two dozen blocks.
  */
-const RULER_BLOCK_ACTIVE_COLOUR = "rgba(56, 189, 248, 0.30)";
+export const RULER_BLOCK_ACTIVE_COLOUR = "rgba(56, 189, 248, 0.30)";
 
 /**
  * The same two tones, pointed at.

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -30,7 +30,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/core/dropdown-menu";
 import { SeamMinimap } from "./graph-seam-minimap";
-import { SEAM_RULER_TOTAL_PX, SeamRuler } from "./graph-seam-ruler";
+import {
+  RULER_BLOCK_ACTIVE_COLOUR,
+  SEAM_RULER_TOTAL_PX,
+  SeamRuler,
+} from "./graph-seam-ruler";
 import {
   buildSeamStrip,
   clampStripOffset,
@@ -170,6 +174,16 @@ function readSeconds(value: number): string {
  * and lighting one would be claiming a scale the bar is not at.
  */
 type FitMode = "clip" | "all";
+
+/**
+ * The gap between the film's track and the minimap under it.
+ *
+ * KEEP IN STEP WITH `mt-1.5` on the minimap's own root. It is a Tailwind class
+ * over there and a number here, and nothing connects them — the failure if they
+ * drift is the active column either stopping short of the map or running into
+ * it.
+ */
+const MINIMAP_GAP_PX = 6;
 
 export function SeamStripBar({
   clips,
@@ -328,6 +342,10 @@ export function SeamStripBar({
     pxPerSecond ??
     (trackWidth > 0 ? fitPixelsPerSecond(subjectCollectionSeconds, trackWidth) : 9);
   const strip = useMemo(() => buildSeamStrip(clips, scale), [clips, scale]);
+  // The subject's own box in strip coordinates — what the active column below
+  // is drawn against. `undefined` while the subject is not on the bar at all,
+  // which is a real state at a tight reach.
+  const activeSegment = strip.segments.find((segment) => segment.clipId === centreClipId);
 
   // ONE NEUTRAL FOR EVERY BOX unless the tint is switched on. Substituted here
   // rather than at the derivation, so the collection tones are still computed
@@ -1096,6 +1114,47 @@ export function SeamStripBar({
         // nothing under it stops being clickable.
         className="relative z-30 flex-1 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       >
+        {/* THE ACTIVE CLIP'S COLUMN (PL15-026).
+            The ruler already tints the active clip's stretch of scale sky —
+            "the one thing in this band with a hue", and the only saturated
+            thing up there, which is what makes it findable on a bar of two
+            dozen blocks. It stopped at the ruler's own band, so the clip being
+            worked on was marked ABOVE the film and nowhere else.
+
+            This continues the same block downward, through the film and into
+            the space before the minimap, so the subject reads as a column
+            rather than as a tab over it. The SAME constant, not a matched
+            value: two ends of one band that drifted apart would be worse than
+            no band at all.
+
+            BEHIND EVERYTHING — `-z-10` against the track's own stacking, so it
+            passes under the boxes rather than washing the frames it is
+            pointing at. `pointer-events-none` for the same reason: the lane
+            below owns every gesture on this track.
+
+            It travels with the film, because `offset` is the same value the
+            strip is translated by. */}
+        {activeSegment !== undefined && (
+          <span
+            data-seam-active-column={centreClipId}
+            aria-hidden="true"
+            style={{
+              left: activeSegment.leftPx + offset,
+              width: activeSegment.widthPx,
+              top: SEAM_RULER_TOTAL_PX,
+              // PAST THE TRACK'S OWN BOTTOM, which is exactly the film's:
+              // measured, the lane ends where the track ends, so `bottom: 0`
+              // stopped the column flush with the frames and filled none of
+              // the space this item is about. The overhang is the minimap's
+              // own top margin, so the band closes the gap between the film
+              // and the map and stops at it.
+              bottom: -MINIMAP_GAP_PX,
+              backgroundColor: RULER_BLOCK_ACTIVE_COLOUR,
+            }}
+            className="pointer-events-none absolute -z-10"
+          />
+        )}
+
         {/* THE SCALE, ABOVE THE FILM IT MEASURES — and the hover target.
             See `graph-seam-ruler` for both: a ruler belongs against what it
             measures, and a preview card belongs somewhere other than on top

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
+import { ChevronLeft, ChevronRight, Pause, Play, Settings2 } from "lucide-react";
 
 import {
   BAR_COLLECTION_COLOURS_ENABLED,
@@ -18,6 +18,11 @@ import {
 import { SEAM_LANE_HEIGHT_PX, SeamLane, type SeamHover } from "./graph-seam-lane";
 import { HAIRLINE, SURFACE_WELL } from "./graph-details-design";
 import { SegmentedControl } from "./graph-details-segmented";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/core/dropdown-menu";
 import { SeamMinimap } from "./graph-seam-minimap";
 import { SEAM_RULER_TOTAL_PX, SeamRuler } from "./graph-seam-ruler";
 import {
@@ -1205,12 +1210,13 @@ export function SeamStripBar({
         // between the minimap and the top of the controls.
         className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 pt-3 pb-2"
       >
-        {/* HIDDEN, NOT WRAPPED, on a narrow view. Wrapping this row costs the
-            strip below a line of height it has to be told about — see the
-            scrim's top padding — and the two settings here are set once, while
-            the transport and the clock are used continuously. The row keeps
-            what is being USED. */}
-        <div className="hidden min-w-0 items-center gap-1 md:flex">{settingsLeft}</div>
+        {/* EMPTY, AND HOLDING THE COLUMN OPEN.
+            `settingsLeft` moved into the gear at the far right (PL15-006), but
+            the row is a three-column grid whose middle track is what centres
+            the transport — removing this cell would hand the transport the
+            left third as well and it would no longer be in the middle of
+            anything. */}
+        <div aria-hidden="true" className="min-w-0" />
 
         {/* THE TRANSPORT, AS ONE OBJECT AND THE BIGGEST THING IN THE ROW.
             It was three small icon buttons with the same weight as the
@@ -1325,31 +1331,72 @@ export function SeamStripBar({
             <span>{formatClock(totalSeconds)}</span>
           </span>
 
-          {/* FIT: the two scales worth one press.
-              Zoom was ⌘-wheel and nothing else, which meant the two scales
-              anyone actually wants — this scene, and the lot — were reachable
-              only by rolling until they happened to arrive. Both are one
-              `fitPixelsPerSecond` call the bar was already making on open;
-              this just gives them a button. */}
-          <div className="hidden shrink-0 md:flex">
-            <SegmentedControl
-              label="fit"
-              ariaLabel="Fit the bar to"
-              groupAttribute="data-seam-fit"
-              segments={(["clip", "all"] as const).map((mode) => ({
-                value: mode,
-                label: mode,
-                title:
-                  mode === "clip"
-                    ? "Fit this clip's collection"
-                    : "Fit everything the bar reaches",
-                active: mode === fitMode,
-              }))}
-              onSelect={fitTo}
-            />
-          </div>
+          {/* FIT MOVED INTO THE GEAR (PL15-006). It is the two scales worth
+              one press — this scene, and the lot — but it is still a thing you
+              set rather than a thing you drive, so it sits with the other two
+              settings rather than in the row. */}
 
           <div className="hidden min-w-0 items-center gap-1 md:flex">{settingsRight}</div>
+
+          {/* THE VIEW'S SETTINGS, BEHIND ONE CONTROL (PL15-006).
+              What the bar's boxes draw, where the hover card sits, and what the
+              zoom fits to were three labelled groups strung along this row —
+              nine or ten segments of chrome around a transport, all of them
+              things you set once and then work. REACH STAYS OUT because it is
+              not that kind of setting: it changes how much of the sequence the
+              bar is showing, which is a thing you reach for while reading it.
+
+              A GEAR, NOT AN ELLIPSIS. The project menu next door documents the
+              distinction and it holds here: an ellipsis says "more things to DO
+              here", a cog says "how this is configured". These are all the
+              second kind.
+
+              Non-modal for the reason every other menu in this header is:
+              Radix's modal default puts `pointer-events: none` on the body,
+              which stops the trigger receiving the click that should close its
+              own menu.
+
+              NOT gated on `md:` like the groups it replaces. Those were hidden
+              on a narrow view because a row of segmented controls has nowhere
+              to go; a menu is the same size whatever the viewport, so folding
+              them behind it makes them reachable on a phone for the first
+              time. */}
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                data-seam-settings-menu
+                aria-label="Bar settings"
+                title="Bar settings — frames, hover card, and what the zoom fits"
+                className="grid h-7 w-7 shrink-0 place-items-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+              >
+                <Settings2 aria-hidden="true" className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              side="top"
+              align="end"
+              data-seam-settings-content
+              className="flex w-auto flex-col items-start gap-3 p-3"
+            >
+              {settingsLeft}
+              <SegmentedControl
+                label="fit"
+                ariaLabel="Fit the bar to"
+                groupAttribute="data-seam-fit"
+                segments={(["clip", "all"] as const).map((mode) => ({
+                  value: mode,
+                  label: mode,
+                  title:
+                    mode === "clip"
+                      ? "Fit this clip's collection"
+                      : "Fit everything the bar reaches",
+                  active: mode === fitMode,
+                }))}
+                onSelect={fitTo}
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -179,6 +179,7 @@ export function SeamStripBar({
   onPreviewingChange,
   atStart,
   atEnd,
+  laneHeight = SEAM_LANE_HEIGHT_PX,
   settingsLeft,
   settingsRight,
   previewAnchor = "follow",
@@ -234,6 +235,8 @@ export function SeamStripBar({
    * clock sits with the controls, and that the whole thing lands between the
    * scrub bar and the minimap — and none of that changes with what is passed.
    */
+  /** The film's drawn height — the `size` picker in the gear (PL15-022). */
+  laneHeight?: number;
   settingsLeft?: React.ReactNode;
   settingsRight?: React.ReactNode;
   /** Whether the hover card follows the pointer or parks under the middle of
@@ -1108,6 +1111,7 @@ export function SeamStripBar({
         />
 
         <SeamLane
+          laneHeight={laneHeight}
           laneRef={laneRef}
           panelClipIds={panelClipIds}
           hoveredClipId={hoveredClipId}
@@ -1143,14 +1147,14 @@ export function SeamStripBar({
           aria-hidden="true"
           data-seam-fade="left"
           hidden={offset >= -0.5}
-          style={{ top: SEAM_RULER_TOTAL_PX, height: SEAM_LANE_HEIGHT_PX }}
+          style={{ top: SEAM_RULER_TOTAL_PX, height: laneHeight }}
           className="pointer-events-none absolute left-0 w-6 bg-gradient-to-r from-zinc-950 to-transparent"
         />
         <span
           aria-hidden="true"
           data-seam-fade="right"
           hidden={strip.totalPx + offset <= trackWidth + 0.5}
-          style={{ top: SEAM_RULER_TOTAL_PX, height: SEAM_LANE_HEIGHT_PX }}
+          style={{ top: SEAM_RULER_TOTAL_PX, height: laneHeight }}
           className="pointer-events-none absolute right-0 w-6 bg-gradient-to-l from-zinc-950 to-transparent"
         />
       </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -1210,13 +1210,40 @@ export function SeamStripBar({
         // between the minimap and the top of the controls.
         className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 pt-3 pb-2"
       >
-        {/* EMPTY, AND HOLDING THE COLUMN OPEN.
-            `settingsLeft` moved into the gear at the far right (PL15-006), but
-            the row is a three-column grid whose middle track is what centres
-            the transport — removing this cell would hand the transport the
-            left third as well and it would no longer be in the middle of
-            anything. */}
-        <div aria-hidden="true" className="min-w-0" />
+        {/* THE CLOCK, ON THE LEFT (PL15-021).
+            It sat at the far right beside reach and the gear, because it
+            arrived there with the transport and the settings ended up around
+            it. This cell was emptied when those moved into the gear
+            (PL15-006), leaving a bare third on one side and three things
+            crowded on the other.
+
+            It belongs on the transport's line either way: it says where
+            playback IS, which is the question the play button answers, and
+            reading the two together is why it came down out of the scrub bar
+            in the first place.
+
+            The cell keeps the column open regardless — the row is a
+            three-column grid and the middle track is what centres the
+            transport. */}
+        <div className="flex min-w-0 items-center">
+          {/* THE CLOCK, which came from the far right of the scrub bar. It
+              belongs with the transport rather than with the track: it says
+              where playback IS, which is the same question the play button
+              answers, and reading the two together is why it moved. */}
+          {/* CLOCK NOTATION, NOT SECONDS. `252.90s` is accurate and unusable —
+              nobody can place it in a four-minute cut without doing division.
+              Tenths rather than hundredths because this number MOVES: the
+              second decimal is a blur at playback speed, and the first is
+              exactly enough to see time passing. */}
+          <span
+            data-seam-clock
+            className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
+          >
+            <span className="text-blue-300">{formatClock(atSeconds)}</span>
+            {" / "}
+            <span>{formatClock(totalSeconds)}</span>
+          </span>
+        </div>
 
         {/* THE TRANSPORT, AS ONE OBJECT AND THE BIGGEST THING IN THE ROW.
             It was three small icon buttons with the same weight as the
@@ -1313,23 +1340,6 @@ export function SeamStripBar({
         </div>
 
         <div className="flex min-w-0 items-center justify-end gap-3">
-          {/* THE CLOCK, which came from the far right of the scrub bar. It
-              belongs with the transport rather than with the track: it says
-              where playback IS, which is the same question the play button
-              answers, and reading the two together is why it moved. */}
-          {/* CLOCK NOTATION, NOT SECONDS. `252.90s` is accurate and unusable —
-              nobody can place it in a four-minute cut without doing division.
-              Tenths rather than hundredths because this number MOVES: the
-              second decimal is a blur at playback speed, and the first is
-              exactly enough to see time passing. */}
-          <span
-            data-seam-clock
-            className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
-          >
-            <span className="text-blue-300">{formatClock(atSeconds)}</span>
-            {" / "}
-            <span>{formatClock(totalSeconds)}</span>
-          </span>
 
           {/* FIT MOVED INTO THE GEAR (PL15-006). It is the two scales worth
               one press — this scene, and the lot — but it is still a thing you

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -15,7 +15,13 @@ import {
   zoomByWheel,
   type SeamBarClip,
 } from "./graph-seam-bar-layout";
-import { SEAM_LANE_HEIGHT_PX, SeamLane, type SeamHover } from "./graph-seam-lane";
+import {
+  CAP_GAP_PX,
+  CAP_WIDTH_PX,
+  SEAM_LANE_HEIGHT_PX,
+  SeamLane,
+  type SeamHover,
+} from "./graph-seam-lane";
 import { HAIRLINE, SURFACE_WELL } from "./graph-details-design";
 import { SegmentedControl } from "./graph-details-segmented";
 import {
@@ -27,6 +33,7 @@ import { SeamMinimap } from "./graph-seam-minimap";
 import { SEAM_RULER_TOTAL_PX, SeamRuler } from "./graph-seam-ruler";
 import {
   buildSeamStrip,
+  clampStripOffset,
   stripCentreOffset,
   stripPositionAt,
   stripXFor,
@@ -344,7 +351,21 @@ export function SeamStripBar({
     centreClipId,
     centreAtPx > 0 ? centreAtPx * 2 : trackWidth,
   );
-  const offset = panPx ?? centredOffset;
+  // HELD AGAINST THE ENDS (PL15-025). Centring the subject is right in the
+  // middle of a sequence and wrong at either end of it — clip 2 of 13 centred
+  // pushes the film most of the way across the track and leaves a screen of
+  // empty space beside it. Applied to the USER's pan as well as the default,
+  // because a flick can overshoot into the same gap.
+  //
+  // The lead is the end stop's own room: `SeamEndCap` draws the mark and its
+  // label OUTSIDE the first and last boxes, so a film held flush to the track
+  // would push its own "start" off screen.
+  const offset = clampStripOffset(
+    panPx ?? centredOffset,
+    strip.totalPx,
+    trackWidth,
+    CAP_WIDTH_PX + CAP_GAP_PX,
+  );
 
   // Set by any deliberate pan, cleared by any deliberate seek. While it is
   // set, playback stops dragging the bar around under the reader.

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -1377,7 +1377,19 @@ export function SeamStripBar({
               side="top"
               align="end"
               data-seam-settings-content
-              className="flex w-auto flex-col items-start gap-3 p-3"
+              // `z-[90]` IS THE WHOLE REASON THIS MENU IS VISIBLE.
+              //
+              // Radix portals its content to `document.body`, so the menu is a
+              // SIBLING of the details modal rather than a descendant — and the
+              // modal is `z-[80]` while `DropdownMenuContent` defaults to
+              // `z-50`. The menu opened correctly, in the right place, behind
+              // the modal's own scrim: a gear that visibly did nothing.
+              //
+              // The other menus in this app sit in the board's header, outside
+              // any modal, which is why none of them needed this and why the
+              // default has never been wrong before. Anything portalled from
+              // INSIDE the details view has to clear 80.
+              className="z-[90] flex w-auto flex-col items-start gap-3 p-3"
             >
               {settingsLeft}
               <SegmentedControl

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildSeamStrip,
   segmentFor,
+  clampStripOffset,
   stripCentreOffset,
   stripPositionAt,
   stripXFor,
@@ -121,5 +122,40 @@ describe("stripPositionAt", () => {
       PPS,
     );
     expect(stripPositionAt(strip, 40)?.clipId).toBe("c");
+  });
+});
+
+// THE FILM IS HELD AGAINST THE TRACK'S ENDS (PL15-025). Centring the subject is
+// right in the middle of a sequence and wrong at either end: clip 2 of 13
+// centred pushes the film most of the way across and leaves a screen of empty
+// space beside it.
+describe("clampStripOffset", () => {
+  // A film twice the track, and 46px of lead for the end stop's own mark.
+  const TOTAL = 2000;
+  const TRACK = 1000;
+  const LEAD = 46;
+
+  it("stops the film's START at the lead rather than centring past it", () => {
+    // Centring an early clip asks to push the film 400px right, which is 354px
+    // of empty track. It goes as far as the lead and no further.
+    expect(clampStripOffset(400, TOTAL, TRACK, LEAD)).toBe(LEAD);
+  });
+
+  it("stops the film's END at the far edge", () => {
+    expect(clampStripOffset(-5000, TOTAL, TRACK, LEAD)).toBe(TRACK - TOTAL - LEAD);
+  });
+
+  it("leaves an offset in the middle of the range alone", () => {
+    expect(clampStripOffset(-500, TOTAL, TRACK, LEAD)).toBe(-500);
+  });
+
+  it("keeps CENTRING a film shorter than the track", () => {
+    // Nothing is being pushed off here — there is no edge to hold it against,
+    // so the complaint this clamp answers does not apply and centring stands.
+    expect(clampStripOffset(300, 400, TRACK, LEAD)).toBe(300);
+  });
+
+  it("does nothing before the track has been measured", () => {
+    expect(clampStripOffset(400, TOTAL, 0, LEAD)).toBe(400);
   });
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip.ts
@@ -99,6 +99,42 @@ export function stripCentreOffset(
 }
 
 /**
+ * Hold the film against the track's ends instead of centring past them.
+ *
+ * `stripCentreOffset` puts the subject in the middle, which is right in the
+ * middle of a long sequence and wrong at either end of it: centring clip 2 of
+ * 13 pushes the film most of the way across the track and leaves a screen of
+ * empty space beside it. The film should travel until its own edge reaches the
+ * track's and then stop, exactly as any scroller does.
+ *
+ * `leadPx` IS NOT SLOP. The end stops and their labels are drawn OUTSIDE the
+ * first and last boxes (see `SeamEndCap`), at negative coordinates before the
+ * film begins — so clamping the film's start flush to the track's left edge
+ * would push its own "start" marker off screen. The lead is the room that mark
+ * needs, and it is passed rather than assumed here because this module does
+ * not own that number.
+ *
+ * A film SHORTER than the track keeps its centring: there is no edge to hold
+ * it against and nothing is being pushed off, so the complaint does not apply.
+ */
+export function clampStripOffset(
+  offset: number,
+  totalPx: number,
+  containerPx: number,
+  leadPx: number,
+): number {
+  if (containerPx <= 0 || totalPx <= 0) return offset;
+  // The film fits — centring is the whole answer.
+  if (totalPx + leadPx <= containerPx) return offset;
+  // Furthest RIGHT the film may sit: its start, plus room for the start mark.
+  const maxOffset = leadPx;
+  // Furthest LEFT: its end flush with the track, plus the same room for the
+  // end mark on the other side.
+  const minOffset = containerPx - totalPx - leadPx;
+  return Math.min(maxOffset, Math.max(minOffset, offset));
+}
+
+/**
  * Where the playhead goes for a position the CLOCK reported.
  *
  * The clock and the strip are two views of the same clips: the clock knows

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import { Folder, FolderOpen, ListTree } from "lucide-react";
+import { Folder, FolderOpen, Layers, ListTree } from "lucide-react";
 
 import {
   VirtualGrid,
@@ -22,7 +22,9 @@ import { VideoFrameLookAhead } from "./graph-card-frame-loading";
 import {
   useCollectionPreviewFrames,
   useEnabledChildCount,
+  useFirstChildIsAudio,
 } from "./graph-card-derivations";
+import { AudioPlaceholder, EmptyCollectionPlaceholder } from "./graph-card-placeholders";
 import { collectionPreviewFrameUrl } from "@/lib/video-frame-url";
 import { hydrateTimeline } from "./graph-hydration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
@@ -153,8 +155,11 @@ function SubTimelineNode({
   // it has to agree with the time totals and the served summary rather than
   // counting clips that are skipped.
   const liveCount = useEnabledChildCount(collectionId);
-  // Same pair the card shows; empty until an un-hydrated row loads.
+  // The same frame the card shows; empty until an un-hydrated row loads.
   const previewFrames = useCollectionPreviewFrames(id, hydrated, detail?.previewItems);
+  // A collection of voice takes gets the audio glyph rather than the empty
+  // gradient, exactly as its card does — see the thumbnail below.
+  const leadsWithAudio = useFirstChildIsAudio(collectionId);
   const childIds = useCollectionChildIds(collectionId);
   const status = subTimelineRowStatus({ expanded, hydrated, failed });
 
@@ -187,7 +192,34 @@ function SubTimelineNode({
       aria-label={`Sub-timeline: ${name}`}
       className="min-w-0 rounded-lg border border-zinc-800/70 bg-zinc-900/40 p-3"
     >
-      <div className="mb-1.5 flex items-center gap-2">
+      {/* THE WHOLE BAR OPENS IT (PL15-010), not just the folder.
+          A 20px folder button was the only way to expand a row whose header is
+          most of the width of the board.
+
+          NOT A `<button>` AROUND THE ROW. It contains a button, and while
+          renaming it contains an `<input>` — nested interactive elements are
+          invalid and take the keyboard behaviour of both with them. So the
+          click lives on the container and the FOLDER stays the one accessible
+          control, with `aria-expanded` on it. This adds a pointer target, not
+          a second tab stop.
+
+          THE NAME IS EXCLUDED, and it is the one exception worth arguing.
+          Double-clicking it renames, so a row that toggled on single click
+          would fire on the first click of every rename — expanding the row,
+          which HYDRATES it (a fetch), then collapsing it again on the second.
+          The end state would be right and the flash and the request would not.
+          Everything else in the header is fair game.
+
+          Hover moves here with the click. The call-out that lights this
+          collection's card lived on the folder alone; a bar that opens from
+          anywhere should light the card from anywhere, or it answers "which
+          card is this" in a smaller region than it answers "press me". */}
+      <div
+        className="mb-1.5 flex cursor-pointer items-center gap-2 rounded transition-colors hover:bg-zinc-800/40"
+        onClick={toggle}
+        onPointerEnter={hoverSource.onPointerEnter}
+        onPointerLeave={hoverSource.onPointerLeave}
+      >
         {/* Tree elbow. Nesting is otherwise carried only by the panels'
             indentation, which reads as "inset boxes" rather than "branches";
             the corner in front of the folder names the relationship. Drawn
@@ -204,12 +236,13 @@ function SubTimelineNode({
           type="button"
           aria-label={expanded ? "Collapse" : "Expand"}
           aria-expanded={expanded}
-          onClick={toggle}
-          // Hovering this folder calls out the same collection's CARD in the
-          // surface above (graph-collection-hover). One direction only: the
-          // card does not reach back down here.
-          onPointerEnter={hoverSource.onPointerEnter}
-          onPointerLeave={hoverSource.onPointerLeave}
+          // STOPS PROPAGATING, or the row's own handler toggles it straight
+          // back: this button is inside the clickable header now, so one press
+          // would run `toggle` twice and the row would appear inert.
+          onClick={(event) => {
+            event.stopPropagation();
+            toggle();
+          }}
           className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-sky-400 transition-colors hover:bg-zinc-800 hover:text-sky-300"
         >
           {expanded ? (
@@ -219,16 +252,25 @@ function SubTimelineNode({
           )}
         </button>
         {rename.editing ? (
-          <InlineNameEditor
-            initialValue={name}
-            onInput={rename.setDraft}
-            onCommit={rename.commit}
-            onCancel={rename.cancel}
-            className="min-w-0 flex-1 rounded border border-sky-500/60 bg-zinc-900 px-1.5 py-0.5 text-sm font-semibold text-zinc-100 outline-none"
-          />
+          // Wrapped so a click inside the editor cannot reach the row's
+          // toggle. Clicking to place a caret while renaming must not collapse
+          // the thing being renamed.
+          <div className="min-w-0 flex-1" onClick={(event) => event.stopPropagation()}>
+            <InlineNameEditor
+              initialValue={name}
+              onInput={rename.setDraft}
+              onCommit={rename.commit}
+              onCancel={rename.cancel}
+              className="w-full rounded border border-sky-500/60 bg-zinc-900 px-1.5 py-0.5 text-sm font-semibold text-zinc-100 outline-none"
+            />
+          </div>
         ) : (
           <h3
             onDoubleClick={rename.begin}
+            // The exception to the clickable row — see the header's note. A
+            // single click here must not toggle, because the first click of a
+            // rename double-click is a single click.
+            onClick={(event) => event.stopPropagation()}
             title="Double-click to rename"
             className="cursor-text truncate text-sm font-semibold text-zinc-100"
           >
@@ -269,7 +311,11 @@ function SubTimelineNode({
         <span
           aria-hidden="true"
           data-subtimeline-thumbs
-          className="flex h-10 w-[72px] shrink-0 overflow-hidden rounded-sm bg-zinc-950/60"
+          // A RING, NOT A BORDER (PL15-011). A border would add to the box and
+          // shift this thumbnail off the vertical column the negative margin
+          // below exists to hold it on; a ring paints outside and takes no part
+          // in layout. Same reason the drop zones wear one.
+          className="relative flex h-10 w-[72px] shrink-0 overflow-hidden rounded-sm bg-zinc-950/60 ring-1 ring-white/15"
           // Cancel the right inset this row's ANCESTOR panels impose, so every
           // preview in the tree lands on one vertical line however deeply the
           // row is nested. Without it each level shifted the frames 13px left
@@ -278,20 +324,69 @@ function SubTimelineNode({
           // they belong to the column, not to the panel they sit in.
           style={{ marginRight: -(depth * SUBTIMELINE_PANEL_RIGHT_INSET_PX) }}
         >
-          {previewFrames.map((frame, index) => (
-            // Keyed by SLOT, not content: the pair is order-stable and the
-            // same asset can be both first and last, so a content key would
-            // collide AND remount an already-loaded frame on every child edit.
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              key={index}
-              src={collectionPreviewFrameUrl(frame)}
-              alt=""
-              draggable={false}
-              loading="lazy"
-              className="h-full min-w-0 flex-1 object-cover"
-            />
-          ))}
+          {previewFrames.length === 0 ? (
+            /* THE CARD'S OWN EMPTY STATES, not a flat tint (PL15-011).
+               This box's `bg-zinc-950/60` used to be all you saw when a
+               collection had no frame — a flat wash that reads at 40px like
+               the card's gradient and is not it. Mirroring the card means
+               using the card's placeholders, so the two cannot drift.
+
+               INCLUDING THE AUDIO ONE. A collection of voice takes draws the
+               audio glyph on its card because "this is sound" is truer there
+               than "this is empty"; drawing the gradient here would make the
+               same collection read as empty in the tree and as audio on the
+               board, which is the exact disagreement this item exists to
+               close. */
+            <span
+              data-subtimeline-thumb-kind={leadsWithAudio ? "audio" : "empty"}
+              className="flex h-full w-full"
+            >
+              {leadsWithAudio ? <AudioPlaceholder /> : <EmptyCollectionPlaceholder />}
+            </span>
+          ) : (
+            previewFrames.map((frame, index) => (
+              // Keyed by SLOT, not content: the same asset can appear more than
+              // once, so a content key would collide AND remount an
+              // already-loaded frame on every child edit.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                key={index}
+                src={collectionPreviewFrameUrl(frame)}
+                alt=""
+                draggable={false}
+                loading="lazy"
+                className="h-full min-w-0 flex-1 object-cover"
+              />
+            ))
+          )}
+          {/* THE COLLECTION MARK, as the card wears it (PL15-011).
+              On the card this says "container, not clip" over the artwork, and
+              it is drawn whether or not there are frames behind it — said once,
+              the same way, either way. The row is the tree view of those very
+              cards, so it says it too.
+
+              ITS OWN SCALE. The card's mark is a 40px glyph in a `p-2` disc,
+              which is the whole height of this 40px box. A 16px glyph in a
+              `p-1` disc is the same object one size down.
+
+              THE DISC IS NOT DECORATION. A bare glyph is white on whatever the
+              children happen to be, and over a pale or busy frame the strokes
+              break up; the disc is its ground. `bg-black/45` as a BACKGROUND
+              alpha rather than `opacity` on the wrapper, which would take the
+              glyph down with it — and the glyph keeps its own half opacity so
+              the frame still reads through, because the frame is how you
+              recognise WHICH collection this is. */}
+          <span
+            data-subtimeline-collection-mark
+            className="pointer-events-none absolute inset-0 grid place-items-center"
+          >
+            <span className="rounded-full bg-black/45 p-1">
+              <Layers
+                className="size-4 text-white opacity-50 drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
+                strokeWidth={1.5}
+              />
+            </span>
+          </span>
         </span>
       </div>
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -282,15 +282,24 @@ export function GraphTimelineView({
   const [waveformOn, setWaveformOn] = useState(false);
   // Flat mode: every item in the focused closure, in order, no nesting.
   // Strip-only — grid has no equivalent, and leaving grid turns it off below.
-  // STRIP OPENS FLAT. The strip is a time axis, and a run of every shot in
-  // order is what a time axis is for — collections are a way to ORGANISE that
-  // run, not the default way to read it. So the control below is inverted: it
-  // offers "Collections", and turning it on is what leaves the flat run.
   //
-  // The cost, stated plainly: flat mode refuses `move-nodes` (see
-  // `commandPolicy`), so a strip that opens flat opens without drag-to-reorder
-  // until you switch to Collections.
-  const [flatOn, setFlatOn] = useState(initialSurface === "strip");
+  // THE STRIP OPENS IN COLLECTIONS (PL15-003), and used to open FLAT. The
+  // argument for flat was that the strip is a time axis and a run of every
+  // shot in order is what a time axis is for — collections being a way to
+  // ORGANISE that run rather than the default way to read it.
+  //
+  // What settled it against that was the cost the old comment already stated
+  // and then accepted: flat mode refuses `move-nodes` (see `commandPolicy`),
+  // so a strip that opened flat opened WITHOUT drag-to-reorder, and nothing on
+  // screen said why. A default posture that quietly disables the board's main
+  // gesture is the wrong default however good the reading is. Opening grouped
+  // means the strip is reorderable on arrival and going flat is an explicit
+  // trade.
+  //
+  // `false`, not `initialSurface !== "strip"`: flat is strip-only, so grid
+  // arriving false is the same answer for its own reason, and one literal says
+  // it once.
+  const [flatOn, setFlatOn] = useState(false);
   const [flatLoading, setFlatLoading] = useState(false);
   const [timeChannel] = useState(createPreviewTimeChannel);
   // The sidebar owns the layout switch and the ruler toggle (its top icons /
@@ -353,7 +362,14 @@ export function GraphTimelineView({
     // Leaving the strip drops flat (grid has no flat run to show); arriving at
     // it restores the strip's default rather than whatever the grid left
     // behind. Both directions, so the strip is the same on every arrival.
-    setFlatOn(surface === "strip");
+    //
+    // THE STRIP'S DEFAULT IS COLLECTIONS (PL15-003), so both directions now
+    // land on the same value. It stays written as a reset rather than being
+    // deleted: what this block guarantees is "the strip is the same on every
+    // arrival", and that is a promise about arrivals, not about the constant
+    // that currently satisfies it — a later default would have to be applied
+    // here or grid → strip would carry the previous session's posture back in.
+    setFlatOn(false);
   }
 
   // The ruler is scoped to flat mode (its toggle only mounts there), so flat

--- a/apps/timeline-gstudio001/components/graph-view/graph-tool-buttons.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tool-buttons.stories.tsx
@@ -30,10 +30,20 @@ import { MediaDropTarget } from "./graph-tool-buttons";
 // so `input.click()` dispatches the click and nothing else happens — which is
 // exactly what needs counting.
 
+// Both stories drive the component through `render` (they need the StrictMode
+// wrapper), but the typed `satisfies` still wants a full arg set on the meta —
+// so these are the defaults each story then re-states for readability.
 const meta = {
   title: "Graph view/Media drop target",
   component: MediaDropTarget,
   parameters: { layout: "centered" },
+  args: {
+    hadUserActivation: true,
+    clientX: 40,
+    clientY: 40,
+    onFiles: () => {},
+    onDismiss: () => {},
+  },
 } satisfies Meta<typeof MediaDropTarget>;
 
 export default meta;

--- a/apps/timeline-gstudio001/components/graph-view/graph-tool-buttons.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tool-buttons.stories.tsx
@@ -1,0 +1,132 @@
+import { StrictMode } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, waitFor } from "storybook/test";
+
+import { MediaDropTarget } from "./graph-tool-buttons";
+
+// The drag path's second half: a drop parked a position, and now it needs
+// files.
+//
+// STRICTMODE IS HERE BUT DOES NOT DO WHAT THIS FILE WAS WRITTEN TO ASSUME.
+//
+// The app runs with `reactStrictMode: true`, and `MediaDropTarget` opens the OS
+// file picker from a mount effect — so the theory for PL15-019 (one drop, two
+// pickers) was StrictMode's deliberate double-invoke of mount effects running
+// that unguarded side effect twice.
+//
+// THIS STORY DOES NOT PROVE THAT, and the check that says so is worth keeping:
+// with the `autoOpenedRef` guard REMOVED, it still counts exactly one click.
+// React only double-invokes effects in a development build of React, and the
+// build behind these stories does not, so wrapping the tree in `StrictMode`
+// changes nothing here. A story cannot reproduce the reported bug.
+//
+// What it does assert is narrower and still worth having: one mount asks for
+// the picker exactly ONCE, and the no-activation branch focuses the prompt
+// instead. Read it as a guard against this effect gaining a second trigger —
+// not as evidence that what the owner saw is fixed. That needs watching the
+// real dev app, or a production build to see whether it doubles there too.
+//
+// NO REAL PICKER OPENS HERE. Headless Chromium does not surface a file dialog,
+// so `input.click()` dispatches the click and nothing else happens — which is
+// exactly what needs counting.
+
+const meta = {
+  title: "Graph view/Media drop target",
+  component: MediaDropTarget,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof MediaDropTarget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Clicks on the hidden file input, counted from BEFORE the component mounts.
+ *
+ * ARMED IN `render`, NOT IN `play`, and that is the whole reason this file
+ * catches anything. `play` runs after the tree has mounted and its effects have
+ * fired — so a listener attached there has already missed the clicks it exists
+ * to count, and the story reads 0 whether the bug is present or not. It would
+ * pass against the broken code, which is worse than not testing it.
+ *
+ * One module-level counter, reset each time a story renders: the listener is
+ * attached once for the page's lifetime, so a per-render closure would leak one
+ * listener per story and count clicks from stories that had already finished.
+ */
+let inputClicks = 0;
+let listening = false;
+
+function armInputClickCounter(): void {
+  inputClicks = 0;
+  if (listening) return;
+  listening = true;
+  document.addEventListener(
+    "click",
+    (event) => {
+      if ((event.target as HTMLElement | null)?.hasAttribute?.("data-media-drop-input")) {
+        inputClicks += 1;
+      }
+    },
+    true,
+  );
+}
+
+/**
+ * ONE MOUNT ASKS FOR THE PICKER ONCE.
+ *
+ * NOT a regression test for PL15-019 — see the note at the top of this file.
+ * Removing the `autoOpenedRef` guard leaves this passing, because the React
+ * build here does not double-invoke the effect the guard exists for.
+ */
+export const OpensThePickerExactlyOnce: Story = {
+  render: () => {
+    armInputClickCounter();
+    return (
+      <StrictMode>
+        <MediaDropTarget
+          hadUserActivation
+          clientX={40}
+          clientY={40}
+          onFiles={() => {}}
+          onDismiss={() => {}}
+        />
+      </StrictMode>
+    );
+  },
+  play: async () => {
+    await waitFor(() =>
+      expect(document.querySelector("[data-media-drop-input]")).not.toBeNull(),
+    );
+    // Wait for the picker to have been asked for at all before asserting how
+    // MANY times — otherwise a count of 1 could be an early read of a sequence
+    // that reaches 2 a frame later, which is exactly the bug.
+    await waitFor(() => expect(inputClicks).toBeGreaterThan(0));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(inputClicks).toBe(1);
+  },
+};
+
+/**
+ * WITHOUT ACTIVATION THE PROMPT IS FOCUSED INSTEAD, and no picker is opened.
+ *
+ * This is the branch that makes the drop reachable without a mouse at all: a
+ * browser refuses a programmatic picker without user activation, so the drop
+ * offers a button to ask again rather than failing silently.
+ */
+export const WithoutActivationItFocusesThePrompt: Story = {
+  render: () => (
+    <StrictMode>
+      <MediaDropTarget
+        hadUserActivation={false}
+        clientX={40}
+        clientY={40}
+        onFiles={() => {}}
+        onDismiss={() => {}}
+      />
+    </StrictMode>
+  ),
+  play: async () => {
+    await waitFor(() =>
+      expect(document.activeElement?.getAttribute("data-media-drop-prompt")).not.toBeNull(),
+    );
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-tool-buttons.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tool-buttons.tsx
@@ -217,13 +217,40 @@ export function MediaDropTarget({
 
   const open = useCallback(() => inputRef.current?.click(), []);
 
+  /**
+   * Whether the picker has already been opened FOR US, by the effect below.
+   *
+   * ONE DROP WAS OPENING TWO PICKERS (PL15-019). The effect called `open()`
+   * with no guard, and `reactStrictMode` is on — StrictMode deliberately
+   * double-invokes mount effects (mount, unmount, remount) to surface effects
+   * that are not idempotent, and this was one: `open()` does something TO THE
+   * USER rather than setting something up, so running it twice opened the OS
+   * file picker twice, one behind the other.
+   *
+   * A ref rather than state: it must not re-render, and it survives
+   * StrictMode's simulated remount for the same reason state does — the
+   * component instance is the same one.
+   *
+   * IT GUARDS THE EFFECT, NOT `open`. The prompt button below calls `open` too,
+   * and that call is the user asking again — after cancelling the first picker,
+   * most likely. Guarding `open` itself would make "Choose files…" work once
+   * and then silently do nothing, which is a worse bug than the one being
+   * fixed.
+   */
+  const autoOpenedRef = useRef(false);
+
   // Open the picker when the drop still had activation; the prompt is rendered
   // either way, so this is an accelerator rather than a branch. Whether it was
   // possible is a PROP — decided at the drop, when it was true — so there is no
   // state to set here and no cascading render.
   useEffect(() => {
-    if (hadUserActivation) open();
-    else promptRef.current?.focus();
+    if (!hadUserActivation) {
+      promptRef.current?.focus();
+      return;
+    }
+    if (autoOpenedRef.current) return;
+    autoOpenedRef.current = true;
+    open();
   }, [hadUserActivation, open]);
 
   // Dismissal: Escape, or a click anywhere that is not the prompt. Not the

--- a/apps/timeline-gstudio001/components/projects/load-project-button.stories.tsx
+++ b/apps/timeline-gstudio001/components/projects/load-project-button.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { Toaster } from "@/components/core/sonner";
+
+import { LoadProjectButton } from "./load-project-button";
+
+// "Load Project" on the library page — the one home this action has (PL15-002).
+//
+// THE FAILURE STORIES CAME FROM `graph-view/graph-project-menu.stories.tsx`,
+// where load used to live in the board's `⋮`. The menu item went; the code
+// behind it did not, so its coverage moved here rather than being deleted with
+// it. Both cases below are the same `loadProjectFromFile` they always tested,
+// reached from the control that still calls it.
+//
+// NO NETWORK, per the storybook workspace's rule. The success path is never
+// exercised — it would replace the offline board — so what is covered is the
+// two ways it is refused, which are the likely outcomes until offline mode is
+// set up.
+//
+// The TOASTER IS MOUNTED HERE because the app mounts it in the root layout, and
+// failures are reported through it. Without it the component would appear to do
+// nothing on failure and the stories would pass by asserting nothing.
+
+const meta = {
+  title: "Projects/Load project button",
+  component: LoadProjectButton,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[240px] items-start justify-center bg-zinc-950 p-4">
+        <Story />
+        <Toaster />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof LoadProjectButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * At rest: an outline button, secondary to "New Project"'s filled blue. Both
+ * make a project appear in the list, but one is the everyday verb and the other
+ * is recovery.
+ */
+export const Closed: Story = {};
+
+/**
+ * A refused load: the server says no (offline mode off, or the target being a
+ * generated fixture) and the reason has to reach the user.
+ *
+ * This story is why the message is a TOAST. It was first rendered inside the
+ * board menu this control replaced, and uploading fires a real pointerdown on
+ * the file input — which Radix treated as an outside press, dismissing the
+ * content and taking the only report of the failure with it. A toast outlives
+ * the control that started it, which is still what makes it right here: this
+ * button does not survive a route change either.
+ */
+export const LoadRefused: Story = {
+  play: async () => {
+    const original = window.fetch;
+    window.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: "scale-probe.json is a generated fixture and will not be overwritten.",
+        }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      )) as typeof window.fetch;
+
+    try {
+      // Straight at the input rather than through the button: clicking that
+      // opens the OS file picker, which a story cannot answer.
+      const input = document.querySelector<HTMLInputElement>("[data-project-import-input]");
+      await expect(input).not.toBeNull();
+      await userEvent.upload(
+        input as HTMLInputElement,
+        new File(['{"documents":{}}'], "toon-town.json", { type: "application/json" }),
+      );
+
+      await waitFor(() =>
+        expect(within(document.body).getByText(/generated fixture/)).toBeInTheDocument(),
+      );
+    } finally {
+      window.fetch = original;
+    }
+  },
+};
+
+/**
+ * A `.json` file whose contents are not JSON — answered locally, with no
+ * request made at all.
+ *
+ * The file is NAMED `.json` on purpose: `userEvent.upload` enforces the input's
+ * `accept` list exactly as a browser does, so handing it a `.txt` discarded the
+ * file silently and the story asserted against a component that had never been
+ * given anything. Which is also the honest scenario — the picker only offers
+ * JSON, so the way to arrive here is a corrupt or truncated export, not a text
+ * file.
+ */
+export const LoadNotJson: Story = {
+  play: async () => {
+    const input = document.querySelector<HTMLInputElement>("[data-project-import-input]");
+    await userEvent.upload(
+      input as HTMLInputElement,
+      new File(["{ truncated…"], "toon-town.json", { type: "application/json" }),
+    );
+
+    await waitFor(() =>
+      expect(within(document.body).getByText(/is not valid JSON/)).toBeInTheDocument(),
+    );
+  },
+};

--- a/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
@@ -97,8 +97,20 @@ export const RAIL_WIDTH_CLASS = {
  * The box is a full-width square at rail width — that is what keeps the rail's
  * rhythm even and the tiles on one grid. What you actually see is the
  * `::before` layer, inset from that box, so every fill (idle, hover, pressed,
- * disabled) paints as a rounded pill floating inside its square rather than a
- * band running edge to edge.
+ * disabled) paints as a pill floating inside its square rather than a band
+ * running edge to edge.
+ *
+ * SQUARE ON THE LEFT, ROUNDED ON THE RIGHT (`rounded-r-2xl`). The rail's
+ * active state is an indicator bar riding the left boundary (see
+ * `SIDEBAR_ICON_PRESSED`), and a fill that rounds AWAY from that edge reads as
+ * a free-floating button that happens to sit near a line. Squared on the side
+ * the bar marks, the two read as one shape anchored to the rail.
+ *
+ * ON EVERY TILE, not only the active one — which is why it is written here on
+ * the base rather than in the pressed variant. The fill is present in every
+ * state (idle is a fainter `zinc-900/40`), so squaring only the pressed one
+ * would make the pill change SHAPE on activation rather than only colour. One
+ * shape in every state, and the bar alone carries "where am I".
  *
  * ON THE RAIL the square becomes a row of the same HEIGHT and the glyph leads
  * rather than centring — unconditionally, in both states. The pill follows the
@@ -108,7 +120,7 @@ export const RAIL_WIDTH_CLASS = {
 export const SIDEBAR_ICON_BASE = [
   "group/sidebar-item relative flex w-full aspect-square items-center justify-center",
   "transition-all duration-200 focus-visible:outline-none",
-  "before:absolute before:inset-2 before:rounded-2xl before:transition-colors before:content-['']",
+  "before:absolute before:inset-2 before:rounded-r-2xl before:transition-colors before:content-['']",
   "focus-visible:before:ring-2 focus-visible:before:ring-zinc-400",
   // Not keyed to the open state — see RAIL_CLASS. 72px is exactly what
   // `aspect-square` already gave at 72px wide.

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 
-import { AuthProvider } from "@/components/auth/auth-provider";
+import { AuthProvider, type AuthUser } from "@/components/auth/auth-provider";
 
 import { TimelineSidebar } from "./timeline-sidebar";
 import { RAIL_OPEN_WIDTH_PX, RAIL_WIDTH_PX } from "./sidebar-icon-styles";
@@ -45,7 +45,10 @@ function forgetRailPreference(): void {
   window.localStorage.removeItem(STORAGE_KEY);
 }
 
-const USER = {
+// ANNOTATED, not inferred. Inference gives `picture` the literal type `null`,
+// which makes every helper taking `typeof USER` reject a user that HAS a
+// picture — including the one the avatar-fallback story is built on.
+const USER: AuthUser = {
   uid: "u-story",
   email: "editor@example.test",
   name: "Story Editor",
@@ -64,7 +67,7 @@ const USER = {
  * testing had been swapped for the default's `null` before the assertion ran,
  * and "no picture" falls back for a reason that has nothing to do with the bug.
  */
-function stubFetch(user: typeof USER = USER) {
+function stubFetch(user: AuthUser = USER) {
   window.fetch = (async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
     const body = url.includes("/api/auth/me")
@@ -79,7 +82,7 @@ function stubFetch(user: typeof USER = USER) {
   }) as typeof window.fetch;
 }
 
-function Harness({ user = USER }: { user?: typeof USER }) {
+function Harness({ user = USER }: { user?: AuthUser }) {
   return (
     // The rail is `h-screen` and sticky; the frame gives it a page to sit in
     // and the app's ground to be read against.

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.stories.tsx
@@ -52,12 +52,23 @@ const USER = {
   picture: null,
 };
 
-/** Everything this component asks the network for, answered locally. */
-function stubFetch() {
+/**
+ * Everything this component asks the network for, answered locally.
+ *
+ * IT MUST ANSWER WITH THE SAME USER THE HARNESS WAS GIVEN, which is why this
+ * takes one. `AuthProvider` background-revalidates against `/api/auth/me` on
+ * mount and `setUser`s whatever comes back — so a stub that always replied
+ * with the default silently REPLACED any user a story had passed as
+ * `initialUser`, a frame after render. The avatar story caught this the
+ * expensive way: it passed with the fix removed, because the picture it was
+ * testing had been swapped for the default's `null` before the assertion ran,
+ * and "no picture" falls back for a reason that has nothing to do with the bug.
+ */
+function stubFetch(user: typeof USER = USER) {
   window.fetch = (async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
     const body = url.includes("/api/auth/me")
-      ? { user: USER }
+      ? { user }
       : url.includes("/api/assets/marked")
         ? { assets: [] }
         : {};
@@ -68,17 +79,30 @@ function stubFetch() {
   }) as typeof window.fetch;
 }
 
-function Harness() {
+function Harness({ user = USER }: { user?: typeof USER }) {
   return (
     // The rail is `h-screen` and sticky; the frame gives it a page to sit in
     // and the app's ground to be read against.
     <div className="graph-view-theme flex min-h-[560px] bg-zinc-950">
-      <AuthProvider initialUser={USER}>
+      <AuthProvider initialUser={user}>
         <TimelineSidebar />
       </AuthProvider>
     </div>
   );
 }
+
+/**
+ * A `picture` that is a real value and cannot be decoded — the shape of the
+ * bug in PL15-007.
+ *
+ * A DATA URI OF NON-IMAGE BYTES, not a URL that 404s. It fails in the decoder
+ * rather than on the network, so the story needs nothing served, cannot be
+ * rescued by a cache, and fires `onError` on every run — which a same-origin
+ * 404 does too but only as long as nobody puts a file at that path.
+ */
+const UNDECODABLE_PICTURE = "data:image/png;base64,Zm9v";
+
+const BROKEN_PICTURE_USER = { ...USER, picture: UNDECODABLE_PICTURE };
 
 const meta: Meta<typeof TimelineSidebar> = {
   title: "timeline/TimelineSidebar",
@@ -281,5 +305,43 @@ export const RepeatedTogglingStaysInStep: Story = {
         "false",
       );
     }
+  },
+};
+
+/**
+ * THE PICTURE FAILS AND THE INITIAL TAKES OVER (PL15-007).
+ *
+ * The branch used to be `picture ? <img> : <initial>`, which covers a picture
+ * that is ABSENT and not one that is BROKEN — a real URL that 404s took the
+ * image branch and had nothing behind it, so the rail drew the browser's
+ * broken-image glyph. Both places that render the avatar had it, so this
+ * checks both: the tile, and the popover behind it.
+ */
+export const TheAvatarFallsBackWhenThePictureFails: Story = {
+  render: () => {
+    // BOTH the initial user and the revalidation answer, or the picture under
+    // test is replaced by the default's `null` a frame after mount and the
+    // story passes for the wrong reason. See `stubFetch`.
+    stubFetch(BROKEN_PICTURE_USER);
+    forgetRailPreference();
+    return <Harness user={BROKEN_PICTURE_USER} />;
+  },
+  play: async ({ canvasElement }) => {
+    const account = canvasElement.querySelector<HTMLElement>('[aria-label="Account"]')!;
+
+    // The <img> is REMOVED, not merely covered. Asserting the letter alone
+    // would pass with a broken glyph sitting underneath it.
+    await waitFor(() => expect(account.querySelector("img")).toBeNull());
+    expect(account.textContent).toContain("S");
+
+    // ...and the popover, which carries its own copy of the same branch.
+    await userEvent.click(account);
+    const popover = await waitFor(() => {
+      const found = canvasElement.querySelector<HTMLElement>(".profile-popover-animate");
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    await waitFor(() => expect(popover.querySelector("img")).toBeNull());
+    expect(popover.textContent).toContain("S");
   },
 };

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -516,6 +516,60 @@ function initialOf(
   return (user?.name?.[0] ?? user?.email?.[0] ?? "U").toUpperCase();
 }
 
+type AccountUser = Readonly<{
+  name?: string | null;
+  email?: string | null;
+  picture?: string | null;
+}>;
+
+/**
+ * The account picture, or the initial in its place.
+ *
+ * WHY THIS IS A COMPONENT and not a third copy of the ternary: the branch was
+ * already written twice — the rail tile and the profile popover — and it was
+ * wrong in both the same way (PL15-007). It covered a picture that is ABSENT
+ * and not one that FAILS. A `picture` that is a real URL takes the image
+ * branch and, when the request 404s or is blocked, has nothing behind it, so
+ * the tile draws the browser's broken-image glyph. `initialOf` exists because
+ * the ternary was duplicated; this exists so the error path cannot be.
+ *
+ * THE FAILED URL IS REMEMBERED, NOT A BOOLEAN. Signing out and back in as
+ * someone else hands this a different `picture`, and a boolean latched by the
+ * previous user's dead URL would hide the new user's good one forever. Keyed
+ * on the src, a new URL is simply not the failed one and gets its own attempt
+ * — no reset effect, and nothing to forget to fire.
+ *
+ * The fallback is the SAME element the no-picture case has always drawn, so a
+ * failed load is indistinguishable from an account with no photo, and the box
+ * is identical either way — nothing reflows when it swaps.
+ */
+function AccountAvatar({
+  user,
+  imageClassName,
+  fallbackClassName,
+}: Readonly<{
+  user: AccountUser | null | undefined;
+  imageClassName: string;
+  fallbackClassName: string;
+}>) {
+  const picture = user?.picture ?? null;
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+
+  if (picture !== null && picture !== failedSrc) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={picture}
+        alt={user?.name || user?.email || "Profile"}
+        className={imageClassName}
+        onError={() => setFailedSrc(picture)}
+      />
+    );
+  }
+
+  return <div className={fallbackClassName}>{initialOf(user)}</div>;
+}
+
 type UtilityItem = {
   id: "assets" | "trash";
   label: string;
@@ -1233,28 +1287,23 @@ export function TimelineSidebar({
               isProfileOpen ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
             )}
           >
-            {user?.picture ? (
-              <img
-                src={user.picture}
-                alt={user.name || user.email || "Profile"}
-                className={cn(
-                  // `relative` for the same reason the glyphs carry it: the tile's pill is
-                  // an absolute ::before and would otherwise paint a 40% black veil over
-                  // this face. Same bug the collection thumbnails had.
-                  "relative h-8 w-8 shrink-0 rounded-full object-cover border border-zinc-700 group-hover/sidebar-item:border-zinc-500 transition-colors",
-                  SIDEBAR_AVATAR_INSET,
-                )}
-              />
-            ) : (
-              <div
-                className={cn(
-                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-xs font-bold text-zinc-400 transition-colors select-none group-hover/sidebar-item:border-zinc-600 group-hover/sidebar-item:bg-zinc-800 group-hover/sidebar-item:text-zinc-100",
-                  SIDEBAR_AVATAR_INSET,
-                )}
-              >
-                {initialOf(user)}
-              </div>
-            )}
+            <AccountAvatar
+              user={user}
+              imageClassName={cn(
+                // `relative` for the same reason the glyphs carry it: the tile's pill is
+                // an absolute ::before and would otherwise paint a 40% black veil over
+                // this face. Same bug the collection thumbnails had.
+                "relative h-8 w-8 shrink-0 rounded-full object-cover border border-zinc-700 group-hover/sidebar-item:border-zinc-500 transition-colors",
+                SIDEBAR_AVATAR_INSET,
+              )}
+              fallbackClassName={cn(
+                // `relative` for the same reason the image above carries it — the
+                // fallback stands in the same place and would otherwise sit under
+                // the pill.
+                "relative flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-xs font-bold text-zinc-400 transition-colors select-none group-hover/sidebar-item:border-zinc-600 group-hover/sidebar-item:bg-zinc-800 group-hover/sidebar-item:text-zinc-100",
+                SIDEBAR_AVATAR_INSET,
+              )}
+            />
             <SidebarTooltipLabel
               id="sidebar-tooltip-utility-account"
               label="Account"
@@ -1270,17 +1319,11 @@ export function TimelineSidebar({
               className="absolute bottom-0 left-full z-50 ml-2 w-64 rounded-xl border border-zinc-800/80 bg-zinc-950/90 p-4 shadow-[0_10px_40px_rgba(0,0,0,0.7)] backdrop-blur-md profile-popover-animate"
             >
               <div className="flex items-center gap-3 border-b border-zinc-800/60 pb-3">
-                {user?.picture ? (
-                  <img
-                    src={user.picture}
-                    alt={user.name || user.email || "Profile"}
-                    className="h-10 w-10 rounded-full object-cover border border-zinc-800"
-                  />
-                ) : (
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-sm font-bold text-zinc-300">
-                    {initialOf(user)}
-                  </div>
-                )}
+                <AccountAvatar
+                  user={user}
+                  imageClassName="h-10 w-10 shrink-0 rounded-full object-cover border border-zinc-800"
+                  fallbackClassName="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-sm font-bold text-zinc-300"
+                />
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-xs font-semibold text-zinc-100">
                     {user?.name || "User"}

--- a/apps/timeline-gstudio001/lib/webmcp/tools.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.ts
@@ -61,6 +61,8 @@ export function createGraphTools(ctx: GraphToolContext): ToolDef[] {
     removeClipTool(ctx),
     setDisabledTool(ctx),
     setLaneTool(ctx),
+    setTagsTool(ctx),
+    setLayerFrameTool(ctx),
     getViewStateTool(ctx),
     selectItemsTool(ctx),
     clearSelectionTool(ctx),
@@ -409,6 +411,110 @@ function setLaneTool(ctx: GraphToolContext): ToolDef {
       return toolOk(lane === 0 ? "Back on the picture." : `On lane ${lane}.`, {
         nodeId: nodeIdStr,
         lane,
+      });
+    },
+  };
+}
+
+// ---- set_tags --------------------------------------------------------------
+
+/**
+ * Tags live in the DETAILS side table, not in the graph — which is why this
+ * writes through `ctx.details` rather than dispatching a command. There is no
+ * tag command to dispatch; the server handler reaches for the same table.
+ *
+ * A node with no details entry is REFUSED rather than given one. An entry is
+ * what a document knows about a clip, and inventing a bare one to hang tags off
+ * would write into a row nothing else believes in.
+ */
+function setTagsTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "set_tags",
+    description: "Replace a clip or collection's tags. Pass an empty list to clear them.",
+    inputSchema: jsonSchemaFor({
+      nodeId: nodeIdField,
+      tags: z.array(z.string()).describe("The complete tag list. Replaces what is there."),
+    }),
+    execute: (args) => {
+      const nodeIdStr = readString(args, "nodeId");
+      if (!nodeIdStr) return toolError("set_tags requires a nodeId.");
+      const graph = ctx.store.getSnapshot().graph;
+      if (!graph.nodesById.get(parseNodeId(nodeIdStr))) {
+        return toolError(`No node with id "${nodeIdStr}".`);
+      }
+      const existing = ctx.details.get(nodeIdStr);
+      if (existing === undefined) {
+        return toolError(`"${nodeIdStr}" has no details entry yet, so tags have nowhere to live.`);
+      }
+      // Trimmed, de-duplicated, blanks dropped — the same normalising the
+      // server does, so the two surfaces cannot disagree about what a tag list
+      // means.
+      const tags = [
+        ...new Set(readStringArray(args, "tags").map((tag) => tag.trim()).filter(Boolean)),
+      ];
+      ctx.details.merge({ [nodeIdStr]: { ...existing, tags } });
+      return toolOk(
+        tags.length === 0 ? "Cleared the tags." : `Tagged: ${tags.join(", ")}.`,
+        { nodeId: nodeIdStr, tags },
+      );
+    },
+  };
+}
+
+// ---- set_layer_frame -------------------------------------------------------
+
+function setLayerFrameTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "set_layer_frame",
+    description:
+      "Inset a layered clip into a frame within the picture, or clear it so the clip fills it.",
+    inputSchema: jsonSchemaFor({
+      nodeId: nodeIdField,
+      // A RECT, NOT A NAME. `layerFrame` is `{x, y, width}` in fractions of the
+      // picture — the first version of this tool took a string and typechecked
+      // clean against `placement`, because `placement` is a partial and an
+      // unknown key is simply ignored. It would have accepted every call and
+      // done nothing.
+      frame: z
+        .object({
+          x: z.number().describe("Left edge, 0-1 across the picture."),
+          y: z.number().describe("Top edge, 0-1 down the picture."),
+          width: z.number().describe("Width, 0-1 of the picture."),
+        })
+        .nullable()
+        .describe("Where to inset the clip, or null to clear it."),
+    }),
+    execute: (args) => {
+      const nodeIdStr = readString(args, "nodeId");
+      if (!nodeIdStr) return toolError("set_layer_frame requires a nodeId.");
+      const graph = ctx.store.getSnapshot().graph;
+      const nodeId = parseNodeId(nodeIdStr);
+      if (!graph.nodesById.get(nodeId)) return toolError(`No node with id "${nodeIdStr}".`);
+      // `null` clears; a MISSING key is not the same thing and must not be read
+      // as one, so absent is an error rather than a silent clear.
+      const raw = record(args)["frame"];
+      if (raw === undefined) {
+        return toolError("`frame` is required — pass null to clear the frame.");
+      }
+      let layerFrame: Readonly<{ x: number; y: number; width: number }> | null = null;
+      if (raw !== null) {
+        const x = readNumber(raw, "x");
+        const y = readNumber(raw, "y");
+        const width = readNumber(raw, "width");
+        if (x === undefined || y === undefined || width === undefined) {
+          return toolError("`frame` needs numeric `x`, `y` and `width`, or null to clear.");
+        }
+        layerFrame = { x, y, width };
+      }
+      const result = ctx.store.dispatch({
+        type: "set-node-placement",
+        nodeIds: [nodeId],
+        placement: { layerFrame },
+      });
+      if (!result.ok) return toolError(describeDispatchRejection(result.error));
+      return toolOk(layerFrame === null ? "Frame cleared." : "Frame set.", {
+        nodeId: nodeIdStr,
+        layerFrame,
       });
     },
   };

--- a/apps/timeline-gstudio001/lib/webmcp/tools.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.ts
@@ -59,6 +59,8 @@ export function createGraphTools(ctx: GraphToolContext): ToolDef[] {
     trimClipTool(ctx),
     renameItemTool(ctx),
     removeClipTool(ctx),
+    setDisabledTool(ctx),
+    setLaneTool(ctx),
     getViewStateTool(ctx),
     selectItemsTool(ctx),
     clearSelectionTool(ctx),
@@ -325,6 +327,89 @@ function renameItemTool(ctx: GraphToolContext): ToolDef {
       const result = ctx.store.dispatch({ type: "rename-node", nodeId, name });
       if (!result.ok) return toolError(describeDispatchRejection(result.error));
       return toolOk(`Renamed to "${name}".`, { nodeId: nodeIdStr, name });
+    },
+  };
+}
+
+// ---- set_disabled ----------------------------------------------------------
+
+/**
+ * TWO WRITE VERBS THE IN-PAGE SURFACE DID NOT HAVE (PL15-018).
+ *
+ * `set_disabled` had no equivalent ANYWHERE — not here and not behind
+ * `/api/mcp` — even though disabling is a first-class action with its own
+ * command, its own clause in the modal's scoped undo, and a control in two
+ * dialogs. `set_lane` existed only on the server, so an agent working in the
+ * browser could not do something the same agent could do down the wire.
+ *
+ * Both go through `store.dispatch`, which is the point of the in-page surface:
+ * the tool runs the ACTUAL command path and its invariants rather than a second
+ * implementation of them, and the open editor animates the change because it
+ * renders from the same graph.
+ */
+function setDisabledTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "set_disabled",
+    description:
+      "Enable or disable a clip or collection. A disabled item keeps its slot and its span; playback skips it.",
+    inputSchema: jsonSchemaFor({
+      nodeId: nodeIdField,
+      disabled: z.boolean().describe("True to disable, false to enable."),
+    }),
+    execute: (args) => {
+      const nodeIdStr = readString(args, "nodeId");
+      if (!nodeIdStr) return toolError("set_disabled requires a nodeId.");
+      const disabled = readBoolean(args, "disabled");
+      if (disabled === undefined) {
+        return toolError("set_disabled requires `disabled` to be true or false.");
+      }
+      const graph = ctx.store.getSnapshot().graph;
+      const nodeId = parseNodeId(nodeIdStr);
+      if (!graph.nodesById.get(nodeId)) return toolError(`No node with id "${nodeIdStr}".`);
+      const result = ctx.store.dispatch({ type: "set-node-disabled", nodeIds: [nodeId], disabled });
+      if (!result.ok) return toolError(describeDispatchRejection(result.error));
+      return toolOk(disabled ? "Disabled." : "Enabled.", { nodeId: nodeIdStr, disabled });
+    },
+  };
+}
+
+// ---- set_lane --------------------------------------------------------------
+
+function setLaneTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "set_lane",
+    description:
+      "Move a clip between lanes. 0 is the picture; anything above runs under it.",
+    inputSchema: jsonSchemaFor({
+      nodeId: nodeIdField,
+      lane: z
+        .number()
+        .int()
+        .min(0)
+        .describe("The lane to put the clip on. 0 is the picture."),
+    }),
+    execute: (args) => {
+      const nodeIdStr = readString(args, "nodeId");
+      if (!nodeIdStr) return toolError("set_lane requires a nodeId.");
+      const lane = readNumber(args, "lane");
+      // Rejected rather than rounded: an agent asking for lane 1.5 has a bug,
+      // and quietly choosing one of the two neighbours for it hides it.
+      if (lane === undefined || !Number.isInteger(lane) || lane < 0) {
+        return toolError("`lane` must be a whole number, 0 or more. 0 is the picture.");
+      }
+      const graph = ctx.store.getSnapshot().graph;
+      const nodeId = parseNodeId(nodeIdStr);
+      if (!graph.nodesById.get(nodeId)) return toolError(`No node with id "${nodeIdStr}".`);
+      const result = ctx.store.dispatch({
+        type: "set-node-placement",
+        nodeIds: [nodeId],
+        placement: { trackIndex: lane },
+      });
+      if (!result.ok) return toolError(describeDispatchRejection(result.error));
+      return toolOk(lane === 0 ? "Back on the picture." : `On lane ${lane}.`, {
+        nodeId: nodeIdStr,
+        lane,
+      });
     },
   };
 }

--- a/apps/timeline-gstudio001/next-env.d.ts
+++ b/apps/timeline-gstudio001/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next-dev/dev/types/routes.d.ts";
+import "./.next-dev/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1645,14 +1645,24 @@ test.describe("graph view E2E", () => {
     ).toHaveAttribute("aria-pressed", "false");
     await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(0);
 
-    // Strip icon → strip layout, which OPENS FLAT. The ruler is scoped to a
-    // single continuous time axis, which only the flat run is — so the toggle
-    // arrives with the strip rather than needing a second control first. It
-    // used to take entering flat by hand; the default moved, and this is the
-    // half of the claim that changed.
+    // Strip icon → strip layout, which OPENS IN COLLECTIONS (PL15-003). The
+    // ruler is scoped to a single continuous time axis, which only the FLAT
+    // run is, so the toggle is not there on arrival and entering flat by hand
+    // is what summons it.
+    //
+    // THIS HALF OF THE CLAIM HAS NOW MOVED TWICE, which is worth saying rather
+    // than quietly rewriting again: the strip opened flat for a while, so the
+    // ruler arrived with it and this test asserted that. Opening flat also
+    // meant opening with drag-to-reorder refused, which is what sent the
+    // default back. The ruler's own rule never changed — it belongs to the
+    // flat run — only which state the strip starts in.
     await surfaceButton(page, "strip").click();
     await expect(strip(page, PROJECT_ID)).toBeVisible();
     await expect(surfaceButton(page, "strip")).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByRole("button", { name: /time ruler/i })).toHaveCount(0);
+
+    // Into the flat run, and the ruler's control arrives with it.
+    await page.getByRole("button", { name: "Show all items in order" }).click();
     const rulerToggle = page.getByRole("button", { name: /show time ruler/i });
     await expect(rulerToggle).toBeVisible();
 

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1030,6 +1030,22 @@ test.describe("graph view E2E", () => {
       .evaluateAll((els) => els.map((el) => Math.round(el.getBoundingClientRect().right)));
     expect(thumbRights.length).toBeGreaterThan(1);
     expect(new Set(thumbRights).size).toBe(1);
+
+    // EVERY THUMBNAIL WEARS THE COLLECTION MARK (PL15-011), the same `Layers`
+    // its card wears — on the card it is drawn whether or not there are frames
+    // behind it, and the row is the tree view of those cards.
+    const thumbs = page.locator("[data-subtimeline-thumbs]");
+    await expect(thumbs.locator("[data-subtimeline-collection-mark]")).toHaveCount(
+      thumbRights.length,
+    );
+
+    // AND A RING, NOT A BORDER. Asserted as a box-shadow rather than by eye
+    // because the distinction is the point: a border would have widened these
+    // boxes and pushed them off the single column just asserted above.
+    const ring = await thumbs
+      .first()
+      .evaluate((el) => getComputedStyle(el).boxShadow);
+    expect(ring).not.toBe("none");
   });
 
   test("a collection id containing a comma is one row, not two broken ones", async ({ page }) => {
@@ -1093,6 +1109,30 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => stripOrder(page, SLASH_ID), { timeout: 15000 }).toEqual(["s1"]);
   });
 
+  test("the whole row header opens the timeline, and the name still renames", async ({
+    page,
+  }) => {
+    // PL15-010. The row was expanded by a 20px folder button and nothing else,
+    // in a header that is most of the width of the board.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const section = page.locator('section[aria-label="Sub-timeline: Scene A"]');
+    const folder = section.locator("button[aria-expanded]").first();
+    await expect(folder).toHaveAttribute("aria-expanded", "false");
+
+    // The CLIP COUNT — an inert readout, nowhere near the folder, and the kind
+    // of place a press used to do nothing at all.
+    await section.getByText(/clips$/).click();
+    await expect(folder).toHaveAttribute("aria-expanded", "true");
+
+    // The folder still works, and works ONCE. It sits inside the clickable
+    // header now, so without stopping propagation a press would run the toggle
+    // twice and the row would read as inert.
+    await folder.click();
+    await expect(folder).toHaveAttribute("aria-expanded", "false");
+  });
+
   test("renaming a sub-graph in place persists to the child document title", async ({ page }) => {
     const api = await installGraphApi(page);
     await openGraph(page);
@@ -1100,6 +1140,17 @@ test.describe("graph view E2E", () => {
     // Double-click the (collapsed) row's name → inline edit; commit with Enter.
     const section = page.locator('section[aria-label="Sub-timeline: Scene A"]');
     await section.getByRole("heading", { name: "Scene A" }).dblclick();
+
+    // THE NAME IS THE ONE PART OF THE HEADER THAT DOES NOT TOGGLE (PL15-010).
+    // The first click of this double-click is a single click on a row that is
+    // otherwise clickable everywhere — and expanding a row HYDRATES it, so
+    // without the exclusion every rename would fire a fetch, flash the body
+    // open and collapse it again on the second click.
+    await expect(section.locator("button[aria-expanded]").first()).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+
     const input = page.getByRole("textbox", { name: "Timeline name" });
     await input.fill("Opening Scene");
     await input.press("Enter");

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1793,7 +1793,14 @@ test.describe("graph view E2E", () => {
     const dividerLineColor = () =>
       dividerLine.evaluate((el) => getComputedStyle(el).color);
     const restLineColor = await dividerLineColor();
-    await divider.hover({ position: { x: 20, y: 10 } });
+    // x=60, NOT x=20 (PL15-008). The divider's left end carries the preview's
+    // audio icon now — a 28px control at `left-2`, so it occupies roughly the
+    // first 36 pixels — and hovering THAT is not hovering the divider. Moving
+    // the point is only honest because of what is left: the drag target is
+    // still everything but the first 36px of a divider that runs the full
+    // width, which is why one icon was allowed there when a button AND a 64px
+    // slider previously were not.
+    await divider.hover({ position: { x: 60, y: 10 } });
     await expect.poll(dividerLineColor).not.toBe(restLineColor);
     await page.mouse.move(0, 0); // unhover before the resize steps below
 
@@ -2764,7 +2771,14 @@ test.describe("graph view E2E", () => {
     ).toBeCloseTo(36, 0);
 
     // Divider hover does not resize or move the transport.
-    await divider.hover({ position: { x: 20, y: 6 } });
+    // x=60, NOT x=20 (PL15-008). The divider's left end carries the preview's
+    // audio icon now — a 28px control at `left-2`, so it occupies roughly the
+    // first 36 pixels — and hovering THAT is not hovering the divider. Moving
+    // the point is only honest because of what is left: the drag target is
+    // still everything but the first 36px of a divider that runs the full
+    // width, which is why one icon was allowed there when a button AND a 64px
+    // slider previously were not.
+    await divider.hover({ position: { x: 60, y: 6 } });
     const groupAfterHover = await buttonGroup.boundingBox();
     expect(groupAfterHover).not.toBeNull();
     expect(groupAfterHover!.x).toBeCloseTo(groupBox!.x, 0);
@@ -2814,15 +2828,23 @@ test.describe("graph view E2E", () => {
     await expect(divider).toHaveAttribute("aria-valuenow", surfaceHeightBeforePlay!);
 
     // The rest of the divider remains a resize target.
+    //
+    // AT x=60, NOT x=20 (PL15-008). The divider's left end carries the
+    // preview's audio icon now — 28px at `left-2` — and that control stops
+    // pointer propagation for exactly the reason the transport does: a press on
+    // it must not begin a resize. So x=20 lands ON the island and the drag
+    // correctly does nothing, which is a pass for the island and a false
+    // failure for this assertion. The claim here is about the REST of the
+    // divider, and 36px in is where the rest begins.
     const dividerBoxAfterPlay = await divider.boundingBox();
     expect(dividerBoxAfterPlay).not.toBeNull();
     await page.mouse.move(
-      dividerBoxAfterPlay!.x + 20,
+      dividerBoxAfterPlay!.x + 60,
       dividerBoxAfterPlay!.y + dividerBoxAfterPlay!.height / 2,
     );
     await page.mouse.down();
     await page.mouse.move(
-      dividerBoxAfterPlay!.x + 20,
+      dividerBoxAfterPlay!.x + 60,
       dividerBoxAfterPlay!.y + dividerBoxAfterPlay!.height / 2 + 24,
     );
     await page.mouse.up();
@@ -2915,6 +2937,12 @@ test.describe("graph view E2E", () => {
     await expect(surface).toHaveAttribute("data-preview-muted", "false");
     await expect(surface).toHaveAttribute("data-preview-volume", "1");
 
+    // THE SLIDER AND MUTE LIVE BEHIND THE ICON NOW (PL15-008): the divider
+    // carries one audio icon, and a press on it reveals the pair. Opening is
+    // part of the flow rather than setup noise — the state being pinned here
+    // is reached the way a user reaches it.
+    const audioToggle = page.getByTestId("workbench-preview-volume-toggle");
+    await audioToggle.click();
     const volume = page.getByTestId("workbench-preview-volume");
     await expect(volume).toHaveValue("1");
 
@@ -2930,6 +2958,10 @@ test.describe("graph view E2E", () => {
     await previewToggle(page).click();
     await expect(surface).toHaveAttribute("data-preview-muted", "true");
 
+    // Reopened pane, reopened popover: the surface unmounted with the pane, so
+    // the reveal is closed again while the MUTE it was showing survived on the
+    // channel — which is the point of the round trip above.
+    await audioToggle.click();
     await page.getByRole("button", { name: "Unmute workbench preview" }).click();
     await expect(surface).toHaveAttribute("data-preview-muted", "false");
   });

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -528,29 +528,31 @@ async function openGraph(page: Page): Promise<void> {
   await strip(page, PROJECT_ID)
     .locator('[data-node-id="alpha"]')
     .waitFor({ state: "visible", timeout: 30000 });
-  await leaveFlatMode(page);
   // Children timelines are OFF by default now; this suite predates that
   // and reads the tree throughout, so reveal it through the real control
   // (the sidebar's children icon).
   await page.getByRole("button", { name: "Show children timelines" }).click();
 }
 
-/**
- * Put the board back into its NESTED reading.
+/*
+ * `leaveFlatMode` USED TO LIVE HERE, and every test in this file called it —
+ * through `openGraph`, or by hand where a test navigates itself.
  *
- * The strip opens FLAT, and a flat run has no collection cards — it replaces
- * every collection with its leaves — so a test about drilling in, dropping,
- * or reordering is asking about a shape that is not on screen. Flat also
- * refuses `move-nodes` outright (see `commandPolicy`), so a drag still runs,
- * still animates, and is then declined: the card returns and nothing says why
- * except a toast the test never reads.
+ * It existed because the strip opened FLAT, and a flat run has no collection
+ * cards (it replaces every collection with its leaves), so a test about
+ * drilling in, dropping or reordering was asking about a shape that was not on
+ * screen. Flat also refuses `move-nodes` outright (see `commandPolicy`), so a
+ * drag ran, animated, and was then declined.
  *
- * Separate from `openGraph` because several tests navigate themselves — they
- * are about what a bare URL does — and still need the nested board afterwards.
+ * THE STRIP OPENS IN COLLECTIONS NOW (PL15-003), so there is nothing to leave
+ * and the helper is gone rather than kept as a no-op. Note what its removal
+ * would have looked like if it had been left calling the old control: the
+ * button is named for the state it moves you TO, so "Show collections" simply
+ * does not exist on arrival any more, and every call would have waited out its
+ * timeout — a suite that hangs rather than one that fails.
  *
- * The control is named for the state it moves you TO, so it reads "Show
- * collections" while flat. Leaving restores "Show all items in order", which
- * is what the flat-specific tests click to go back.
+ * `enableRuler` below still clicks "Show all items in order" to ENTER flat,
+ * which is the direction that still has somewhere to go.
  */
 /**
  * Add a collection through the Collection tool — the CLICK route.
@@ -562,10 +564,6 @@ async function openGraph(page: Page): Promise<void> {
  */
 async function addCollectionViaButton(page: Page): Promise<void> {
   await page.locator('[data-tool-button="collection"]').click();
-}
-
-async function leaveFlatMode(page: Page): Promise<void> {
-  await page.getByRole("button", { name: "Show collections" }).click();
 }
 
 /** A collection card's metadata row in the project strip, which carries
@@ -2040,12 +2038,6 @@ test.describe("graph view E2E", () => {
     await strip(page, CHILD_ID)
       .locator('[data-node-id="c1"]')
       .waitFor({ state: "visible", timeout: 30000 });
-    // This test navigates itself (it checks what a bare URL does at the root),
-    // so it does not go through `openGraph` and has to leave flat on its own.
-    // Flat refuses `move-nodes`, so the drag below would run, animate, and be
-    // declined — the card returning to where it started, with the reason only
-    // in a toast.
-    await leaveFlatMode(page);
     expect(await stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
     const projectCrumb = page.locator(`[data-graph-ancestor-drop="${PROJECT_ID}"]`);
     await expect(projectCrumb).toHaveCount(1);
@@ -2097,10 +2089,6 @@ test.describe("graph view E2E", () => {
     await strip(page, GRANDCHILD_ID)
       .locator('[data-node-id="g1"]')
       .waitFor({ state: "visible", timeout: 30000 });
-    // Deep-linked rather than opened through `openGraph`, so flat is still on
-    // and would refuse the move below. See `leaveFlatMode`.
-    await leaveFlatMode(page);
-
     // BOTH ancestors are drop targets — the project (root) and Scene A (parent).
     await expect(page.locator("[data-graph-ancestor-drop]")).toHaveCount(2);
     const projectCrumb = page.locator(`[data-graph-ancestor-drop="${PROJECT_ID}"]`);

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4860,10 +4860,15 @@ test.describe("graph view E2E", () => {
   });
 
   test("hovering a child row's folder calls out its collection card", async ({ page }) => {
-    // PL9-002, revising PL8-012: ONE direction now, and the card is called out
-    // by an animation rather than its icon changing. PL10-001 made that
-    // animation an elastic SCALE on the card itself (the old inset glow
-    // overlay is gone), so the marker moved onto the card.
+    // PL9-002, revising PL8-012: ONE direction, and the card is called out
+    // rather than its icon changing.
+    //
+    // The MARK has been round a loop. PL9-002 was a glow, PL10-001 replaced it
+    // with an elastic scale on the card itself, and PL15-009 removed the
+    // jiggle — landing back on a glow, which had survived the whole time
+    // inside `prefers-reduced-motion` as the version for users who could not
+    // see the scale. What never changed is the claim: this row and that card
+    // are the same collection.
     await installGraphApi(page);
     await openGraph(page); // children timelines on
     const cardIcon = drillButton(page, "Scene A");
@@ -4886,85 +4891,58 @@ test.describe("graph view E2E", () => {
     await rowFolder.hover();
     await expect(calledOut).toHaveCount(1);
 
-    // EVERYTHING that has to be observed mid-animation is read in ONE
-    // evaluate, because the keyframes last 320ms and each round trip to the
-    // page spends part of that. Split across four calls, as this once was, a
-    // loaded CI runner reaches the end of the animation before the last one
-    // lands and the test fails on timing rather than on behaviour.
+    // THE MARK IS A STEADY GLOW, NOT AN ANIMATION (PL15-009).
     //
-    // The class is not the point — the KEYFRAMES are. Assert the card is
-    // actually running them, and that they scale it (an animation whose name
-    // resolves but whose rule was renamed away would still pass on class
-    // presence alone).
-    const running = await calledOut.evaluate((el) => {
+    // It was an elastic scale, and most of what this test used to do was cope
+    // with that: everything had to be read in ONE evaluate because the
+    // keyframes lasted 320ms and each round trip spent part of them, and the
+    // flick had to be judged by recording `animation.finished` up front rather
+    // than by looking for the class again and hoping to be quick enough. None
+    // of that is needed against a mark that simply stays while the pointer
+    // does — which is worth noting, because a test that stops racing the clock
+    // is most of the benefit of the change.
+    const marked = await calledOut.evaluate((el) => {
       const style = getComputedStyle(el);
-      const animation = el
-        .getAnimations()
-        .find(
-          (candidate) =>
-            (candidate as CSSAnimation).animationName === "collection-paired-callout",
-        );
-
-      // How the flick is judged, instead of by looking for the class again
-      // later and hoping to be quick enough. `finished` resolves if the
-      // keyframes play out and REJECTS if the animation is cancelled — and
-      // dropping the class is exactly what cancels it. So the outcome is
-      // recorded here, while the animation is definitely still in hand, and
-      // simply read back afterwards. No wall-clock race either way.
-      const target = window as Window & { __calloutOutcome?: string };
-      target.__calloutOutcome = "pending";
-      animation?.finished.then(
-        () => {
-          target.__calloutOutcome = "finished";
-        },
-        () => {
-          target.__calloutOutcome = "cancelled";
-        },
-      );
-
       return {
-        name: style.animationName,
-        scales: animation !== undefined,
+        glow: style.boxShadow,
+        // The class alone is not the point: a rule renamed away would still
+        // leave the class on the element and nothing on the screen.
+        //
+        // `animationName`, NOT `getAnimations().length`. A CSS TRANSITION is an
+        // Animation as far as `getAnimations` is concerned, and the glow has
+        // one (it fades in over 150ms), so counting them can never reach zero
+        // and the assertion would be testing nothing it claims to. The
+        // computed `animation-name` asks the question actually meant: are any
+        // KEYFRAMES running on this card.
+        animationName: style.animationName,
         inCard: el
           .closest("[data-node-wrapper]")
           ?.querySelector("[data-node-id]")
           ?.getAttribute("data-node-id"),
       };
     });
-    expect(running.inCard).toBe(CHILD_ID);
-    expect(running.name).toBe("collection-paired-callout");
-    expect(running.scales).toBe(true);
+    expect(marked.inCard).toBe(CHILD_ID);
+    expect(marked.glow).not.toBe("none");
+    expect(marked.animationName).toBe("none");
 
-    // It is a TRANSFORM, so it reflows nothing: the neighbour must not budge
-    // while the called-out card is mid-animation. (The called-out card's own
-    // box does change under the scale — that is the effect, and measuring it
-    // mid-flight would only race the keyframes.)
+    // IT REFLOWS NOTHING, and the claim is now stronger than it was. Under the
+    // scale only the NEIGHBOUR could be asserted still — the called-out card's
+    // own box changed, because changing it was the effect. A box-shadow paints
+    // outside the border box and takes no part in layout or scroll size, so
+    // both boxes hold.
     const neighbourDuring = (await neighbour.boundingBox())!;
     expect(neighbourDuring.x).toBeCloseTo(neighbourBefore.x, 0);
     expect(neighbourDuring.width).toBeCloseTo(neighbourBefore.width, 0);
+    const cardDuring = (await card.boundingBox())!;
+    expect(cardDuring.x).toBeCloseTo(cardBefore.x, 0);
+    expect(cardDuring.width).toBeCloseTo(cardBefore.width, 0);
 
-    // PL10-002: a flick still plays the whole animation. Without the hold the
-    // class would come off one or two frames in, cancelling the animation
-    // mid-keyframe; with it, the keyframes run to their end.
-    //
-    // This used to assert `calledOut.count() === 1` right after the move —
-    // "the class is still there" — which is only true inside the remaining
-    // slice of those 320ms. It was reading the clock, not the behaviour, and
-    // failed whenever the runner was slow enough to have spent the animation
-    // already. Waiting for the recorded outcome asks the real question, and a
-    // torn-off animation reports `cancelled` however long the wait takes.
+    // IT FOLLOWS THE POINTER. The hold that used to keep the class on past a
+    // flick is gone with the animation it protected — there is no play left to
+    // let finish, and a highlight outliving the pointer by a third of a second
+    // would read as lag.
     await page.mouse.move(0, 0);
-    await page.waitForFunction(
-      () => (window as Window & { __calloutOutcome?: string }).__calloutOutcome !== "pending",
-    );
-    const outcome = await page.evaluate(
-      () => (window as Window & { __calloutOutcome?: string }).__calloutOutcome,
-    );
-    expect(outcome).toBe("finished");
-
-    // ...and then it ends on its own.
     await expect(calledOut).toHaveCount(0);
-    // And the card comes back to exactly the box it started in.
     const cardAfter = (await card.boundingBox())!;
     const neighbourAfter = (await neighbour.boundingBox())!;
     expect(neighbourAfter.x).toBeCloseTo(neighbourBefore.x, 0);
@@ -5905,12 +5883,23 @@ test.describe("graph view E2E", () => {
     await expect(frame).toHaveCount(0);
   });
 
-  test("the call-out's scale never grows a scroll area", async ({ page }) => {
+  test("the call-out never grows a scroll area", async ({ page }) => {
     // PL10-003. A transform that spills past its box counts as SCROLLABLE
     // overflow, so the call-out used to grow whichever scroller held the card
     // and flash a scrollbar for the length of the animation. The card's
     // wrapper is `overflow: clip` (with a margin wide enough for the growth
     // and for the drop bars) so nothing above it ever hears about the scale.
+    //
+    // THE SCALE IS GONE (PL15-009) and the mark is a box-shadow, which cannot
+    // produce scrollable overflow at all — so this now passes by construction
+    // rather than by the clipping wrapper. Kept anyway, and rewritten rather
+    // than deleted: the invariant it states is about the CALL-OUT, not about
+    // one implementation of it, and it is the test that would catch a future
+    // mark going back to a transform and taking the scrollbars with it.
+    //
+    // Simpler for it, too. The old version had to pause the animation and
+    // drive `currentTime` to the 1.06 peak, because sampling a 320ms one-shot
+    // from the test side raced it. A steady mark can just be looked at.
     await installGraphApi(page);
     await openGraph(page);
     const rowFolder = page
@@ -5918,43 +5907,29 @@ test.describe("graph view E2E", () => {
       .getByRole("button", { name: "Expand" })
       .first();
 
+    // Every ancestor's scroll size, measured from the card's own wrapper
+    // upward. Start ABOVE the clip box itself: a clip container still reports
+    // its own scrollWidth, it just stops handing it upward, and that upward
+    // propagation is the whole bug.
+    const ancestorSizes = () =>
+      page.evaluate((childId) => {
+        const card = document.querySelector(`[data-node-id="${childId}"]`);
+        if (!card) return ["no card"];
+        const sizes: string[] = [];
+        for (let n = card.closest("[data-node-wrapper]")?.parentElement; n; n = n.parentElement) {
+          sizes.push(`${n.tagName}.${n.className}: ${n.scrollWidth}x${n.scrollHeight}`);
+        }
+        return sizes;
+      }, CHILD_ID);
+
+    const rest = await ancestorSizes();
+    expect(rest.length).toBeGreaterThan(0);
+    expect(rest[0]).not.toBe("no card");
+
     await rowFolder.hover();
     await expect(page.locator(".is-called-out-card")).toHaveCount(1);
 
-    // Measure every ancestor at rest and at the animation's peak. Pausing the
-    // animation is what makes this deterministic — sampling a 320ms one-shot
-    // from the test side would race it.
-    const changed = await page.evaluate(() => {
-      const card = document.querySelector(".is-called-out-card");
-      if (!card) return ["no call-out"];
-      const animation = card.getAnimations()[0];
-      if (!animation) return ["no animation"];
-      const chain: Element[] = [];
-      // Start ABOVE the clip box itself: a clip container still reports its
-      // own scrollWidth, it just stops handing it upward, and that upward
-      // propagation is the whole bug.
-      for (let n = card.closest("[data-node-wrapper]")?.parentElement; n; n = n.parentElement) {
-        chain.push(n);
-      }
-      const snap = () => chain.map((n) => `${n.scrollWidth}x${n.scrollHeight}`);
-      animation.pause();
-      animation.currentTime = 0;
-      const rest = snap();
-      animation.currentTime = 128; // the 1.06 peak
-      const peak = snap();
-      animation.play();
-      return peak.flatMap((size, i) => {
-        // Read into locals: this runs in the BROWSER, so the test file's
-        // helpers do not exist here.
-        const before = rest[i];
-        const element = chain[i];
-        if (before === undefined || element === undefined) return [];
-        return size === before
-          ? []
-          : [`${element.tagName}.${element.className}: ${before} -> ${size}`];
-      });
-    });
-    expect(changed).toEqual([]);
+    expect(await ancestorSizes()).toEqual(rest);
   });
 
   test("clicking away anywhere that is not a control clears the selection", async ({

--- a/docs/webmcp-agent-tools.md
+++ b/docs/webmcp-agent-tools.md
@@ -1,7 +1,7 @@
 # WebMCP agent tools
 
 **Status: shipped, and still growing.** Two surfaces are live — the in-page
-**WebMCP** tools (11 tools; real-time, mutate the live store) and a **remote
+**WebMCP** tools (18 tools; real-time, mutate the live store) and a **remote
 MCP** endpoint at `/api/mcp` (read-only, OAuth 2.1 + PKCE, reachable by URL
 with no browser open). The design below is what they were built from; the
 decision log at the bottom is the running record of what actually shipped and

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-storybook": "npm run build-storybook --workspace=apps/storybook",
     "dev:frontend": "npm run dev --workspace=apps/timeline-gstudio001",
     "audit:ui": "node scripts/find-unreachable-ui.mjs",
+    "audit:loc": "node scripts/count-loc.mjs",
     "audit:ownership": "npm run audit:ownership --workspace=apps/timeline-gstudio001 --",
     "audit:orphans": "npm run audit:orphans --workspace=apps/timeline-gstudio001 --",
     "prune:orphans": "npm run prune:orphans --workspace=apps/timeline-gstudio001 --",

--- a/packages/ui/dnd-collections/react/trim-gesture.test.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.test.ts
@@ -6,7 +6,12 @@ import {
   type ImageMediaNode,
   type VideoMediaNode,
 } from "../core/graph";
-import { resolveMove, resolveTrim, TRIM_QUANTUM_SECONDS } from "./trim-gesture";
+import {
+  MIN_TRIM_WINDOW_SECONDS,
+  resolveMove,
+  resolveTrim,
+  TRIM_QUANTUM_SECONDS,
+} from "./trim-gesture";
 
 // Pure-resolver coverage for the pointer trim gesture: quantization to the
 // 0.1s grid and the reducer-shared clamps. The pointer lifecycle
@@ -73,10 +78,12 @@ describe("resolveTrim on audio", () => {
       mediaKind: "audio",
       trimInSeconds: 2,
     });
-    // Past the far end lands ON the limit rather than through it.
+    // Past the far end lands ON the limit rather than through it. The limit is
+    // `full - trimOut - MIN_TRIM_WINDOW_SECONDS` now, not `full - trimOut`:
+    // landing exactly on the far edge left a window of zero (PL15-015).
     expect(resolveTrim(audio(), "left", 99).update).toEqual({
       mediaKind: "audio",
-      trimInSeconds: 9,
+      trimInSeconds: 8.75,
     });
   });
 
@@ -120,10 +127,13 @@ describe("resolveTrim quantization", () => {
   });
 
   it("still clamps at the physical limit after snapping", () => {
-    // Over-drag the end far past the source: trim-out clamps to full - trim-in.
+    // Over-drag the end far past the source. This used to clamp to
+    // `full - trimIn` and leave `effectiveSeconds` at ZERO — the edge could be
+    // dragged through the middle of the clip and out the far side, swallowing
+    // it (PL15-015). The ceiling keeps a minimum window back now.
     const { update, live } = resolveTrim(video({ trimInSeconds: 2 }), "right", -100);
-    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 8 });
-    expect(live.effectiveSeconds).toBe(0);
+    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 7.75 });
+    expect(live.effectiveSeconds).toBe(MIN_TRIM_WINDOW_SECONDS);
   });
 
   it("does not leave float dust on the grid", () => {
@@ -147,5 +157,50 @@ describe("resolveMove quantization", () => {
 describe("TRIM_QUANTUM_SECONDS", () => {
   it("is the 0.1s grid the display path also rounds to", () => {
     expect(TRIM_QUANTUM_SECONDS).toBe(0.1);
+  });
+});
+
+// A TRIM MAY NOT SWALLOW ITS CLIP (PL15-015). Each edge used to be clamped
+// only against the other, which forbids CROSSING and permits MEETING — so a
+// drag could leave a window of zero and the clip would still be there,
+// occupying no time and impossible to grab back.
+describe("the minimum trim window", () => {
+  it("stops the LEFT edge short of the right one", () => {
+    const { update, live } = resolveTrim(video({ trimInSeconds: 0, trimOutSeconds: 1 }), "left", 100);
+    // 10 full, 1 trimmed off the end, so the left edge stops a quarter second
+    // before what is left of the source rather than at it.
+    expect(update).toEqual({ mediaKind: "video", trimInSeconds: 8.75 });
+    expect(live.effectiveSeconds).toBe(MIN_TRIM_WINDOW_SECONDS);
+  });
+
+  it("stops the RIGHT edge short of the left one", () => {
+    const { update, live } = resolveTrim(video({ trimInSeconds: 3, trimOutSeconds: 0 }), "right", -100);
+    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 6.75 });
+    expect(live.effectiveSeconds).toBe(MIN_TRIM_WINDOW_SECONDS);
+  });
+
+  it("applies to audio, which shares the windowed branch", () => {
+    const { live } = resolveTrim(audio({ trimInSeconds: 0, trimOutSeconds: 0 }), "left", 100);
+    expect(live.effectiveSeconds).toBe(MIN_TRIM_WINDOW_SECONDS);
+  });
+
+  it("leaves an ordinary trim untouched", () => {
+    // The floor must only bite at the extreme. A one-second pull on a
+    // seven-second window is not near it and must resolve exactly.
+    const { update } = resolveTrim(video({ trimInSeconds: 2, trimOutSeconds: 1 }), "left", 1);
+    expect(update).toEqual({ mediaKind: "video", trimInSeconds: 3 });
+  });
+
+  it("does not invert the clamp on a source SHORTER than the minimum", () => {
+    // The ceiling is `full - other - minimum`, which goes negative here. Left
+    // unguarded that is a max BELOW the min, and `clamp` would pin the edge at
+    // the ceiling — dragging the handle backwards. It floors at zero instead,
+    // so the edge simply cannot move.
+    const { update } = resolveTrim(
+      video({ fullDurationSeconds: 0.2, trimInSeconds: 0, trimOutSeconds: 0 }),
+      "left",
+      100,
+    );
+    expect(update).toEqual({ mediaKind: "video", trimInSeconds: 0 });
   });
 });

--- a/packages/ui/dnd-collections/react/trim-gesture.test.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.test.ts
@@ -83,7 +83,7 @@ describe("resolveTrim on audio", () => {
     // landing exactly on the far edge left a window of zero (PL15-015).
     expect(resolveTrim(audio(), "left", 99).update).toEqual({
       mediaKind: "audio",
-      trimInSeconds: 8.75,
+      trimInSeconds: 8.9,
     });
   });
 
@@ -132,8 +132,12 @@ describe("resolveTrim quantization", () => {
     // dragged through the middle of the clip and out the far side, swallowing
     // it (PL15-015). The ceiling keeps a minimum window back now.
     const { update, live } = resolveTrim(video({ trimInSeconds: 2 }), "right", -100);
-    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 7.75 });
-    expect(live.effectiveSeconds).toBe(MIN_TRIM_WINDOW_SECONDS);
+    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 7.9 });
+    // `toBeCloseTo`: the COMMITTED value is on the grid (the ceiling is
+    // quantized), but `effectiveSeconds` is `full - in - out` computed live,
+    // and 10 - 2 - 7.9 is 0.09999999999999964. Grid-cleanliness is a property
+    // of what is stored, not of a subtraction done for the preview.
+    expect(live.effectiveSeconds).toBeCloseTo(MIN_TRIM_WINDOW_SECONDS, 6);
   });
 
   it("does not leave float dust on the grid", () => {
@@ -169,19 +173,31 @@ describe("the minimum trim window", () => {
     const { update, live } = resolveTrim(video({ trimInSeconds: 0, trimOutSeconds: 1 }), "left", 100);
     // 10 full, 1 trimmed off the end, so the left edge stops a quarter second
     // before what is left of the source rather than at it.
-    expect(update).toEqual({ mediaKind: "video", trimInSeconds: 8.75 });
-    expect(live.effectiveSeconds).toBe(MIN_TRIM_WINDOW_SECONDS);
+    expect(update).toEqual({ mediaKind: "video", trimInSeconds: 8.9 });
+    // `toBeCloseTo`: the COMMITTED value is on the grid (the ceiling is
+    // quantized), but `effectiveSeconds` is `full - in - out` computed live,
+    // and 10 - 2 - 7.9 is 0.09999999999999964. Grid-cleanliness is a property
+    // of what is stored, not of a subtraction done for the preview.
+    expect(live.effectiveSeconds).toBeCloseTo(MIN_TRIM_WINDOW_SECONDS, 6);
   });
 
   it("stops the RIGHT edge short of the left one", () => {
     const { update, live } = resolveTrim(video({ trimInSeconds: 3, trimOutSeconds: 0 }), "right", -100);
-    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 6.75 });
-    expect(live.effectiveSeconds).toBe(MIN_TRIM_WINDOW_SECONDS);
+    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 6.9 });
+    // `toBeCloseTo`: the COMMITTED value is on the grid (the ceiling is
+    // quantized), but `effectiveSeconds` is `full - in - out` computed live,
+    // and 10 - 2 - 7.9 is 0.09999999999999964. Grid-cleanliness is a property
+    // of what is stored, not of a subtraction done for the preview.
+    expect(live.effectiveSeconds).toBeCloseTo(MIN_TRIM_WINDOW_SECONDS, 6);
   });
 
   it("applies to audio, which shares the windowed branch", () => {
     const { live } = resolveTrim(audio({ trimInSeconds: 0, trimOutSeconds: 0 }), "left", 100);
-    expect(live.effectiveSeconds).toBe(MIN_TRIM_WINDOW_SECONDS);
+    // `toBeCloseTo`: the COMMITTED value is on the grid (the ceiling is
+    // quantized), but `effectiveSeconds` is `full - in - out` computed live,
+    // and 10 - 2 - 7.9 is 0.09999999999999964. Grid-cleanliness is a property
+    // of what is stored, not of a subtraction done for the preview.
+    expect(live.effectiveSeconds).toBeCloseTo(MIN_TRIM_WINDOW_SECONDS, 6);
   });
 
   it("leaves an ordinary trim untouched", () => {
@@ -197,7 +213,7 @@ describe("the minimum trim window", () => {
     // the ceiling — dragging the handle backwards. It floors at zero instead,
     // so the edge simply cannot move.
     const { update } = resolveTrim(
-      video({ fullDurationSeconds: 0.2, trimInSeconds: 0, trimOutSeconds: 0 }),
+      video({ fullDurationSeconds: 0.05, trimInSeconds: 0, trimOutSeconds: 0 }),
       "left",
       100,
     );

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -37,6 +37,32 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 /**
+ * THE SHORTEST A TRIM MAY LEAVE A CLIP.
+ *
+ * Each edge used to be clamped only against the OTHER edge — `trimIn` up to
+ * `full - trimOut`, `trimOut` up to `full - trimIn` — which forbids crossing
+ * and permits MEETING. So an edge could be dragged through the middle of the
+ * clip and out the far side, leaving a window of zero, and nothing else
+ * stopped it: `MAX_HANDLE_SHARE` only decides whether a handle is DRAWN on a
+ * short clip and does nothing to a drag already under way (PL15-015).
+ *
+ * A QUARTER SECOND, and the number is a judgement rather than a derivation. It
+ * has to be small enough never to refuse a real edit — six frames at 24fps is
+ * a flash cut, which is a thing people cut — and large enough that what is
+ * left is still a clip you can see, grab and trim again. The 0.1s quantize
+ * grid is the smallest expressible floor and only rules out the exactly
+ * degenerate case, which is not what was being complained about.
+ *
+ * NOT A HALFWAY STOP. The other reading of "the end cannot be dragged to the
+ * middle" is that neither edge may pass the clip's midpoint, so no single edge
+ * can take more than half. That is a much stronger rule and it forbids
+ * legitimate work — keeping the last two seconds of a ten-second take is one
+ * edge doing eighty per cent of it. Left unbuilt deliberately; it is the same
+ * two lines if it turns out to be what was wanted.
+ */
+export const MIN_TRIM_WINDOW_SECONDS = 0.25;
+
+/**
  * Whether a trim currently OWNS the pointer, for the pan hook's
  * `isGestureClaimed`.
  *
@@ -105,7 +131,11 @@ export function resolveTrim(
       const trimInSeconds = clamp(
         quantize(node.trimInSeconds + deltaSeconds),
         0,
-        node.fullDurationSeconds - node.trimOutSeconds
+        // Room for the window to survive: the far edge, LESS the minimum. The
+        // `Math.max(0, …)` matters for a source already shorter than the
+        // minimum — the ceiling must not go negative and invert the clamp,
+        // which would pin the edge at 0 and make the handle feel dead.
+        Math.max(0, node.fullDurationSeconds - node.trimOutSeconds - MIN_TRIM_WINDOW_SECONDS)
       );
       return {
         update: { mediaKind, trimInSeconds },
@@ -121,7 +151,7 @@ export function resolveTrim(
     const trimOutSeconds = clamp(
       quantize(node.trimOutSeconds - deltaSeconds),
       0,
-      node.fullDurationSeconds - node.trimInSeconds
+      Math.max(0, node.fullDurationSeconds - node.trimInSeconds - MIN_TRIM_WINDOW_SECONDS)
     );
     return {
       update: { mediaKind, trimOutSeconds },

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -46,12 +46,20 @@ function clamp(value: number, min: number, max: number): number {
  * stopped it: `MAX_HANDLE_SHARE` only decides whether a handle is DRAWN on a
  * short clip and does nothing to a drag already under way (PL15-015).
  *
- * A QUARTER SECOND, and the number is a judgement rather than a derivation. It
- * has to be small enough never to refuse a real edit — six frames at 24fps is
- * a flash cut, which is a thing people cut — and large enough that what is
- * left is still a clip you can see, grab and trim again. The 0.1s quantize
- * grid is the smallest expressible floor and only rules out the exactly
- * degenerate case, which is not what was being complained about.
+ * ONE QUANTUM — the 0.1s grid, the smallest floor that can be expressed — and
+ * it started at a quarter second before the tests said otherwise.
+ *
+ * 0.25 was a judgement: small enough not to refuse a real edit, large enough
+ * that what is left is still a clip you can grab. `VirtualStrip.stories` then
+ * failed asserting `0.10s / 10.00s`, which is a SHIPPED, TESTED trim that the
+ * floor had quietly made impossible. That is the exact risk this item was
+ * warned about — a floor picked for feel forbidding work somebody relies on —
+ * and the test is the evidence, so the floor gives way rather than the test.
+ *
+ * What is left is narrow and safe: it rules out the degenerate window and
+ * nothing else. If a larger floor is genuinely wanted it is this one constant,
+ * but it needs to be chosen against the trims people actually make rather than
+ * against how it feels to drag.
  *
  * NOT A HALFWAY STOP. The other reading of "the end cannot be dragged to the
  * middle" is that neither edge may pass the clip's midpoint, so no single edge
@@ -60,7 +68,7 @@ function clamp(value: number, min: number, max: number): number {
  * edge doing eighty per cent of it. Left unbuilt deliberately; it is the same
  * two lines if it turns out to be what was wanted.
  */
-export const MIN_TRIM_WINDOW_SECONDS = 0.25;
+export const MIN_TRIM_WINDOW_SECONDS = 0.1;
 
 /**
  * Whether a trim currently OWNS the pointer, for the pan hook's
@@ -135,7 +143,11 @@ export function resolveTrim(
         // `Math.max(0, …)` matters for a source already shorter than the
         // minimum — the ceiling must not go negative and invert the clamp,
         // which would pin the edge at 0 and make the handle feel dead.
-        Math.max(0, node.fullDurationSeconds - node.trimOutSeconds - MIN_TRIM_WINDOW_SECONDS)
+        // QUANTIZED, like the value it bounds. `10 - 1 - 0.1` is
+        // 8.899999999999999, and an un-gridded ceiling hands that straight
+        // through as the committed trim — the same float dust the test below
+        // pins for the value, arriving by way of the limit instead.
+        quantize(Math.max(0, node.fullDurationSeconds - node.trimOutSeconds - MIN_TRIM_WINDOW_SECONDS))
       );
       return {
         update: { mediaKind, trimInSeconds },
@@ -151,7 +163,7 @@ export function resolveTrim(
     const trimOutSeconds = clamp(
       quantize(node.trimOutSeconds - deltaSeconds),
       0,
-      Math.max(0, node.fullDurationSeconds - node.trimInSeconds - MIN_TRIM_WINDOW_SECONDS)
+      quantize(Math.max(0, node.fullDurationSeconds - node.trimInSeconds - MIN_TRIM_WINDOW_SECONDS))
     );
     return {
       update: { mediaKind, trimOutSeconds },

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -427,15 +427,25 @@ export const ControlledPlayback: Story = {
       /0(?:\.\d+)?s \/ 30\.0s/,
     );
 
-    // Tab order follows the DOM: the audio controls overlay the picture, so
-    // they come BEFORE the divider transport. Walk past them and the transport
-    // is still reachable, which is what this ever asserted.
+    // Tab order follows the DOM: the audio control sits on the divider before
+    // the transport, so it comes first. Walk past it and the transport is
+    // still reachable, which is what this ever asserted.
+    //
+    // ONE STOP, NOT TWO (PL15-008). It used to be mute then the slider, both
+    // permanently in the picture. They are behind the icon now, so a keyboard
+    // user walking the view passes ONE audio control rather than two — and the
+    // pair below proves they are still reachable once it is opened, which is
+    // the half that would otherwise be lost silently.
     await user.tab();
-    expect(canvas.getByTestId("workbench-preview-mute")).toHaveFocus();
-    await user.tab();
-    expect(canvas.getByTestId("workbench-preview-volume")).toHaveFocus();
+    const audioToggle = canvas.getByTestId("workbench-preview-volume-toggle");
+    expect(audioToggle).toHaveFocus();
     await user.tab();
     expect(controls.contains(document.activeElement)).toBe(true);
+
+    // Opened, the mute button and the slider are both reachable from the icon.
+    await user.click(audioToggle);
+    expect(canvas.getByTestId("workbench-preview-mute")).toBeInTheDocument();
+    expect(canvas.getByTestId("workbench-preview-volume")).toBeInTheDocument();
     expect(controls).toHaveAttribute("data-transport-layout", "static");
   },
 };
@@ -485,6 +495,10 @@ export const ControlledAudio: Story = {
     expect(surface).toHaveAttribute("data-preview-muted", "false");
     expect(surface).toHaveAttribute("data-preview-volume", "1");
     expect(canvas.getByTestId("audio-readout")).toHaveTextContent("volume=1 muted=false");
+
+    // The divider carries an audio ICON; mute and the slider are behind it
+    // (PL15-008), so opening it is the first step of the flow now.
+    await user.click(canvas.getByRole("button", { name: "Preview audio" }));
 
     const mute = canvas.getByRole("button", { name: "Mute workbench preview" });
     expect(mute).toHaveAttribute("aria-pressed", "false");

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -278,12 +278,33 @@ type WorkbenchAudioControlsProps = {
 };
 
 /**
- * Volume lives INSIDE the preview, not on the divider beside play/pause.
+ * Volume: an icon on the DIVIDER, and a slider it reveals.
  *
- * The divider is a resize handle first: its whole band is the drag target, and
+ * IT USED TO LIVE INSIDE THE PREVIEW, and the comment here said why: "The
+ * divider is a resize handle first: its whole band is the drag target, and
  * parking a button at its left end quietly shrank that target — the e2e that
- * hovers the divider at x=20 caught it immediately. Overlaying the picture is
- * also simply where every video player puts this control.
+ * hovers the divider at x=20 caught it immediately."
+ *
+ * That objection was against a button AND a 64px slider sitting there
+ * permanently. What sits there now is one 28px icon, and the slider only
+ * exists while it is open — so the band it costs is the left 36px of a divider
+ * that runs the full width. The two e2e hover points moved off that end with
+ * this change, which is only honest because of that measurement: the drag
+ * target is still everything but its first 36 pixels.
+ *
+ * THE ISLAND PATTERN IS THE TRANSPORT'S, not a new one. The wrapper is
+ * `pointer-events-none` so the divider keeps every pixel it is not actually
+ * covering, the control itself is `pointer-events-auto`, and a pointer press
+ * on it stops propagating — a press on the audio control must never begin a
+ * resize, exactly as a transport press must not.
+ *
+ * CLICK OPENS THE SLIDER; MUTE MOVES INSIDE IT. Click used to mute, and the
+ * plain reading of "click the icon and you get the slider" would have left
+ * mute as "drag to zero and drag back to a level you have to remember" —
+ * losing a one-press action to gain a reveal. So the popover carries a mute
+ * button beside the slider: mute costs one extra press rather than a gesture
+ * and a memory, and the icon still SHOWS the silent state whether or not the
+ * popover is open.
  */
 function WorkbenchAudioControls({
   volume,
@@ -293,44 +314,101 @@ function WorkbenchAudioControls({
   audioBlocked,
 }: WorkbenchAudioControlsProps) {
   const silent = muted || volume <= 0;
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // DISMISS ON A PRESS OUTSIDE, AND ON ESCAPE — with one owner, so there is no
+  // question which of them closed it. `pointerdown` rather than `click`: the
+  // click that opens the popover is still in flight when the listener is
+  // attached, and listening for clicks would close it in the same gesture.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (event: PointerEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      // Stopped, or Escape reaches whatever else in the view treats it as
+      // "close me" and two things answer one press.
+      event.stopPropagation();
+      setOpen(false);
+    };
+    document.addEventListener("pointerdown", onDown);
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      document.removeEventListener("pointerdown", onDown);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [open]);
 
   return (
     <div
-      className="absolute bottom-2 left-2 z-20 flex items-center gap-1.5 rounded-full bg-zinc-950/70 px-1.5 py-1 backdrop-blur-sm"
+      className="pointer-events-none absolute inset-x-0 top-full z-50 h-0"
       data-testid="workbench-preview-audio"
-      onPointerDown={(event) => {
-        // The canvas below toggles play on click. These controls are their own
-        // island — pressing one must not also start the preview.
-        event.stopPropagation();
-      }}
-      onClick={(event) => {
-        event.stopPropagation();
-      }}
     >
-      <button
-        type="button"
-        onClick={onToggleMuted}
-        className="grid size-6 shrink-0 place-items-center rounded-full text-zinc-300 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-        aria-label={silent ? "Unmute workbench preview" : "Mute workbench preview"}
-        aria-pressed={silent}
-        title={audioBlocked ? "Click to enable sound" : silent ? "Unmute" : "Mute"}
-        data-testid="workbench-preview-mute"
-        data-audio-blocked={audioBlocked || undefined}
+      <div
+        ref={rootRef}
+        className="pointer-events-auto absolute left-2 flex items-center"
+        style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
+        onPointerDown={(event) => {
+          // The audio control visually occupies the divider and is its own
+          // interaction island — a press here must never begin a resize.
+          event.stopPropagation();
+        }}
       >
-        {silent ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
-      </button>
+        <button
+          type="button"
+          onClick={() => setOpen((was) => !was)}
+          className="grid size-7 shrink-0 place-items-center rounded-full text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          // NOT "Workbench preview volume" — that name belongs to the SLIDER,
+          // and it has had it since before this control existed. Handing it to
+          // the trigger would have made an accessible-name lookup ambiguous the
+          // moment the popover opened, and silently changed which element every
+          // existing `getByRole("slider", { name: … })` resolves to.
+          aria-label="Preview audio"
+          aria-expanded={open}
+          title={audioBlocked ? "Click to enable sound" : "Volume"}
+          data-testid="workbench-preview-volume-toggle"
+          data-audio-blocked={audioBlocked || undefined}
+        >
+          {silent ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
+        </button>
 
-      <input
-        type="range"
-        min={0}
-        max={1}
-        step={0.01}
-        value={muted ? 0 : volume}
-        onChange={(event) => onVolumeChange(Number(event.target.value))}
-        className="h-1 w-16 cursor-pointer appearance-none rounded-full bg-zinc-700 accent-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-        aria-label="Workbench preview volume"
-        data-testid="workbench-preview-volume"
-      />
+        {open && (
+          <div
+            className="ml-1 flex items-center gap-2 rounded-full bg-zinc-950/90 px-2 py-1 shadow-lg ring-1 ring-white/15 backdrop-blur-sm"
+            data-testid="workbench-preview-volume-popover"
+          >
+            {/* MUTE, which the icon outside used to carry on its own click.
+                Kept as a press rather than folded into the slider's zero end:
+                muting and restoring is one action, and a drag to zero followed
+                by a drag back to a level you have to remember is not. */}
+            <button
+              type="button"
+              onClick={onToggleMuted}
+              className="grid size-6 shrink-0 place-items-center rounded-full text-zinc-300 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+              aria-label={silent ? "Unmute workbench preview" : "Mute workbench preview"}
+              aria-pressed={silent}
+              title={silent ? "Unmute" : "Mute"}
+              data-testid="workbench-preview-mute"
+            >
+              {silent ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
+            </button>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={muted ? 0 : volume}
+              onChange={(event) => onVolumeChange(Number(event.target.value))}
+              className="h-1 w-16 cursor-pointer appearance-none rounded-full bg-zinc-700 accent-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+              aria-label="Workbench preview volume"
+              data-testid="workbench-preview-volume"
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -2128,25 +2206,6 @@ export function WorkbenchDisplaySurface({
             <Play className="h-20 w-20 fill-white text-white sm:h-28 sm:w-28" />
           )}
         </div>
-        <WorkbenchAudioControls
-          volume={activeVolume}
-          muted={activeMuted}
-          audioBlocked={audioBlocked}
-          onToggleMuted={() => {
-            // This click IS a user gesture — resume the context on it.
-            void getMixer().resume();
-            // Unmuting from a zeroed slider must actually be audible, or the
-            // control appears to do nothing.
-            if (activeMuted && activeVolume <= 0) setVolume(1);
-            setMuted(!activeMuted);
-          }}
-          onVolumeChange={(next) => {
-            void getMixer().resume();
-            setVolume(next);
-            // Dragging the slider up is an unmute in every player people know.
-            if (next > 0 && activeMuted) setMuted(false);
-          }}
-        />
         {/* Names what the grayed frame means. Only ever visible while
             SCRUBBING — playing jumps the span, so the clock never rests here.
             Top-LEFT: the close button owns the right corner. */}
@@ -2175,6 +2234,25 @@ export function WorkbenchDisplaySurface({
           </button>
         )}
       </div>
+      <WorkbenchAudioControls
+        volume={activeVolume}
+        muted={activeMuted}
+        audioBlocked={audioBlocked}
+        onToggleMuted={() => {
+          // This click IS a user gesture — resume the context on it.
+          void getMixer().resume();
+          // Unmuting from a zeroed slider must actually be audible, or the
+          // control appears to do nothing.
+          if (activeMuted && activeVolume <= 0) setVolume(1);
+          setMuted(!activeMuted);
+        }}
+        onVolumeChange={(next) => {
+          void getMixer().resume();
+          setVolume(next);
+          // Dragging the slider up is an unmute in every player people know.
+          if (next > 0 && activeMuted) setMuted(false);
+        }}
+      />
       <WorkbenchDividerTransport
         currentTime={currentTime}
         duration={duration}

--- a/punch-list/PUNCH-LIST-15-loc.txt
+++ b/punch-list/PUNCH-LIST-15-loc.txt
@@ -1,627 +1,435 @@
-5525  T  graph-view.spec.ts  —  apps/timeline-gstudio001/tests/e2e
-2230  T  VirtualStrip.stories.tsx  —  packages/ui/dnd-collections
-2205  T  graph-item-details-modal.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
-1829     workbench-display-surface.tsx  —  packages/ui/timeline/viewport
-1515     graph-board.tsx  —  apps/timeline-gstudio001/components/graph-view
-1371  T  graph-item-content.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
-1274  T  adapter.test.ts  —  packages/timeline-domain/src
- 987     VirtualStrip.tsx  —  packages/ui/dnd-collections/virtual
- 973  T  commands.test.ts  —  packages/collections-core
- 962  T  collections-store.test.ts  —  packages/ui/dnd-collections/react
- 862  T  graph-documents-gateway.test.ts  —  apps/timeline-gstudio001/lib
- 858     graph-preview.tsx  —  apps/timeline-gstudio001/components/graph-view
- 855  T  CustomItemContent.stories.tsx  —  packages/ui/dnd-collections
- 820     firebase-timeline-store.ts  —  apps/timeline-gstudio001/lib
- 812  T  WorkbenchSplitPane.stories.tsx  —  packages/ui/timeline/viewport
- 796  T  DndCollections.stories.tsx  —  packages/ui/dnd-collections
- 760     graph-item-details-modal.tsx  —  apps/timeline-gstudio001/components/graph-view
- 745     graph-seam-strip-bar.tsx  —  apps/timeline-gstudio001/components/graph-view
- 741     DndCollections.tsx  —  packages/ui/dnd-collections/react
- 732     graph.ts  —  packages/collections-core
- 726     timeline-documents.ts  —  packages/ui/timeline
- 702  T  graph.test.ts  —  packages/collections-core
- 700     timeline-sidebar.tsx  —  apps/timeline-gstudio001/components/timeline
- 697     graph-documents-gateway.ts  —  apps/timeline-gstudio001/lib
- 689  T  graph-playhead-model.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 689     graph-seek-rails.tsx  —  apps/timeline-gstudio001/components/graph-view
- 669     adapter.ts  —  packages/timeline-domain/src
- 667  T  timelines-batch.test.ts  —  apps/timeline-gstudio001/app/api/timelines
- 653     tools.ts  —  apps/timeline-gstudio001/lib/webmcp
- 653  T  VirtualGrid.stories.tsx  —  packages/ui/dnd-collections
- 633  T  dnd-collections.spec.ts  —  apps/timeline-gstudio001/tests/e2e
- 564     graph-timeline-view.tsx  —  apps/timeline-gstudio001/components/graph-view
- 561     globals.css  —  apps/timeline-gstudio001/app
- 542     route.ts  —  apps/timeline-gstudio001/app/api/mcp
- 539     collections-store.ts  —  packages/ui/dnd-collections/react
- 531     write-handlers.ts  —  apps/timeline-gstudio001/lib/mcp
- 498     graph-item-actions.tsx  —  apps/timeline-gstudio001/components/graph-view
- 475     foobar-demo.mjs  —  apps/timeline-gstudio001/tests/demo
- 469  T  keyboard.test.ts  —  packages/collections-core
- 466     graph-playhead-model.ts  —  apps/timeline-gstudio001/components/graph-view
- 462     cloudinary-media-store.ts  —  apps/timeline-gstudio001/lib
- 449     graph-seam-lane.tsx  —  apps/timeline-gstudio001/components/graph-view
- 432     trash-drawer.tsx  —  apps/timeline-gstudio001/components/assets
- 425  T  PaletteTrash.stories.tsx  —  packages/ui/dnd-collections
- 422  T  upload.test.ts  —  apps/timeline-gstudio001/lib/mcp
- 421  T  trash-empty.test.ts  —  apps/timeline-gstudio001/app/api/trash
- 409     graph-sub-timelines.tsx  —  apps/timeline-gstudio001/components/graph-view
- 406     commands.ts  —  packages/collections-core
- 403  T  TrimReadouts.stories.tsx  —  packages/ui/dnd-collections
- 367     VirtualGrid.tsx  —  packages/ui/dnd-collections/virtual
- 362  T  tools.test.ts  —  apps/timeline-gstudio001/lib/webmcp
- 359     timeline-document-store.tsx  —  packages/ui/timeline
- 348     graph-view-chrome.tsx  —  apps/timeline-gstudio001/components/graph-view
- 347     page.tsx  —  apps/timeline-gstudio001/app
- 342  T  intents.test.ts  —  packages/collections-core
- 342     use-keyboard-controller.ts  —  packages/ui/dnd-collections/react
- 329  T  firebase-timeline-cascade-delete.test.ts  —  apps/timeline-gstudio001/lib
- 328  T  ffmpeg-plan.test.ts  —  apps/timeline-gstudio001/lib/render
- 324     collection-item.tsx  —  packages/ui/dnd-collections/react
- 320  T  derive-collection-summaries.test.ts  —  apps/timeline-gstudio001/lib
- 319     graph-native-drop-engine.ts  —  apps/timeline-gstudio001/components/graph-view
- 319     use-timeline-clips.ts  —  packages/ui/timeline/hooks
- 317  T  cut-list.test.ts  —  apps/timeline-gstudio001/lib/render
- 315     node-views.tsx  —  packages/ui/dnd-collections/react
- 308  T  virtual-strip-lanes.test.ts  —  packages/ui/dnd-collections/virtual
- 300  T  graph-native-drop-model.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 286     apply-command.ts  —  apps/timeline-gstudio001/lib/mcp
- 285  T  apply-command.test.ts  —  apps/timeline-gstudio001/lib/mcp
- 283     globals.css  —  apps/storybook/.storybook
- 278  T  audio-graph.test.ts  —  packages/ui/timeline/viewport
- 277  T  timelines-authorization.test.ts  —  apps/timeline-gstudio001/app/api/timelines
- 273  T  InteractionPolicy.stories.tsx  —  packages/ui/dnd-collections
- 272     styles.css  —  packages/timeline-widget/src
- 268  T  CompoundItem.stories.tsx  —  packages/ui/dnd-collections
- 267  T  storyboard-monster-mark.stories.tsx  —  apps/timeline-gstudio001/components/timeline
- 265     intents.ts  —  packages/collections-core
- 265     keyboard.ts  —  packages/collections-core
- 265  T  lane-roundtrip.test.ts  —  packages/timeline-domain/src
- 262     graph-collection-card.tsx  —  apps/timeline-gstudio001/components/graph-view
- 257     route.ts  —  apps/timeline-gstudio001/app/api/timeline-media/upload
- 252  T  playback-manifest.test.ts  —  packages/timeline-domain/src
- 252  T  TrimGesture.stories.tsx  —  packages/ui/dnd-collections
- 250     validator.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
- 248  T  timelines-export-import.test.ts  —  apps/timeline-gstudio001/app/api/timelines
- 240     graph-clip-card.tsx  —  apps/timeline-gstudio001/components/graph-view
- 239     patches.ts  —  packages/collections-core
- 238     graph-item-details-panel.tsx  —  apps/timeline-gstudio001/components/graph-view
- 237     graph-item-details-monitor.tsx  —  apps/timeline-gstudio001/components/graph-view
- 237  T  graph-rsc-payloads.test.ts  —  apps/timeline-gstudio001/lib
- 236     graph-hydration.tsx  —  apps/timeline-gstudio001/components/graph-view
- 236     timeline-media-client.ts  —  apps/timeline-gstudio001/lib
- 235  T  timelines-preview-manifest.test.ts  —  apps/timeline-gstudio001/app/api/timelines
- 234  T  graph-lane-rows.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 234     trim-gesture.ts  —  packages/ui/dnd-collections/react
- 233  T  set-start.test.ts  —  apps/timeline-gstudio001/lib/mcp
- 227     graph-navigation.tsx  —  apps/timeline-gstudio001/components/graph-view
- 227     scene-service.ts  —  packages/db/lib
- 226  T  aspect-correction.test.ts  —  apps/timeline-gstudio001/lib
- 226     virtual-strip-lanes.ts  —  packages/ui/dnd-collections/virtual
- 224  T  remove-clip.test.ts  —  apps/timeline-gstudio001/lib/mcp
- 223  T  reclaim-route.test.ts  —  apps/timeline-gstudio001/app/api/assets/reclaim
- 220     upload.ts  —  apps/timeline-gstudio001/lib/mcp
- 220  T  PanMomentumCoverage.stories.tsx  —  packages/ui/dnd-collections
- 216  T  playback-skip.test.ts  —  packages/ui/timeline/viewport
- 212     graph-grid-play-button.tsx  —  apps/timeline-gstudio001/components/graph-view
- 210  T  lane-manifest.test.ts  —  packages/timeline-domain/src
- 209     graph-native-drop-model.ts  —  apps/timeline-gstudio001/components/graph-view
- 209     graph-seam-bar.tsx  —  apps/timeline-gstudio001/components/graph-view
- 209     graph-selection-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
- 207     graph-collection-details.tsx  —  apps/timeline-gstudio001/components/graph-view
- 204  T  sidebar-collection-shortcuts.stories.tsx  —  apps/timeline-gstudio001/components/timeline
- 201     storyboard-monster-mark.tsx  —  apps/timeline-gstudio001/components/timeline
- 198  T  documents.test.ts  —  packages/timeline-model
- 198  T  validate.test.ts  —  packages/timeline-model
- 197  T  flat-order.test.ts  —  packages/timeline-domain/src
- 196  T  job-store.test.ts  —  apps/timeline-gstudio001/lib/render
- 195  T  timelines-batch-get.test.ts  —  apps/timeline-gstudio001/app/api/timelines
- 195     ffmpeg-plan.mjs  —  apps/timeline-gstudio001/scripts/render-worker
- 195     playback-manifest.ts  —  packages/timeline-domain/src
- 194     graph-card-derivations.ts  —  apps/timeline-gstudio001/components/graph-view
- 194  T  move-clip.test.ts  —  apps/timeline-gstudio001/lib/mcp
- 193     correct-clip-aspects.mjs  —  apps/timeline-gstudio001/scripts
- 193  T  FirstItemTrim.stories.tsx  —  packages/ui/dnd-collections
- 192     graph-breadcrumb-drop.tsx  —  apps/timeline-gstudio001/components/graph-view
- 192     auth-service.ts  —  packages/db/lib
- 190  T  cloudinary-media-store.test.ts  —  apps/timeline-gstudio001/lib
- 187  T  graph-seam-bar-layout.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 187     index.mjs  —  apps/timeline-gstudio001/scripts/render-worker
- 186  T  timeline-media-client.test.ts  —  apps/timeline-gstudio001/lib
- 186  T  clip-display.test.ts  —  packages/timeline-model
- 186  T  GestureArbitration.stories.tsx  —  packages/ui/dnd-collections
- 183     index.ts  —  packages/ui/dnd-collections
- 182  T  timeline-sidebar.stories.tsx  —  apps/timeline-gstudio001/components/timeline
- 182  T  change-log.test.ts  —  apps/timeline-gstudio001/lib
- 181     graph-native-drop-grid.tsx  —  apps/timeline-gstudio001/components/graph-view
- 181  T  graph-node-clone.test.ts  —  apps/timeline-gstudio001/lib
- 180  T  graph-card-model.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 180     graph-seam-ruler.tsx  —  apps/timeline-gstudio001/components/graph-view
- 178  T  AlwaysOnTrimHandles.stories.tsx  —  packages/ui/dnd-collections
- 176  T  graph-insert-placement.test.ts  —  apps/timeline-gstudio001/lib
- 176     audio-graph.ts  —  packages/ui/timeline/viewport
- 175  T  client-manifest-equivalence.test.ts  —  apps/timeline-gstudio001/lib
- 175  T  layer-frame.test.ts  —  packages/timeline-model
- 173  T  video-frame-url.test.ts  —  apps/timeline-gstudio001/lib
- 173  T  commands.fuzz.test.ts  —  packages/collections-core
- 173  T  TimelineStrip.stories.tsx  —  packages/timeline-widget/src/views
- 172     use-pan-with-momentum.ts  —  packages/ui/dnd-collections/react
- 171     graph-item-action-specs.ts  —  apps/timeline-gstudio001/lib
- 168     serve-timeline.ts  —  apps/timeline-gstudio001/lib
- 167     sidebar-collection-shortcuts.tsx  —  apps/timeline-gstudio001/components/timeline
- 166     graph-native-drop-strip.tsx  —  apps/timeline-gstudio001/components/graph-view
- 166     remove-dangling-collection-references.ts  —  apps/timeline-gstudio001/scripts
- 166  T  virtual-strip-geometry.test.ts  —  packages/ui/dnd-collections/virtual
- 165     job-store.ts  —  apps/timeline-gstudio001/lib/render
- 164     auth-gate.tsx  —  apps/timeline-gstudio001/components/auth
- 162  T  asset-references.test.ts  —  apps/timeline-gstudio001/lib/assets
- 158     charts-bar-chart.tsx  —  .agents/skills/remotion-best-practices/rules/assets
- 158     graph-tag-filter-control.tsx  —  apps/timeline-gstudio001/components/graph-view
- 158  T  core.test.ts  —  apps/timeline-gstudio001/lib/oauth
- 157  T  marked-route.test.ts  —  apps/timeline-gstudio001/app/api/assets/marked
- 154  T  button.stories.tsx  —  apps/timeline-gstudio001/components/core
- 154     graph-tag-editor.tsx  —  apps/timeline-gstudio001/components/graph-view
- 154     App.tsx  —  packages/timeline-widget/src/app
- 153  T  graph-layer-frame-picker.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
- 152  T  route.test.ts  —  apps/timeline-gstudio001/app/api/timeline-media
- 151     graph-seam-minimap.tsx  —  apps/timeline-gstudio001/components/graph-view
- 151  T  job-state.test.ts  —  apps/timeline-gstudio001/lib/render
- 150     route.ts  —  apps/timeline-gstudio001/app/api/oauth/token
- 149  T  graph-item-action-specs.test.ts  —  apps/timeline-gstudio001/lib
- 149     migrate-legacy-video-durations.mjs  —  apps/timeline-gstudio001/scripts
- 148     trim-overview.tsx  —  packages/ui/dnd-collections/react
- 147     documents.ts  —  packages/timeline-model
- 146     graph-shortcuts.tsx  —  apps/timeline-gstudio001/components/graph-view
- 146     repair-truncated-asset-paths.mjs  —  apps/timeline-gstudio001/scripts
- 146  T  trim-gesture.test.ts  —  packages/ui/dnd-collections/react
- 145     dropdown-menu.tsx  —  apps/timeline-gstudio001/components/core
- 145     attach-output.ts  —  apps/timeline-gstudio001/lib/render
- 144  T  route.test.ts  —  apps/timeline-gstudio001/app/api/timeline-media/upload
- 144     graph-anchor-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
- 144  T  read-timeline.test.ts  —  apps/timeline-gstudio001/lib/mcp
- 143  T  graph-details-store.test.ts  —  apps/timeline-gstudio001/lib
- 143     virtual-strip-geometry.ts  —  packages/ui/dnd-collections/virtual
- 140     route.ts  —  apps/timeline-gstudio001/app/api/timelines/batch
- 140     timeline-snapshot.mjs  —  apps/timeline-gstudio001/scripts
- 139     graph-layer-frame-picker.tsx  —  apps/timeline-gstudio001/components/graph-view
- 139     graph-tool-buttons.tsx  —  apps/timeline-gstudio001/components/graph-view
- 139     use-virtual-collection-view.tsx  —  packages/ui/dnd-collections/virtual
- 138     route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]
- 138  T  default-layer-frame.test.ts  —  apps/timeline-gstudio001/lib
- 138  T  renders-collection.test.ts  —  apps/timeline-gstudio001/lib/render
- 137     firebase-media-store.ts  —  apps/timeline-gstudio001/lib
- 137     edge-autoscroll-coordinator.ts  —  packages/ui/dnd-collections/react
- 134     db-client.ts  —  packages/db/lib
- 133     graph-item-details-trim-strip.tsx  —  apps/timeline-gstudio001/components/graph-view
- 133     bin-unreachable-timelines.mjs  —  apps/timeline-gstudio001/scripts
- 132     audit-review-findings.mjs  —  apps/timeline-gstudio001/scripts
- 131  T  MediaThumbnails.stories.tsx  —  packages/ui/dnd-collections
- 130  T  trash-groups.test.ts  —  apps/timeline-gstudio001/lib
- 130  T  waveform-cache.test.ts  —  apps/timeline-gstudio001/lib
- 130     inspect-squatted-fixtures.mjs  —  apps/timeline-gstudio001/scripts
- 130     make-dev-fixture.mjs  —  apps/timeline-gstudio001/scripts
- 130  T  hydrate.test.ts  —  packages/collections-core
- 130     use-flip-graph-animation.ts  —  packages/ui/dnd-collections/react
- 129  T  placement.test.ts  —  packages/timeline-model
- 128     waveform-cache.ts  —  apps/timeline-gstudio001/lib
- 128     find-unreachable-ui.mjs  —  scripts
- 126     audit-orphaned-timelines.mjs  —  apps/timeline-gstudio001/scripts
- 125     graph-render-status.tsx  —  apps/timeline-gstudio001/components/graph-view
- 125  T  use-timeline-clips.test.ts  —  packages/ui/timeline/hooks
- 124     smoke-test.mjs  —  apps/timeline-gstudio001/scripts/render-worker
- 124     validate.ts  —  packages/timeline-model
- 123     graph-item-details-trim-fields.tsx  —  apps/timeline-gstudio001/components/graph-view
- 123     core.ts  —  apps/timeline-gstudio001/lib/oauth
- 122     layer-frame.ts  —  packages/timeline-model
- 121     graph-card-badges.tsx  —  apps/timeline-gstudio001/components/graph-view
- 121     graph-remote-changes.tsx  —  apps/timeline-gstudio001/components/graph-view
- 121     count-loc.mjs  —  scripts
- 120  T  create-collection.test.ts  —  apps/timeline-gstudio001/lib/mcp
- 120  T  waveform-peaks.test.ts  —  packages/ui/timeline/viewport
- 117     derive-collection-summaries.ts  —  apps/timeline-gstudio001/lib
- 117     graph-view-events.ts  —  apps/timeline-gstudio001/lib
- 116     graph-persistence.tsx  —  apps/timeline-gstudio001/components/graph-view
- 116     fixture-timeline-store.ts  —  apps/timeline-gstudio001/lib
- 114     graph-item-details-header.tsx  —  apps/timeline-gstudio001/components/graph-view
- 114  T  graph-seam-scrub.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 114  T  tag-facets.test.ts  —  apps/timeline-gstudio001/lib
- 113     asset-tombstones.ts  —  apps/timeline-gstudio001/lib
- 113  T  collection-shortcuts.test.ts  —  apps/timeline-gstudio001/lib
- 112     graph-seam-scrub.ts  —  apps/timeline-gstudio001/components/graph-view
- 111  T  TrimGestureUnmount.stories.tsx  —  packages/ui/dnd-collections
- 110     use-seeked-video.ts  —  apps/timeline-gstudio001/hooks
- 110     timeline-app-html.ts  —  packages/timeline-widget
- 110     use-palette-drag.ts  —  packages/ui/dnd-collections/react
- 110  T  timeline-documents.test.ts  —  packages/ui/timeline
- 109  T  graph-history-format.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 109     timeline-tree.ts  —  apps/timeline-gstudio001/lib/webmcp
- 109     interaction-policy.ts  —  packages/ui/dnd-collections/react
- 108  T  fixture-timeline-store.test.ts  —  apps/timeline-gstudio001/lib
- 107     auth-provider.tsx  —  apps/timeline-gstudio001/components/auth
- 107     preview-time-channel.ts  —  apps/timeline-gstudio001/components/graph-view
- 107     measure-closure-batched-vs-per-document-reads.mjs  —  apps/timeline-gstudio001/scripts
- 107  T  CollisionCoverage.stories.tsx  —  packages/ui/dnd-collections
- 107  T  interaction-policy.test.ts  —  packages/ui/dnd-collections/react
- 107     use-announcements.ts  —  packages/ui/dnd-collections/react
- 107     use-background-clear.ts  —  packages/ui/dnd-collections/react
- 106     route.ts  —  apps/timeline-gstudio001/app/api/renders
- 106     graph-seam-bar-layout.ts  —  apps/timeline-gstudio001/components/graph-view
- 105     route.ts  —  apps/timeline-gstudio001/app/api/timeline-media
- 105     route.ts  —  apps/timeline-gstudio001/app/api/trash
- 104     stories-helpers.ts  —  packages/ui/dnd-collections
- 103     graph-item-details-panel-header.tsx  —  apps/timeline-gstudio001/components/graph-view
- 103     graph-trim-panel.tsx  —  apps/timeline-gstudio001/components/graph-view
- 103  T  graph-trash-discard.test.ts  —  apps/timeline-gstudio001/lib
- 103     collections-components.tsx  —  packages/ui/dnd-collections/react
- 101  T  graph-details-neighbours.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 101  T  graph-item-details-change-note.test.ts  —  apps/timeline-gstudio001/components/graph-view
- 101     aspect-correction.mjs  —  apps/timeline-gstudio001/scripts
- 101     playback-skip.ts  —  packages/ui/timeline/viewport
- 101     waveform-peaks.ts  —  packages/ui/timeline/viewport
- 100     measure-project-query-vs-closure-walk.mjs  —  apps/timeline-gstudio001/scripts
- 100  T  replay-guard.test.ts  —  packages/collections-core
- 100  T  preview-items.test.ts  —  packages/timeline-model
-  99     create-collection.ts  —  apps/timeline-gstudio001/lib/mcp
-  99     render.ts  —  apps/timeline-gstudio001/lib/mcp
-  99  T  view-state.test.ts  —  packages/timeline-widget/src/app
-  98     page.tsx  —  apps/timeline-gstudio001/app/oauth/authorize
-  98     graph-item-context-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
-  98     graph-selection-actions.tsx  —  apps/timeline-gstudio001/components/graph-view
-  98     graph-rsc-payloads.ts  —  apps/timeline-gstudio001/lib
-  98     audit-dead-asset-references.mjs  —  apps/timeline-gstudio001/scripts
-  97     route.ts  —  apps/timeline-gstudio001/app/api/timelines/import
-  97  T  graph-seam-strip.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  97     load-timeline-closure.ts  —  apps/timeline-gstudio001/lib
-  97  T  patches.test.ts  —  packages/collections-core
-  96  T  preview-time-channel.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  96     view-tools.ts  —  packages/timeline-widget/src/tools
-  94     authorize-request.ts  —  apps/timeline-gstudio001/lib/oauth
-  94     node-thumbnail.tsx  —  packages/ui/dnd-collections/react
-  93  T  history.test.ts  —  packages/collections-core
-  92     graph-card-caption.tsx  —  apps/timeline-gstudio001/components/graph-view
-  92  T  authorize-request.test.ts  —  apps/timeline-gstudio001/lib/oauth
-  91     firebase-auth-session.ts  —  apps/timeline-gstudio001/lib
-  90     text-animations-word-highlight.tsx  —  .agents/skills/remotion-best-practices/rules/assets
-  89     text-animations-typewriter.tsx  —  .agents/skills/remotion-best-practices/rules/assets
-  89     route.ts  —  apps/timeline-gstudio001/app/api/timelines/batch-get
-  89  T  firestore-failure.test.ts  —  apps/timeline-gstudio001/lib
-  88  T  http-range.test.ts  —  apps/timeline-gstudio001/lib
-  88     stamp-project-id-on-timeline-documents.mjs  —  apps/timeline-gstudio001/scripts
-  87     graph-trim-preview.tsx  —  apps/timeline-gstudio001/components/graph-view
-  87  T  project-thumbnail.test.ts  —  apps/timeline-gstudio001/lib
-  86     graph-render-format.tsx  —  apps/timeline-gstudio001/components/graph-view
-  86  T  tag-write-plan.test.ts  —  apps/timeline-gstudio001/lib
-  86     index.ts  —  packages/collections-core
-  86     types.ts  —  packages/timeline-model
-  85     graph-item-details-change-note.ts  —  apps/timeline-gstudio001/components/graph-view
-  85  T  graph-layer-frame.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  84  T  graph-render-format.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
-  84  T  offline-media-store.test.ts  —  apps/timeline-gstudio001/lib
-  84  T  RovingFocusReorder.stories.tsx  —  packages/ui/dnd-collections
-  83     graph-item-content.tsx  —  apps/timeline-gstudio001/components/graph-view
-  83     graph-clipboard.ts  —  apps/timeline-gstudio001/lib
-  83     prune-empty-orphans.mjs  —  apps/timeline-gstudio001/scripts
-  83  T  render-format.test.ts  —  packages/timeline-model
-  82  T  NodeDomCoverage.stories.tsx  —  packages/ui/dnd-collections
-  81     route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]/report
-  81     audit-foreign-accounts.mjs  —  apps/timeline-gstudio001/scripts
-  81  T  tags-roundtrip.test.ts  —  packages/timeline-domain/src
-  81     default-item-content.tsx  —  packages/ui/dnd-collections/react
-  80     history-views.tsx  —  packages/ui/dnd-collections/react
-  79     route.ts  —  apps/timeline-gstudio001/app/api/assets/reclaim
-  79  T  move-cost.test.ts  —  packages/collections-core
-  78     graph-item-details-history.ts  —  apps/timeline-gstudio001/components/graph-view
-  78  T  metadata.test.ts  —  apps/timeline-gstudio001/lib/oauth
-  78     store.ts  —  apps/timeline-gstudio001/lib/oauth
-  78     audit-ownerless-timelines.mjs  —  apps/timeline-gstudio001/scripts
-  78     clip-display.ts  —  packages/timeline-model
-  78     utils.ts  —  packages/ui/timeline
-  77     graph-inline-rename.tsx  —  apps/timeline-gstudio001/components/graph-view
-  77  T  graph-remote-diff.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  77     graph-seam-strip.ts  —  apps/timeline-gstudio001/components/graph-view
-  77     tag-facets.ts  —  apps/timeline-gstudio001/lib
-  77     stamp-ownerless-timelines.mjs  —  apps/timeline-gstudio001/scripts
-  77     view-state.ts  —  packages/timeline-widget/src/app
-  76     graph-card-ghost.tsx  —  apps/timeline-gstudio001/components/graph-view
-  76     graph-collection-hover.tsx  —  apps/timeline-gstudio001/components/graph-view
-  76     graph-lane-rows.ts  —  apps/timeline-gstudio001/components/graph-view
-  76  T  graph-tool-buttons.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
-  76     graph-details-store.ts  —  apps/timeline-gstudio001/lib
-  76  T  placement.test.ts  —  apps/timeline-gstudio001/lib/webmcp
-  75     graph-save-status.tsx  —  apps/timeline-gstudio001/components/graph-view
-  75  T  use-hover-prefetch.test.ts  —  apps/timeline-gstudio001/components/projects
-  75     firebase-auth-rest.ts  —  apps/timeline-gstudio001/lib
-  75  T  timeline-tree.test.ts  —  apps/timeline-gstudio001/lib/webmcp
-  74     change-log.ts  —  apps/timeline-gstudio001/lib
-  74  T  webmcp-adapter.test.ts  —  apps/timeline-gstudio001/lib/webmcp
-  74     Clip.tsx  —  packages/timeline-widget/src/components
-  73     context-menu.tsx  —  apps/timeline-gstudio001/components/core
-  73     firestore-failure.ts  —  apps/timeline-gstudio001/lib
-  73  T  graph-clipboard.test.ts  —  apps/timeline-gstudio001/lib
-  73     history.ts  —  packages/collections-core
-  72  T  card-ghost-frames.test.ts  —  apps/timeline-gstudio001/lib
-  72  T  KeyboardDuringDrag.stories.tsx  —  packages/ui/dnd-collections
-  72     trim-handles.tsx  —  packages/ui/dnd-collections/react
-  71     graph-card-model.ts  —  apps/timeline-gstudio001/components/graph-view
-  71     firebase-admin.ts  —  apps/timeline-gstudio001/lib
-  71     offline-media-store.ts  —  apps/timeline-gstudio001/lib
-  71     cut-list.ts  —  apps/timeline-gstudio001/lib/render
-  71     job-state.ts  —  apps/timeline-gstudio001/lib/render
-  71  T  tags.test.ts  —  packages/timeline-model
-  70     route.ts  —  apps/timeline-gstudio001/app/api/oauth/authorize
-  70     route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]/export
-  70  T  preview-card-geometry.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  70  T  s3-provider.test.ts  —  apps/timeline-gstudio001/lib/assets
-  70  T  card-provenance.test.ts  —  apps/timeline-gstudio001/lib
-  69     graph-card-trim.tsx  —  apps/timeline-gstudio001/components/graph-view
-  68     layout.tsx  —  apps/timeline-gstudio001/app
-  68     graph-native-drop-insertion.ts  —  apps/timeline-gstudio001/components/graph-view
-  67  T  mcp-timeline-summary.test.ts  —  apps/timeline-gstudio001/lib
-  66     graph-add-collection-slot.tsx  —  apps/timeline-gstudio001/components/graph-view
-  66  T  render-poll.test.ts  —  apps/timeline-gstudio001/lib/render
-  65     graph-details-segmented.tsx  —  apps/timeline-gstudio001/components/graph-view
-  65     graph-node-clone.ts  —  apps/timeline-gstudio001/lib
-  65  T  hydration-skeletons.test.ts  —  apps/timeline-gstudio001/lib
-  65     metadata.ts  —  apps/timeline-gstudio001/lib/oauth
-  65  T  provider.test.ts  —  apps/timeline-gstudio001/lib/render
-  65     video-frame-url.ts  —  apps/timeline-gstudio001/lib
-  64     routes.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
-  64  T  graph-item-details-bar-reach.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  64     graph-mcp-tools.tsx  —  apps/timeline-gstudio001/components/graph-view
-  64     graph-waveform-model.ts  —  apps/timeline-gstudio001/components/graph-view
-  64     eslint.config.mjs  —  apps/timeline-gstudio001
-  64  T  map-with-concurrency.test.ts  —  apps/timeline-gstudio001/lib
-  63     main.ts  —  apps/storybook/.storybook
-  63     vitest.config.ts  —  apps/storybook
-  63     graph-native-drag-signal.ts  —  apps/timeline-gstudio001/components/graph-view
-  62     global-error.tsx  —  apps/timeline-gstudio001/app
-  62  T  role-roundtrip.test.ts  —  packages/timeline-domain/src
-  61     use-dialog-focus.ts  —  apps/timeline-gstudio001/hooks
-  60     default-layer-frame.ts  —  apps/timeline-gstudio001/lib
-  60     hydrate.ts  —  packages/collections-core
-  59     graph-history-format.ts  —  apps/timeline-gstudio001/components/graph-view
-  59     client-playback-manifest.ts  —  apps/timeline-gstudio001/lib
-  59     node-dom.ts  —  packages/ui/dnd-collections/react
-  58  T  auth-allowlist.test.ts  —  apps/timeline-gstudio001/lib
-  57     graph-view-loading.tsx  —  apps/timeline-gstudio001/components/graph-view
-  57  T  load-project-button.stories.tsx  —  apps/timeline-gstudio001/components/projects
-  57  T  derived-cache.test.ts  —  apps/timeline-gstudio001/lib
-  57  T  tool-fields.test.ts  —  apps/timeline-gstudio001/lib/webmcp
-  56     use-frame-crossfade.ts  —  apps/timeline-gstudio001/hooks
-  55     s3-provider.ts  —  apps/timeline-gstudio001/lib/assets
-  55  T  frame-override.test.ts  —  packages/ui/timeline/viewport
-  54     host.ts  —  packages/timeline-widget/src/bridge
-  53     graph-details-neighbours.ts  —  apps/timeline-gstudio001/components/graph-view
-  53     preview-card-geometry.ts  —  apps/timeline-gstudio001/components/graph-view
-  53     trash-target.tsx  —  packages/ui/dnd-collections/react
-  52     button.tsx  —  apps/timeline-gstudio001/components/core
-  51     slider.tsx  —  apps/timeline-gstudio001/components/core
-  51     graph-item-details-context.tsx  —  apps/timeline-gstudio001/components/graph-view
-  51  T  sidebar-icon-styles.test.ts  —  apps/timeline-gstudio001/components/timeline
-  51  T  project-asset-scope.test.ts  —  apps/timeline-gstudio001/lib
-  51     flat-order.ts  —  packages/timeline-domain/src
-  50     route.ts  —  apps/timeline-gstudio001/app/api/auth/login
-  50     graph-insert-placement.ts  —  apps/timeline-gstudio001/lib
-  49     route.ts  —  apps/timeline-gstudio001/app/api/assets/marked
-  49  T  graph-strip-swipe.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  49     results.ts  —  apps/timeline-gstudio001/lib/webmcp
-  49     next.config.ts  —  apps/timeline-gstudio001
-  49     live-trim.ts  —  packages/ui/dnd-collections/react
-  47     graph-project-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
-  47  T  trash-provenance.test.ts  —  apps/timeline-gstudio001/lib
-  47     placement.ts  —  packages/timeline-model
-  46     error.tsx  —  apps/timeline-gstudio001/app
-  46     load-project-button.tsx  —  apps/timeline-gstudio001/components/projects
-  46     asset-references.ts  —  apps/timeline-gstudio001/lib/assets
-  46     rate-limit.ts  —  apps/timeline-gstudio001/lib
-  45     route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest
-  45     route.ts  —  apps/timeline-gstudio001/app/api/timelines/closure
-  45     graph-details-context.tsx  —  apps/timeline-gstudio001/components/graph-view
-  45     graph-item-disable-toggle.tsx  —  apps/timeline-gstudio001/components/graph-view
-  45     sidebar-tooltip-label.tsx  —  apps/timeline-gstudio001/components/timeline
-  45  T  edge-autoscroll-math.test.ts  —  packages/ui/dnd-collections/react
-  44     types.ts  —  apps/timeline-gstudio001/lib/render
-  44     playwright.config.ts  —  apps/timeline-gstudio001
-  44  T  numeric.test.ts  —  packages/collections-core
-  44     TimelineStrip.tsx  —  packages/timeline-widget/src/views
-  43     graph-history-persistence.tsx  —  apps/timeline-gstudio001/components/graph-view
-  43     graph-playbar-thumbnails.tsx  —  apps/timeline-gstudio001/components/graph-view
-  43     load-project.ts  —  apps/timeline-gstudio001/components/projects
-  43     placement.ts  —  apps/timeline-gstudio001/lib/webmcp
-  42  T  cloudinary-provider.test.ts  —  apps/timeline-gstudio001/lib/assets
-  42  T  caption-tag-fit.test.ts  —  apps/timeline-gstudio001/lib
-  42     webmcp-adapter.ts  —  apps/timeline-gstudio001/lib/webmcp
-  42  T  edge-autoscroll-coordinator.test.ts  —  packages/ui/dnd-collections/react
-  41     route.ts  —  apps/timeline-gstudio001/app/api/auth/login/complete
-  40     graph-card-measure.ts  —  apps/timeline-gstudio001/components/graph-view
-  40     graph-remote-diff.ts  —  apps/timeline-gstudio001/components/graph-view
-  40     graph-view-config.ts  —  apps/timeline-gstudio001/components/graph-view
-  40     graph-trash-discard.ts  —  apps/timeline-gstudio001/lib
-  40     provider.ts  —  apps/timeline-gstudio001/lib/render
-  40  T  insert-noop.test.ts  —  packages/ui/dnd-collections/virtual
-  39     route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]/upload-ticket
-  39     graph-paste-flash.ts  —  apps/timeline-gstudio001/lib
-  38     route.ts  —  apps/timeline-gstudio001/app/api/timelines/revisions
-  37  T  sidebar-rail-preference.test.ts  —  apps/timeline-gstudio001/components/timeline
-  37     tag-write-plan.ts  —  apps/timeline-gstudio001/lib
-  37     render-format.ts  —  packages/timeline-model
-  37     tags.ts  —  packages/timeline-model
-  36     route.ts  —  apps/timeline-gstudio001/app/api/timelines
-  36     graph-native-drop-chrome.tsx  —  apps/timeline-gstudio001/components/graph-view
-  36     use-hover-prefetch.ts  —  apps/timeline-gstudio001/components/projects
-  36     types.ts  —  packages/timeline-widget/src
-  36     palette.tsx  —  packages/ui/dnd-collections/react
-  36     constants.ts  —  packages/ui/timeline
-  35     route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]
-  35     graph-strip-swipe.ts  —  apps/timeline-gstudio001/components/graph-view
-  35     graph-tag-filter.tsx  —  apps/timeline-gstudio001/components/graph-view
-  35  T  timeline-ownership.test.ts  —  apps/timeline-gstudio001/lib
-  35     trash-groups.ts  —  apps/timeline-gstudio001/lib
-  35     index.ts  —  packages/timeline-domain
-  35  T  audio-roundtrip.test.ts  —  packages/timeline-domain/src
-  34  T  graph-dropped-media.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  34     format-duration.ts  —  apps/timeline-gstudio001/lib
-  34  T  hydration-target.test.ts  —  apps/timeline-gstudio001/lib
-  34     project-asset-scope.ts  —  apps/timeline-gstudio001/lib
-  34  T  results.test.ts  —  apps/timeline-gstudio001/lib/webmcp
-  34  T  utils.test.ts  —  packages/ui/timeline
-  33     preview-scroller.ts  —  apps/timeline-gstudio001/components/graph-view
-  33     collection-shortcuts.ts  —  apps/timeline-gstudio001/lib
-  33  T  frame-count-settle.test.ts  —  apps/timeline-gstudio001/lib
-  33     http-range.ts  —  apps/timeline-gstudio001/lib
-  33     apply-flag.mjs  —  apps/timeline-gstudio001/scripts
-  32     route.ts  —  apps/timeline-gstudio001/app/api/renders/claim
-  32     page.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]/graph/[[...activeTimelinePath]]
-  32     graph-dropped-media.ts  —  apps/timeline-gstudio001/components/graph-view
-  32  T  graph-project-menu.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
-  32  T  graph-sub-timeline-status.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  32     preview-contexts.tsx  —  apps/timeline-gstudio001/components/graph-view
-  32     renders-collection.ts  —  apps/timeline-gstudio001/lib/render
-  32     tool-fields.ts  —  apps/timeline-gstudio001/lib/webmcp
-  31  T  cloudinary-scrub-proxy.test.ts  —  apps/timeline-gstudio001/lib
-  31     read-timeline.ts  —  apps/timeline-gstudio001/lib/mcp
-  31  T  aspect.test.ts  —  packages/timeline-model
-  30     page.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]
-  30     caption-tag-fit.ts  —  apps/timeline-gstudio001/lib
-  30     compile-timeline-manifest.ts  —  apps/timeline-gstudio001/lib
-  29     client-graph-view.tsx  —  apps/timeline-gstudio001/components/graph-view
-  29     graph-layer-frame.ts  —  apps/timeline-gstudio001/components/graph-view
-  29     provider.ts  —  apps/timeline-gstudio001/lib/assets
-  28  T  asset-deletion-window.test.ts  —  apps/timeline-gstudio001/lib
-  28     timeline-ownership.ts  —  apps/timeline-gstudio001/lib
-  28     trash-provenance.ts  —  apps/timeline-gstudio001/lib
-  28     virtual-droppable.ts  —  packages/ui/dnd-collections/react
-  27     cache-life.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
-  27  T  boot-session-key.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  27     graph-card-dimming.ts  —  apps/timeline-gstudio001/components/graph-view
-  27  T  disabled-visuals.test.ts  —  apps/timeline-gstudio001/lib
-  27     preview-items.ts  —  packages/timeline-model
-  26     graph-pending-details.ts  —  apps/timeline-gstudio001/components/graph-view
-  26     derived-cache.ts  —  apps/timeline-gstudio001/lib
-  26     ErrorBoundary.tsx  —  packages/timeline-widget/src/app
-  26     pointer-sensors.ts  —  packages/ui/dnd-collections/react
-  25     layout.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]/graph
-  25     sidebar-icon-styles.ts  —  apps/timeline-gstudio001/components/timeline
-  25  T  provider.test.ts  —  apps/timeline-gstudio001/lib/assets
-  25  T  cloudinary-public-id.test.ts  —  apps/timeline-gstudio001/lib
-  24     main.ts  —  apps/timeline-gstudio001/.storybook
-  24     graph-card-placeholders.tsx  —  apps/timeline-gstudio001/components/graph-view
-  24     card-ghost-frames.ts  —  apps/timeline-gstudio001/lib
-  24     view-transition.ts  —  apps/timeline-gstudio001/lib
-  24     container-context.ts  —  packages/ui/dnd-collections/react
-  23     sonner.tsx  —  apps/timeline-gstudio001/components/core
-  23     graph-item-details-bar-reach.ts  —  apps/timeline-gstudio001/components/graph-view
-  23     press-feedback.ts  —  apps/timeline-gstudio001/components/graph-view
-  23     make-scale-probe.mjs  —  apps/timeline-gstudio001/scripts
-  23     numeric.ts  —  packages/collections-core
-  22     tag-accent-dot.tsx  —  apps/timeline-gstudio001/components/graph-view
-  21     preview.ts  —  apps/timeline-gstudio001/.storybook
-  21     render-poll.ts  —  apps/timeline-gstudio001/lib/render
-  21     edge-autoscroll-math.ts  —  packages/ui/dnd-collections/react
-  20     graph-details-design.ts  —  apps/timeline-gstudio001/components/graph-view
-  20     graph-item-details-view-count.ts  —  apps/timeline-gstudio001/components/graph-view
-  20     map-with-concurrency.ts  —  apps/timeline-gstudio001/lib
-  20     worker-request.ts  —  apps/timeline-gstudio001/lib/render
-  19     use-mobile.ts  —  apps/timeline-gstudio001/hooks
-  19     frame-count-settle.ts  —  apps/timeline-gstudio001/lib
-  19     mcp-timeline-summary.ts  —  apps/timeline-gstudio001/lib
-  18     graph-seam-lane-size.ts  —  apps/timeline-gstudio001/components/graph-view
-  18     cloudinary-provider.ts  —  apps/timeline-gstudio001/lib/assets
-  18     types.ts  —  apps/timeline-gstudio001/lib/webmcp
-  18     vitest.config.ts  —  apps/timeline-gstudio001
-  18     use-edge-autoscroll.ts  —  packages/ui/dnd-collections/react
-  18     insert-noop.ts  —  packages/ui/dnd-collections/virtual
-  17     route.ts  —  apps/timeline-gstudio001/app/.well-known/oauth-authorization-server
-  17     route.ts  —  apps/timeline-gstudio001/app/.well-known/oauth-protected-resource
-  17     trim-preview-context.ts  —  packages/ui/dnd-collections/react
-  16     graph-gateway-primer.tsx  —  apps/timeline-gstudio001/components/graph-view
-  16     auth-allowlist.ts  —  apps/timeline-gstudio001/lib
-  16     hydration-skeletons.ts  —  apps/timeline-gstudio001/lib
-  16     build-html-module.mjs  —  packages/timeline-widget
-  16     vite.config.ts  —  packages/timeline-widget
-  15     middleware-build-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
-  15     card-provenance.ts  —  apps/timeline-gstudio001/lib
-  15     use-coarse-pointer.ts  —  apps/timeline-gstudio001/lib
-  15     engine.ts  —  packages/timeline-domain/src
-  14  T  trash-document-id.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  14     hydration-target.ts  —  apps/timeline-gstudio001/lib
-  13     graph-card-frame-loading.tsx  —  apps/timeline-gstudio001/components/graph-view
-  13     types.ts  —  apps/timeline-gstudio001/lib/assets
-  12     route.ts  —  apps/timeline-gstudio001/app/api/auth/me
-  12     skeleton.tsx  —  apps/timeline-gstudio001/components/core
-  12     graph-clip-names.tsx  —  apps/timeline-gstudio001/components/graph-view
-  12     graph-seam-preview-anchor.ts  —  apps/timeline-gstudio001/components/graph-view
-  12     graph-sub-timeline-status.ts  —  apps/timeline-gstudio001/components/graph-view
-  12     disabled-visuals.ts  —  apps/timeline-gstudio001/lib
-  12     local-provider.ts  —  apps/timeline-gstudio001/lib/render
-  12     main.tsx  —  packages/timeline-widget/src
-  11     preview.ts  —  apps/storybook/.storybook
-  11     _buildManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
-  11     loading.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]
-  11     graph-seam-metrics.ts  —  apps/timeline-gstudio001/components/graph-view
-  11     sidebar-rail-preference.ts  —  apps/timeline-gstudio001/components/timeline
-  11     asset-deletion-window.ts  —  apps/timeline-gstudio001/lib
-  10     graph-details-motion.ts  —  apps/timeline-gstudio001/components/graph-view
-  10  T  graph-view-config.test.ts  —  apps/timeline-gstudio001/components/graph-view
-  10     bearer-token.ts  —  apps/timeline-gstudio001/lib
-  10     cloudinary-scrub-proxy.ts  —  apps/timeline-gstudio001/lib
-  10     index.ts  —  packages/timeline-model
-   9     route.ts  —  apps/timeline-gstudio001/app/api/auth/register
-   9     project-thumbnail.ts  —  apps/timeline-gstudio001/lib
-   9     at.ts  —  apps/timeline-gstudio001/lib/test-support
-   9     at.ts  —  packages/ui/test-support
-   9     types.ts  —  packages/ui/timeline
-   8     preview.css  —  apps/storybook/.storybook
-   8     boot-session-key.ts  —  apps/timeline-gstudio001/components/graph-view
-   7     postcss.config.mjs  —  apps/storybook
-   7     route.ts  —  apps/timeline-gstudio001/app/api/auth/logout
-   7     graph-item-details-shared.ts  —  apps/timeline-gstudio001/components/graph-view
-   7     registry.ts  —  apps/timeline-gstudio001/lib/assets
-   7     postcss.config.mjs  —  apps/timeline-gstudio001
-   6     read-json-body.ts  —  apps/timeline-gstudio001/lib
-   5     utils.ts  —  apps/timeline-gstudio001/lib
-   5     utils.ts  —  packages/ui/lib
-   4     registry.ts  —  apps/timeline-gstudio001/lib/render
-   4     gesture-thresholds.ts  —  packages/ui/dnd-collections/react
-   3     preview.css  —  apps/timeline-gstudio001/.storybook
-   3     trash-document-id.ts  —  apps/timeline-gstudio001/components/graph-view
-   3     bar-collection-colours-flag.ts  —  apps/timeline-gstudio001/lib
-   3     cloudinary-public-id.ts  —  apps/timeline-gstudio001/lib
-   3     index.ts  —  packages/db
-   3     constants.ts  —  packages/timeline-model
-   3     duration-format.ts  —  packages/ui/dnd-collections/react
-   2     es-toolkit-compat-get.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-isPlainObject.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-last.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-maxBy.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-minBy.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-omit.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-range.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-sortBy.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-sumBy.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-throttle.ts  —  apps/storybook/.storybook/shims
-   2     es-toolkit-compat-uniqBy.ts  —  apps/storybook/.storybook/shims
-   2     sidebar-collection-shortcuts-flag.ts  —  apps/timeline-gstudio001/lib
-   2     next-env.d.ts  —  apps/timeline-gstudio001
-   1     interception-route-rewrite-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
-   1     next-font-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
-   1     server-reference-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
-   1     _clientMiddlewareManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
-   1     _ssgManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
-   1     root-params.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
-   1     lane-tracks-flag.ts  —  apps/timeline-gstudio001/lib
-   1     timeline-documents.ts  —  apps/timeline-gstudio001/lib
-   1     index.ts  —  packages/timeline-widget
-   1     commands.ts  —  packages/ui/dnd-collections/core
-   1     graph.ts  —  packages/ui/dnd-collections/core
-   1     history.ts  —  packages/ui/dnd-collections/core
-   1     hydrate.ts  —  packages/ui/dnd-collections/core
-   1     index.ts  —  packages/ui/dnd-collections/core
-   1     intents.ts  —  packages/ui/dnd-collections/core
-   1     keyboard.ts  —  packages/ui/dnd-collections/core
-   1     numeric.ts  —  packages/ui/dnd-collections/core
-   1     patches.ts  —  packages/ui/dnd-collections/core
-   1     index.ts  —  packages/ui
+1829  workbench-display-surface.tsx  —  packages/ui/timeline/viewport
+1515  graph-board.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 987  VirtualStrip.tsx  —  packages/ui/dnd-collections/virtual
+ 858  graph-preview.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 820  firebase-timeline-store.ts  —  apps/timeline-gstudio001/lib
+ 760  graph-item-details-modal.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 745  graph-seam-strip-bar.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 741  DndCollections.tsx  —  packages/ui/dnd-collections/react
+ 732  graph.ts  —  packages/collections-core
+ 726  timeline-documents.ts  —  packages/ui/timeline
+ 700  timeline-sidebar.tsx  —  apps/timeline-gstudio001/components/timeline
+ 697  graph-documents-gateway.ts  —  apps/timeline-gstudio001/lib
+ 689  graph-seek-rails.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 669  adapter.ts  —  packages/timeline-domain/src
+ 653  tools.ts  —  apps/timeline-gstudio001/lib/webmcp
+ 564  graph-timeline-view.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 561  globals.css  —  apps/timeline-gstudio001/app
+ 542  route.ts  —  apps/timeline-gstudio001/app/api/mcp
+ 539  collections-store.ts  —  packages/ui/dnd-collections/react
+ 531  write-handlers.ts  —  apps/timeline-gstudio001/lib/mcp
+ 498  graph-item-actions.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 466  graph-playhead-model.ts  —  apps/timeline-gstudio001/components/graph-view
+ 462  cloudinary-media-store.ts  —  apps/timeline-gstudio001/lib
+ 449  graph-seam-lane.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 432  trash-drawer.tsx  —  apps/timeline-gstudio001/components/assets
+ 409  graph-sub-timelines.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 406  commands.ts  —  packages/collections-core
+ 367  VirtualGrid.tsx  —  packages/ui/dnd-collections/virtual
+ 359  timeline-document-store.tsx  —  packages/ui/timeline
+ 348  graph-view-chrome.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 347  page.tsx  —  apps/timeline-gstudio001/app
+ 342  use-keyboard-controller.ts  —  packages/ui/dnd-collections/react
+ 324  collection-item.tsx  —  packages/ui/dnd-collections/react
+ 319  graph-native-drop-engine.ts  —  apps/timeline-gstudio001/components/graph-view
+ 319  use-timeline-clips.ts  —  packages/ui/timeline/hooks
+ 315  node-views.tsx  —  packages/ui/dnd-collections/react
+ 286  apply-command.ts  —  apps/timeline-gstudio001/lib/mcp
+ 283  globals.css  —  apps/storybook/.storybook
+ 272  styles.css  —  packages/timeline-widget/src
+ 265  intents.ts  —  packages/collections-core
+ 265  keyboard.ts  —  packages/collections-core
+ 262  graph-collection-card.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 257  route.ts  —  apps/timeline-gstudio001/app/api/timeline-media/upload
+ 250  validator.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
+ 240  graph-clip-card.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 239  patches.ts  —  packages/collections-core
+ 238  graph-item-details-panel.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 237  graph-item-details-monitor.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 236  graph-hydration.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 236  timeline-media-client.ts  —  apps/timeline-gstudio001/lib
+ 234  trim-gesture.ts  —  packages/ui/dnd-collections/react
+ 227  graph-navigation.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 227  scene-service.ts  —  packages/db/lib
+ 226  virtual-strip-lanes.ts  —  packages/ui/dnd-collections/virtual
+ 220  upload.ts  —  apps/timeline-gstudio001/lib/mcp
+ 212  graph-grid-play-button.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 209  graph-native-drop-model.ts  —  apps/timeline-gstudio001/components/graph-view
+ 209  graph-seam-bar.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 209  graph-selection-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 207  graph-collection-details.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 201  storyboard-monster-mark.tsx  —  apps/timeline-gstudio001/components/timeline
+ 195  ffmpeg-plan.mjs  —  apps/timeline-gstudio001/scripts/render-worker
+ 195  playback-manifest.ts  —  packages/timeline-domain/src
+ 194  graph-card-derivations.ts  —  apps/timeline-gstudio001/components/graph-view
+ 193  correct-clip-aspects.mjs  —  apps/timeline-gstudio001/scripts
+ 192  graph-breadcrumb-drop.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 192  auth-service.ts  —  packages/db/lib
+ 187  index.mjs  —  apps/timeline-gstudio001/scripts/render-worker
+ 183  index.ts  —  packages/ui/dnd-collections
+ 181  graph-native-drop-grid.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 180  graph-seam-ruler.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 176  audio-graph.ts  —  packages/ui/timeline/viewport
+ 172  use-pan-with-momentum.ts  —  packages/ui/dnd-collections/react
+ 171  graph-item-action-specs.ts  —  apps/timeline-gstudio001/lib
+ 168  serve-timeline.ts  —  apps/timeline-gstudio001/lib
+ 167  sidebar-collection-shortcuts.tsx  —  apps/timeline-gstudio001/components/timeline
+ 166  graph-native-drop-strip.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 166  remove-dangling-collection-references.ts  —  apps/timeline-gstudio001/scripts
+ 165  job-store.ts  —  apps/timeline-gstudio001/lib/render
+ 164  auth-gate.tsx  —  apps/timeline-gstudio001/components/auth
+ 158  charts-bar-chart.tsx  —  .agents/skills/remotion-best-practices/rules/assets
+ 158  graph-tag-filter-control.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 154  graph-tag-editor.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 154  App.tsx  —  packages/timeline-widget/src/app
+ 151  graph-seam-minimap.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 150  route.ts  —  apps/timeline-gstudio001/app/api/oauth/token
+ 149  migrate-legacy-video-durations.mjs  —  apps/timeline-gstudio001/scripts
+ 148  trim-overview.tsx  —  packages/ui/dnd-collections/react
+ 147  documents.ts  —  packages/timeline-model
+ 146  graph-shortcuts.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 146  repair-truncated-asset-paths.mjs  —  apps/timeline-gstudio001/scripts
+ 145  dropdown-menu.tsx  —  apps/timeline-gstudio001/components/core
+ 145  attach-output.ts  —  apps/timeline-gstudio001/lib/render
+ 144  graph-anchor-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 143  virtual-strip-geometry.ts  —  packages/ui/dnd-collections/virtual
+ 140  route.ts  —  apps/timeline-gstudio001/app/api/timelines/batch
+ 140  timeline-snapshot.mjs  —  apps/timeline-gstudio001/scripts
+ 139  graph-layer-frame-picker.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 139  graph-tool-buttons.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 139  use-virtual-collection-view.tsx  —  packages/ui/dnd-collections/virtual
+ 138  route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]
+ 137  firebase-media-store.ts  —  apps/timeline-gstudio001/lib
+ 137  edge-autoscroll-coordinator.ts  —  packages/ui/dnd-collections/react
+ 134  db-client.ts  —  packages/db/lib
+ 133  graph-item-details-trim-strip.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 133  bin-unreachable-timelines.mjs  —  apps/timeline-gstudio001/scripts
+ 132  audit-review-findings.mjs  —  apps/timeline-gstudio001/scripts
+ 130  inspect-squatted-fixtures.mjs  —  apps/timeline-gstudio001/scripts
+ 130  make-dev-fixture.mjs  —  apps/timeline-gstudio001/scripts
+ 130  use-flip-graph-animation.ts  —  packages/ui/dnd-collections/react
+ 128  waveform-cache.ts  —  apps/timeline-gstudio001/lib
+ 128  find-unreachable-ui.mjs  —  scripts
+ 127  count-loc.mjs  —  scripts
+ 126  audit-orphaned-timelines.mjs  —  apps/timeline-gstudio001/scripts
+ 125  graph-render-status.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 124  validate.ts  —  packages/timeline-model
+ 123  graph-item-details-trim-fields.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 123  core.ts  —  apps/timeline-gstudio001/lib/oauth
+ 122  layer-frame.ts  —  packages/timeline-model
+ 121  graph-card-badges.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 121  graph-remote-changes.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 117  derive-collection-summaries.ts  —  apps/timeline-gstudio001/lib
+ 117  graph-view-events.ts  —  apps/timeline-gstudio001/lib
+ 116  graph-persistence.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 116  fixture-timeline-store.ts  —  apps/timeline-gstudio001/lib
+ 114  graph-item-details-header.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 113  asset-tombstones.ts  —  apps/timeline-gstudio001/lib
+ 112  graph-seam-scrub.ts  —  apps/timeline-gstudio001/components/graph-view
+ 110  use-seeked-video.ts  —  apps/timeline-gstudio001/hooks
+ 110  timeline-app-html.ts  —  packages/timeline-widget
+ 110  use-palette-drag.ts  —  packages/ui/dnd-collections/react
+ 109  timeline-tree.ts  —  apps/timeline-gstudio001/lib/webmcp
+ 109  interaction-policy.ts  —  packages/ui/dnd-collections/react
+ 107  auth-provider.tsx  —  apps/timeline-gstudio001/components/auth
+ 107  preview-time-channel.ts  —  apps/timeline-gstudio001/components/graph-view
+ 107  measure-closure-batched-vs-per-document-reads.mjs  —  apps/timeline-gstudio001/scripts
+ 107  use-announcements.ts  —  packages/ui/dnd-collections/react
+ 107  use-background-clear.ts  —  packages/ui/dnd-collections/react
+ 106  route.ts  —  apps/timeline-gstudio001/app/api/renders
+ 106  graph-seam-bar-layout.ts  —  apps/timeline-gstudio001/components/graph-view
+ 105  route.ts  —  apps/timeline-gstudio001/app/api/timeline-media
+ 105  route.ts  —  apps/timeline-gstudio001/app/api/trash
+ 103  graph-item-details-panel-header.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 103  graph-trim-panel.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 103  collections-components.tsx  —  packages/ui/dnd-collections/react
+ 101  aspect-correction.mjs  —  apps/timeline-gstudio001/scripts
+ 101  playback-skip.ts  —  packages/ui/timeline/viewport
+ 101  waveform-peaks.ts  —  packages/ui/timeline/viewport
+ 100  measure-project-query-vs-closure-walk.mjs  —  apps/timeline-gstudio001/scripts
+  99  create-collection.ts  —  apps/timeline-gstudio001/lib/mcp
+  99  render.ts  —  apps/timeline-gstudio001/lib/mcp
+  98  page.tsx  —  apps/timeline-gstudio001/app/oauth/authorize
+  98  graph-item-context-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
+  98  graph-selection-actions.tsx  —  apps/timeline-gstudio001/components/graph-view
+  98  graph-rsc-payloads.ts  —  apps/timeline-gstudio001/lib
+  98  audit-dead-asset-references.mjs  —  apps/timeline-gstudio001/scripts
+  97  route.ts  —  apps/timeline-gstudio001/app/api/timelines/import
+  97  load-timeline-closure.ts  —  apps/timeline-gstudio001/lib
+  96  view-tools.ts  —  packages/timeline-widget/src/tools
+  94  authorize-request.ts  —  apps/timeline-gstudio001/lib/oauth
+  94  node-thumbnail.tsx  —  packages/ui/dnd-collections/react
+  92  graph-card-caption.tsx  —  apps/timeline-gstudio001/components/graph-view
+  91  firebase-auth-session.ts  —  apps/timeline-gstudio001/lib
+  90  text-animations-word-highlight.tsx  —  .agents/skills/remotion-best-practices/rules/assets
+  89  text-animations-typewriter.tsx  —  .agents/skills/remotion-best-practices/rules/assets
+  89  route.ts  —  apps/timeline-gstudio001/app/api/timelines/batch-get
+  88  stamp-project-id-on-timeline-documents.mjs  —  apps/timeline-gstudio001/scripts
+  87  graph-trim-preview.tsx  —  apps/timeline-gstudio001/components/graph-view
+  86  graph-render-format.tsx  —  apps/timeline-gstudio001/components/graph-view
+  86  index.ts  —  packages/collections-core
+  86  types.ts  —  packages/timeline-model
+  85  graph-item-details-change-note.ts  —  apps/timeline-gstudio001/components/graph-view
+  83  graph-item-content.tsx  —  apps/timeline-gstudio001/components/graph-view
+  83  graph-clipboard.ts  —  apps/timeline-gstudio001/lib
+  83  prune-empty-orphans.mjs  —  apps/timeline-gstudio001/scripts
+  81  route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]/report
+  81  audit-foreign-accounts.mjs  —  apps/timeline-gstudio001/scripts
+  81  default-item-content.tsx  —  packages/ui/dnd-collections/react
+  80  history-views.tsx  —  packages/ui/dnd-collections/react
+  79  route.ts  —  apps/timeline-gstudio001/app/api/assets/reclaim
+  78  graph-item-details-history.ts  —  apps/timeline-gstudio001/components/graph-view
+  78  store.ts  —  apps/timeline-gstudio001/lib/oauth
+  78  audit-ownerless-timelines.mjs  —  apps/timeline-gstudio001/scripts
+  78  clip-display.ts  —  packages/timeline-model
+  78  utils.ts  —  packages/ui/timeline
+  77  graph-inline-rename.tsx  —  apps/timeline-gstudio001/components/graph-view
+  77  graph-seam-strip.ts  —  apps/timeline-gstudio001/components/graph-view
+  77  tag-facets.ts  —  apps/timeline-gstudio001/lib
+  77  stamp-ownerless-timelines.mjs  —  apps/timeline-gstudio001/scripts
+  77  view-state.ts  —  packages/timeline-widget/src/app
+  76  graph-card-ghost.tsx  —  apps/timeline-gstudio001/components/graph-view
+  76  graph-collection-hover.tsx  —  apps/timeline-gstudio001/components/graph-view
+  76  graph-lane-rows.ts  —  apps/timeline-gstudio001/components/graph-view
+  76  graph-details-store.ts  —  apps/timeline-gstudio001/lib
+  75  graph-save-status.tsx  —  apps/timeline-gstudio001/components/graph-view
+  75  firebase-auth-rest.ts  —  apps/timeline-gstudio001/lib
+  74  change-log.ts  —  apps/timeline-gstudio001/lib
+  74  Clip.tsx  —  packages/timeline-widget/src/components
+  73  context-menu.tsx  —  apps/timeline-gstudio001/components/core
+  73  firestore-failure.ts  —  apps/timeline-gstudio001/lib
+  73  history.ts  —  packages/collections-core
+  72  trim-handles.tsx  —  packages/ui/dnd-collections/react
+  71  graph-card-model.ts  —  apps/timeline-gstudio001/components/graph-view
+  71  firebase-admin.ts  —  apps/timeline-gstudio001/lib
+  71  offline-media-store.ts  —  apps/timeline-gstudio001/lib
+  71  cut-list.ts  —  apps/timeline-gstudio001/lib/render
+  71  job-state.ts  —  apps/timeline-gstudio001/lib/render
+  70  route.ts  —  apps/timeline-gstudio001/app/api/oauth/authorize
+  70  route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]/export
+  69  graph-card-trim.tsx  —  apps/timeline-gstudio001/components/graph-view
+  68  layout.tsx  —  apps/timeline-gstudio001/app
+  68  graph-native-drop-insertion.ts  —  apps/timeline-gstudio001/components/graph-view
+  66  graph-add-collection-slot.tsx  —  apps/timeline-gstudio001/components/graph-view
+  65  graph-details-segmented.tsx  —  apps/timeline-gstudio001/components/graph-view
+  65  graph-node-clone.ts  —  apps/timeline-gstudio001/lib
+  65  metadata.ts  —  apps/timeline-gstudio001/lib/oauth
+  65  video-frame-url.ts  —  apps/timeline-gstudio001/lib
+  64  routes.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
+  64  graph-mcp-tools.tsx  —  apps/timeline-gstudio001/components/graph-view
+  64  graph-waveform-model.ts  —  apps/timeline-gstudio001/components/graph-view
+  64  eslint.config.mjs  —  apps/timeline-gstudio001
+  63  main.ts  —  apps/storybook/.storybook
+  63  graph-native-drag-signal.ts  —  apps/timeline-gstudio001/components/graph-view
+  62  global-error.tsx  —  apps/timeline-gstudio001/app
+  61  use-dialog-focus.ts  —  apps/timeline-gstudio001/hooks
+  60  default-layer-frame.ts  —  apps/timeline-gstudio001/lib
+  60  hydrate.ts  —  packages/collections-core
+  59  graph-history-format.ts  —  apps/timeline-gstudio001/components/graph-view
+  59  client-playback-manifest.ts  —  apps/timeline-gstudio001/lib
+  59  node-dom.ts  —  packages/ui/dnd-collections/react
+  57  graph-view-loading.tsx  —  apps/timeline-gstudio001/components/graph-view
+  56  use-frame-crossfade.ts  —  apps/timeline-gstudio001/hooks
+  55  s3-provider.ts  —  apps/timeline-gstudio001/lib/assets
+  54  host.ts  —  packages/timeline-widget/src/bridge
+  53  graph-details-neighbours.ts  —  apps/timeline-gstudio001/components/graph-view
+  53  preview-card-geometry.ts  —  apps/timeline-gstudio001/components/graph-view
+  53  trash-target.tsx  —  packages/ui/dnd-collections/react
+  52  button.tsx  —  apps/timeline-gstudio001/components/core
+  51  slider.tsx  —  apps/timeline-gstudio001/components/core
+  51  graph-item-details-context.tsx  —  apps/timeline-gstudio001/components/graph-view
+  51  flat-order.ts  —  packages/timeline-domain/src
+  50  route.ts  —  apps/timeline-gstudio001/app/api/auth/login
+  50  graph-insert-placement.ts  —  apps/timeline-gstudio001/lib
+  49  route.ts  —  apps/timeline-gstudio001/app/api/assets/marked
+  49  results.ts  —  apps/timeline-gstudio001/lib/webmcp
+  49  next.config.ts  —  apps/timeline-gstudio001
+  49  live-trim.ts  —  packages/ui/dnd-collections/react
+  47  graph-project-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
+  47  placement.ts  —  packages/timeline-model
+  46  error.tsx  —  apps/timeline-gstudio001/app
+  46  load-project-button.tsx  —  apps/timeline-gstudio001/components/projects
+  46  asset-references.ts  —  apps/timeline-gstudio001/lib/assets
+  46  rate-limit.ts  —  apps/timeline-gstudio001/lib
+  45  route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest
+  45  route.ts  —  apps/timeline-gstudio001/app/api/timelines/closure
+  45  graph-details-context.tsx  —  apps/timeline-gstudio001/components/graph-view
+  45  graph-item-disable-toggle.tsx  —  apps/timeline-gstudio001/components/graph-view
+  45  sidebar-tooltip-label.tsx  —  apps/timeline-gstudio001/components/timeline
+  44  types.ts  —  apps/timeline-gstudio001/lib/render
+  44  TimelineStrip.tsx  —  packages/timeline-widget/src/views
+  43  graph-history-persistence.tsx  —  apps/timeline-gstudio001/components/graph-view
+  43  graph-playbar-thumbnails.tsx  —  apps/timeline-gstudio001/components/graph-view
+  43  load-project.ts  —  apps/timeline-gstudio001/components/projects
+  43  placement.ts  —  apps/timeline-gstudio001/lib/webmcp
+  42  webmcp-adapter.ts  —  apps/timeline-gstudio001/lib/webmcp
+  41  route.ts  —  apps/timeline-gstudio001/app/api/auth/login/complete
+  40  graph-card-measure.ts  —  apps/timeline-gstudio001/components/graph-view
+  40  graph-remote-diff.ts  —  apps/timeline-gstudio001/components/graph-view
+  40  graph-view-config.ts  —  apps/timeline-gstudio001/components/graph-view
+  40  graph-trash-discard.ts  —  apps/timeline-gstudio001/lib
+  40  provider.ts  —  apps/timeline-gstudio001/lib/render
+  39  route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]/upload-ticket
+  39  graph-paste-flash.ts  —  apps/timeline-gstudio001/lib
+  38  route.ts  —  apps/timeline-gstudio001/app/api/timelines/revisions
+  37  tag-write-plan.ts  —  apps/timeline-gstudio001/lib
+  37  render-format.ts  —  packages/timeline-model
+  37  tags.ts  —  packages/timeline-model
+  36  route.ts  —  apps/timeline-gstudio001/app/api/timelines
+  36  graph-native-drop-chrome.tsx  —  apps/timeline-gstudio001/components/graph-view
+  36  use-hover-prefetch.ts  —  apps/timeline-gstudio001/components/projects
+  36  types.ts  —  packages/timeline-widget/src
+  36  palette.tsx  —  packages/ui/dnd-collections/react
+  36  constants.ts  —  packages/ui/timeline
+  35  route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]
+  35  graph-strip-swipe.ts  —  apps/timeline-gstudio001/components/graph-view
+  35  graph-tag-filter.tsx  —  apps/timeline-gstudio001/components/graph-view
+  35  trash-groups.ts  —  apps/timeline-gstudio001/lib
+  35  index.ts  —  packages/timeline-domain
+  34  format-duration.ts  —  apps/timeline-gstudio001/lib
+  34  project-asset-scope.ts  —  apps/timeline-gstudio001/lib
+  33  preview-scroller.ts  —  apps/timeline-gstudio001/components/graph-view
+  33  collection-shortcuts.ts  —  apps/timeline-gstudio001/lib
+  33  http-range.ts  —  apps/timeline-gstudio001/lib
+  33  apply-flag.mjs  —  apps/timeline-gstudio001/scripts
+  32  route.ts  —  apps/timeline-gstudio001/app/api/renders/claim
+  32  page.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]/graph/[[...activeTimelinePath]]
+  32  graph-dropped-media.ts  —  apps/timeline-gstudio001/components/graph-view
+  32  preview-contexts.tsx  —  apps/timeline-gstudio001/components/graph-view
+  32  renders-collection.ts  —  apps/timeline-gstudio001/lib/render
+  32  tool-fields.ts  —  apps/timeline-gstudio001/lib/webmcp
+  31  read-timeline.ts  —  apps/timeline-gstudio001/lib/mcp
+  30  page.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]
+  30  caption-tag-fit.ts  —  apps/timeline-gstudio001/lib
+  30  compile-timeline-manifest.ts  —  apps/timeline-gstudio001/lib
+  29  client-graph-view.tsx  —  apps/timeline-gstudio001/components/graph-view
+  29  graph-layer-frame.ts  —  apps/timeline-gstudio001/components/graph-view
+  29  provider.ts  —  apps/timeline-gstudio001/lib/assets
+  28  timeline-ownership.ts  —  apps/timeline-gstudio001/lib
+  28  trash-provenance.ts  —  apps/timeline-gstudio001/lib
+  28  virtual-droppable.ts  —  packages/ui/dnd-collections/react
+  27  cache-life.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
+  27  graph-card-dimming.ts  —  apps/timeline-gstudio001/components/graph-view
+  27  preview-items.ts  —  packages/timeline-model
+  26  graph-pending-details.ts  —  apps/timeline-gstudio001/components/graph-view
+  26  derived-cache.ts  —  apps/timeline-gstudio001/lib
+  26  ErrorBoundary.tsx  —  packages/timeline-widget/src/app
+  26  pointer-sensors.ts  —  packages/ui/dnd-collections/react
+  25  layout.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]/graph
+  25  sidebar-icon-styles.ts  —  apps/timeline-gstudio001/components/timeline
+  24  main.ts  —  apps/timeline-gstudio001/.storybook
+  24  graph-card-placeholders.tsx  —  apps/timeline-gstudio001/components/graph-view
+  24  card-ghost-frames.ts  —  apps/timeline-gstudio001/lib
+  24  view-transition.ts  —  apps/timeline-gstudio001/lib
+  24  container-context.ts  —  packages/ui/dnd-collections/react
+  23  sonner.tsx  —  apps/timeline-gstudio001/components/core
+  23  graph-item-details-bar-reach.ts  —  apps/timeline-gstudio001/components/graph-view
+  23  press-feedback.ts  —  apps/timeline-gstudio001/components/graph-view
+  23  make-scale-probe.mjs  —  apps/timeline-gstudio001/scripts
+  23  numeric.ts  —  packages/collections-core
+  22  tag-accent-dot.tsx  —  apps/timeline-gstudio001/components/graph-view
+  21  preview.ts  —  apps/timeline-gstudio001/.storybook
+  21  render-poll.ts  —  apps/timeline-gstudio001/lib/render
+  21  edge-autoscroll-math.ts  —  packages/ui/dnd-collections/react
+  20  graph-details-design.ts  —  apps/timeline-gstudio001/components/graph-view
+  20  graph-item-details-view-count.ts  —  apps/timeline-gstudio001/components/graph-view
+  20  map-with-concurrency.ts  —  apps/timeline-gstudio001/lib
+  20  worker-request.ts  —  apps/timeline-gstudio001/lib/render
+  19  use-mobile.ts  —  apps/timeline-gstudio001/hooks
+  19  frame-count-settle.ts  —  apps/timeline-gstudio001/lib
+  19  mcp-timeline-summary.ts  —  apps/timeline-gstudio001/lib
+  18  graph-seam-lane-size.ts  —  apps/timeline-gstudio001/components/graph-view
+  18  cloudinary-provider.ts  —  apps/timeline-gstudio001/lib/assets
+  18  types.ts  —  apps/timeline-gstudio001/lib/webmcp
+  18  use-edge-autoscroll.ts  —  packages/ui/dnd-collections/react
+  18  insert-noop.ts  —  packages/ui/dnd-collections/virtual
+  17  route.ts  —  apps/timeline-gstudio001/app/.well-known/oauth-authorization-server
+  17  route.ts  —  apps/timeline-gstudio001/app/.well-known/oauth-protected-resource
+  17  trim-preview-context.ts  —  packages/ui/dnd-collections/react
+  16  graph-gateway-primer.tsx  —  apps/timeline-gstudio001/components/graph-view
+  16  auth-allowlist.ts  —  apps/timeline-gstudio001/lib
+  16  hydration-skeletons.ts  —  apps/timeline-gstudio001/lib
+  16  build-html-module.mjs  —  packages/timeline-widget
+  16  vite.config.ts  —  packages/timeline-widget
+  15  middleware-build-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
+  15  card-provenance.ts  —  apps/timeline-gstudio001/lib
+  15  use-coarse-pointer.ts  —  apps/timeline-gstudio001/lib
+  15  engine.ts  —  packages/timeline-domain/src
+  14  hydration-target.ts  —  apps/timeline-gstudio001/lib
+  13  graph-card-frame-loading.tsx  —  apps/timeline-gstudio001/components/graph-view
+  13  types.ts  —  apps/timeline-gstudio001/lib/assets
+  12  route.ts  —  apps/timeline-gstudio001/app/api/auth/me
+  12  skeleton.tsx  —  apps/timeline-gstudio001/components/core
+  12  graph-clip-names.tsx  —  apps/timeline-gstudio001/components/graph-view
+  12  graph-seam-preview-anchor.ts  —  apps/timeline-gstudio001/components/graph-view
+  12  graph-sub-timeline-status.ts  —  apps/timeline-gstudio001/components/graph-view
+  12  disabled-visuals.ts  —  apps/timeline-gstudio001/lib
+  12  local-provider.ts  —  apps/timeline-gstudio001/lib/render
+  12  main.tsx  —  packages/timeline-widget/src
+  11  preview.ts  —  apps/storybook/.storybook
+  11  _buildManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
+  11  loading.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]
+  11  graph-seam-metrics.ts  —  apps/timeline-gstudio001/components/graph-view
+  11  sidebar-rail-preference.ts  —  apps/timeline-gstudio001/components/timeline
+  11  asset-deletion-window.ts  —  apps/timeline-gstudio001/lib
+  10  graph-details-motion.ts  —  apps/timeline-gstudio001/components/graph-view
+  10  bearer-token.ts  —  apps/timeline-gstudio001/lib
+  10  cloudinary-scrub-proxy.ts  —  apps/timeline-gstudio001/lib
+  10  index.ts  —  packages/timeline-model
+   9  route.ts  —  apps/timeline-gstudio001/app/api/auth/register
+   9  project-thumbnail.ts  —  apps/timeline-gstudio001/lib
+   9  types.ts  —  packages/ui/timeline
+   8  preview.css  —  apps/storybook/.storybook
+   8  boot-session-key.ts  —  apps/timeline-gstudio001/components/graph-view
+   7  postcss.config.mjs  —  apps/storybook
+   7  route.ts  —  apps/timeline-gstudio001/app/api/auth/logout
+   7  graph-item-details-shared.ts  —  apps/timeline-gstudio001/components/graph-view
+   7  registry.ts  —  apps/timeline-gstudio001/lib/assets
+   7  postcss.config.mjs  —  apps/timeline-gstudio001
+   6  read-json-body.ts  —  apps/timeline-gstudio001/lib
+   5  utils.ts  —  apps/timeline-gstudio001/lib
+   5  utils.ts  —  packages/ui/lib
+   4  registry.ts  —  apps/timeline-gstudio001/lib/render
+   4  gesture-thresholds.ts  —  packages/ui/dnd-collections/react
+   3  preview.css  —  apps/timeline-gstudio001/.storybook
+   3  trash-document-id.ts  —  apps/timeline-gstudio001/components/graph-view
+   3  bar-collection-colours-flag.ts  —  apps/timeline-gstudio001/lib
+   3  cloudinary-public-id.ts  —  apps/timeline-gstudio001/lib
+   3  index.ts  —  packages/db
+   3  constants.ts  —  packages/timeline-model
+   3  duration-format.ts  —  packages/ui/dnd-collections/react
+   2  es-toolkit-compat-get.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-isPlainObject.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-last.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-maxBy.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-minBy.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-omit.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-range.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-sortBy.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-sumBy.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-throttle.ts  —  apps/storybook/.storybook/shims
+   2  es-toolkit-compat-uniqBy.ts  —  apps/storybook/.storybook/shims
+   2  sidebar-collection-shortcuts-flag.ts  —  apps/timeline-gstudio001/lib
+   2  next-env.d.ts  —  apps/timeline-gstudio001
+   1  interception-route-rewrite-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
+   1  next-font-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
+   1  server-reference-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
+   1  _clientMiddlewareManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
+   1  _ssgManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
+   1  root-params.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
+   1  lane-tracks-flag.ts  —  apps/timeline-gstudio001/lib
+   1  timeline-documents.ts  —  apps/timeline-gstudio001/lib
+   1  index.ts  —  packages/timeline-widget
+   1  commands.ts  —  packages/ui/dnd-collections/core
+   1  graph.ts  —  packages/ui/dnd-collections/core
+   1  history.ts  —  packages/ui/dnd-collections/core
+   1  hydrate.ts  —  packages/ui/dnd-collections/core
+   1  index.ts  —  packages/ui/dnd-collections/core
+   1  intents.ts  —  packages/ui/dnd-collections/core
+   1  keyboard.ts  —  packages/ui/dnd-collections/core
+   1  numeric.ts  —  packages/ui/dnd-collections/core
+   1  patches.ts  —  packages/ui/dnd-collections/core
+   1  index.ts  —  packages/ui
 
-623 files, 96235 lines of code
-  440 source     51768
-  183 test/story 44467   (marked T)
+432 files, 50928 lines of code
+  tests and stories excluded — pass --tests to include them

--- a/punch-list/PUNCH-LIST-15-loc.txt
+++ b/punch-list/PUNCH-LIST-15-loc.txt
@@ -1,0 +1,627 @@
+5525  T  graph-view.spec.ts  —  apps/timeline-gstudio001/tests/e2e
+2230  T  VirtualStrip.stories.tsx  —  packages/ui/dnd-collections
+2205  T  graph-item-details-modal.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
+1829     workbench-display-surface.tsx  —  packages/ui/timeline/viewport
+1515     graph-board.tsx  —  apps/timeline-gstudio001/components/graph-view
+1371  T  graph-item-content.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
+1274  T  adapter.test.ts  —  packages/timeline-domain/src
+ 987     VirtualStrip.tsx  —  packages/ui/dnd-collections/virtual
+ 973  T  commands.test.ts  —  packages/collections-core
+ 962  T  collections-store.test.ts  —  packages/ui/dnd-collections/react
+ 862  T  graph-documents-gateway.test.ts  —  apps/timeline-gstudio001/lib
+ 858     graph-preview.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 855  T  CustomItemContent.stories.tsx  —  packages/ui/dnd-collections
+ 820     firebase-timeline-store.ts  —  apps/timeline-gstudio001/lib
+ 812  T  WorkbenchSplitPane.stories.tsx  —  packages/ui/timeline/viewport
+ 796  T  DndCollections.stories.tsx  —  packages/ui/dnd-collections
+ 760     graph-item-details-modal.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 745     graph-seam-strip-bar.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 741     DndCollections.tsx  —  packages/ui/dnd-collections/react
+ 732     graph.ts  —  packages/collections-core
+ 726     timeline-documents.ts  —  packages/ui/timeline
+ 702  T  graph.test.ts  —  packages/collections-core
+ 700     timeline-sidebar.tsx  —  apps/timeline-gstudio001/components/timeline
+ 697     graph-documents-gateway.ts  —  apps/timeline-gstudio001/lib
+ 689  T  graph-playhead-model.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 689     graph-seek-rails.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 669     adapter.ts  —  packages/timeline-domain/src
+ 667  T  timelines-batch.test.ts  —  apps/timeline-gstudio001/app/api/timelines
+ 653     tools.ts  —  apps/timeline-gstudio001/lib/webmcp
+ 653  T  VirtualGrid.stories.tsx  —  packages/ui/dnd-collections
+ 633  T  dnd-collections.spec.ts  —  apps/timeline-gstudio001/tests/e2e
+ 564     graph-timeline-view.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 561     globals.css  —  apps/timeline-gstudio001/app
+ 542     route.ts  —  apps/timeline-gstudio001/app/api/mcp
+ 539     collections-store.ts  —  packages/ui/dnd-collections/react
+ 531     write-handlers.ts  —  apps/timeline-gstudio001/lib/mcp
+ 498     graph-item-actions.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 475     foobar-demo.mjs  —  apps/timeline-gstudio001/tests/demo
+ 469  T  keyboard.test.ts  —  packages/collections-core
+ 466     graph-playhead-model.ts  —  apps/timeline-gstudio001/components/graph-view
+ 462     cloudinary-media-store.ts  —  apps/timeline-gstudio001/lib
+ 449     graph-seam-lane.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 432     trash-drawer.tsx  —  apps/timeline-gstudio001/components/assets
+ 425  T  PaletteTrash.stories.tsx  —  packages/ui/dnd-collections
+ 422  T  upload.test.ts  —  apps/timeline-gstudio001/lib/mcp
+ 421  T  trash-empty.test.ts  —  apps/timeline-gstudio001/app/api/trash
+ 409     graph-sub-timelines.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 406     commands.ts  —  packages/collections-core
+ 403  T  TrimReadouts.stories.tsx  —  packages/ui/dnd-collections
+ 367     VirtualGrid.tsx  —  packages/ui/dnd-collections/virtual
+ 362  T  tools.test.ts  —  apps/timeline-gstudio001/lib/webmcp
+ 359     timeline-document-store.tsx  —  packages/ui/timeline
+ 348     graph-view-chrome.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 347     page.tsx  —  apps/timeline-gstudio001/app
+ 342  T  intents.test.ts  —  packages/collections-core
+ 342     use-keyboard-controller.ts  —  packages/ui/dnd-collections/react
+ 329  T  firebase-timeline-cascade-delete.test.ts  —  apps/timeline-gstudio001/lib
+ 328  T  ffmpeg-plan.test.ts  —  apps/timeline-gstudio001/lib/render
+ 324     collection-item.tsx  —  packages/ui/dnd-collections/react
+ 320  T  derive-collection-summaries.test.ts  —  apps/timeline-gstudio001/lib
+ 319     graph-native-drop-engine.ts  —  apps/timeline-gstudio001/components/graph-view
+ 319     use-timeline-clips.ts  —  packages/ui/timeline/hooks
+ 317  T  cut-list.test.ts  —  apps/timeline-gstudio001/lib/render
+ 315     node-views.tsx  —  packages/ui/dnd-collections/react
+ 308  T  virtual-strip-lanes.test.ts  —  packages/ui/dnd-collections/virtual
+ 300  T  graph-native-drop-model.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 286     apply-command.ts  —  apps/timeline-gstudio001/lib/mcp
+ 285  T  apply-command.test.ts  —  apps/timeline-gstudio001/lib/mcp
+ 283     globals.css  —  apps/storybook/.storybook
+ 278  T  audio-graph.test.ts  —  packages/ui/timeline/viewport
+ 277  T  timelines-authorization.test.ts  —  apps/timeline-gstudio001/app/api/timelines
+ 273  T  InteractionPolicy.stories.tsx  —  packages/ui/dnd-collections
+ 272     styles.css  —  packages/timeline-widget/src
+ 268  T  CompoundItem.stories.tsx  —  packages/ui/dnd-collections
+ 267  T  storyboard-monster-mark.stories.tsx  —  apps/timeline-gstudio001/components/timeline
+ 265     intents.ts  —  packages/collections-core
+ 265     keyboard.ts  —  packages/collections-core
+ 265  T  lane-roundtrip.test.ts  —  packages/timeline-domain/src
+ 262     graph-collection-card.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 257     route.ts  —  apps/timeline-gstudio001/app/api/timeline-media/upload
+ 252  T  playback-manifest.test.ts  —  packages/timeline-domain/src
+ 252  T  TrimGesture.stories.tsx  —  packages/ui/dnd-collections
+ 250     validator.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
+ 248  T  timelines-export-import.test.ts  —  apps/timeline-gstudio001/app/api/timelines
+ 240     graph-clip-card.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 239     patches.ts  —  packages/collections-core
+ 238     graph-item-details-panel.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 237     graph-item-details-monitor.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 237  T  graph-rsc-payloads.test.ts  —  apps/timeline-gstudio001/lib
+ 236     graph-hydration.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 236     timeline-media-client.ts  —  apps/timeline-gstudio001/lib
+ 235  T  timelines-preview-manifest.test.ts  —  apps/timeline-gstudio001/app/api/timelines
+ 234  T  graph-lane-rows.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 234     trim-gesture.ts  —  packages/ui/dnd-collections/react
+ 233  T  set-start.test.ts  —  apps/timeline-gstudio001/lib/mcp
+ 227     graph-navigation.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 227     scene-service.ts  —  packages/db/lib
+ 226  T  aspect-correction.test.ts  —  apps/timeline-gstudio001/lib
+ 226     virtual-strip-lanes.ts  —  packages/ui/dnd-collections/virtual
+ 224  T  remove-clip.test.ts  —  apps/timeline-gstudio001/lib/mcp
+ 223  T  reclaim-route.test.ts  —  apps/timeline-gstudio001/app/api/assets/reclaim
+ 220     upload.ts  —  apps/timeline-gstudio001/lib/mcp
+ 220  T  PanMomentumCoverage.stories.tsx  —  packages/ui/dnd-collections
+ 216  T  playback-skip.test.ts  —  packages/ui/timeline/viewport
+ 212     graph-grid-play-button.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 210  T  lane-manifest.test.ts  —  packages/timeline-domain/src
+ 209     graph-native-drop-model.ts  —  apps/timeline-gstudio001/components/graph-view
+ 209     graph-seam-bar.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 209     graph-selection-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 207     graph-collection-details.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 204  T  sidebar-collection-shortcuts.stories.tsx  —  apps/timeline-gstudio001/components/timeline
+ 201     storyboard-monster-mark.tsx  —  apps/timeline-gstudio001/components/timeline
+ 198  T  documents.test.ts  —  packages/timeline-model
+ 198  T  validate.test.ts  —  packages/timeline-model
+ 197  T  flat-order.test.ts  —  packages/timeline-domain/src
+ 196  T  job-store.test.ts  —  apps/timeline-gstudio001/lib/render
+ 195  T  timelines-batch-get.test.ts  —  apps/timeline-gstudio001/app/api/timelines
+ 195     ffmpeg-plan.mjs  —  apps/timeline-gstudio001/scripts/render-worker
+ 195     playback-manifest.ts  —  packages/timeline-domain/src
+ 194     graph-card-derivations.ts  —  apps/timeline-gstudio001/components/graph-view
+ 194  T  move-clip.test.ts  —  apps/timeline-gstudio001/lib/mcp
+ 193     correct-clip-aspects.mjs  —  apps/timeline-gstudio001/scripts
+ 193  T  FirstItemTrim.stories.tsx  —  packages/ui/dnd-collections
+ 192     graph-breadcrumb-drop.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 192     auth-service.ts  —  packages/db/lib
+ 190  T  cloudinary-media-store.test.ts  —  apps/timeline-gstudio001/lib
+ 187  T  graph-seam-bar-layout.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 187     index.mjs  —  apps/timeline-gstudio001/scripts/render-worker
+ 186  T  timeline-media-client.test.ts  —  apps/timeline-gstudio001/lib
+ 186  T  clip-display.test.ts  —  packages/timeline-model
+ 186  T  GestureArbitration.stories.tsx  —  packages/ui/dnd-collections
+ 183     index.ts  —  packages/ui/dnd-collections
+ 182  T  timeline-sidebar.stories.tsx  —  apps/timeline-gstudio001/components/timeline
+ 182  T  change-log.test.ts  —  apps/timeline-gstudio001/lib
+ 181     graph-native-drop-grid.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 181  T  graph-node-clone.test.ts  —  apps/timeline-gstudio001/lib
+ 180  T  graph-card-model.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 180     graph-seam-ruler.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 178  T  AlwaysOnTrimHandles.stories.tsx  —  packages/ui/dnd-collections
+ 176  T  graph-insert-placement.test.ts  —  apps/timeline-gstudio001/lib
+ 176     audio-graph.ts  —  packages/ui/timeline/viewport
+ 175  T  client-manifest-equivalence.test.ts  —  apps/timeline-gstudio001/lib
+ 175  T  layer-frame.test.ts  —  packages/timeline-model
+ 173  T  video-frame-url.test.ts  —  apps/timeline-gstudio001/lib
+ 173  T  commands.fuzz.test.ts  —  packages/collections-core
+ 173  T  TimelineStrip.stories.tsx  —  packages/timeline-widget/src/views
+ 172     use-pan-with-momentum.ts  —  packages/ui/dnd-collections/react
+ 171     graph-item-action-specs.ts  —  apps/timeline-gstudio001/lib
+ 168     serve-timeline.ts  —  apps/timeline-gstudio001/lib
+ 167     sidebar-collection-shortcuts.tsx  —  apps/timeline-gstudio001/components/timeline
+ 166     graph-native-drop-strip.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 166     remove-dangling-collection-references.ts  —  apps/timeline-gstudio001/scripts
+ 166  T  virtual-strip-geometry.test.ts  —  packages/ui/dnd-collections/virtual
+ 165     job-store.ts  —  apps/timeline-gstudio001/lib/render
+ 164     auth-gate.tsx  —  apps/timeline-gstudio001/components/auth
+ 162  T  asset-references.test.ts  —  apps/timeline-gstudio001/lib/assets
+ 158     charts-bar-chart.tsx  —  .agents/skills/remotion-best-practices/rules/assets
+ 158     graph-tag-filter-control.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 158  T  core.test.ts  —  apps/timeline-gstudio001/lib/oauth
+ 157  T  marked-route.test.ts  —  apps/timeline-gstudio001/app/api/assets/marked
+ 154  T  button.stories.tsx  —  apps/timeline-gstudio001/components/core
+ 154     graph-tag-editor.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 154     App.tsx  —  packages/timeline-widget/src/app
+ 153  T  graph-layer-frame-picker.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 152  T  route.test.ts  —  apps/timeline-gstudio001/app/api/timeline-media
+ 151     graph-seam-minimap.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 151  T  job-state.test.ts  —  apps/timeline-gstudio001/lib/render
+ 150     route.ts  —  apps/timeline-gstudio001/app/api/oauth/token
+ 149  T  graph-item-action-specs.test.ts  —  apps/timeline-gstudio001/lib
+ 149     migrate-legacy-video-durations.mjs  —  apps/timeline-gstudio001/scripts
+ 148     trim-overview.tsx  —  packages/ui/dnd-collections/react
+ 147     documents.ts  —  packages/timeline-model
+ 146     graph-shortcuts.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 146     repair-truncated-asset-paths.mjs  —  apps/timeline-gstudio001/scripts
+ 146  T  trim-gesture.test.ts  —  packages/ui/dnd-collections/react
+ 145     dropdown-menu.tsx  —  apps/timeline-gstudio001/components/core
+ 145     attach-output.ts  —  apps/timeline-gstudio001/lib/render
+ 144  T  route.test.ts  —  apps/timeline-gstudio001/app/api/timeline-media/upload
+ 144     graph-anchor-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 144  T  read-timeline.test.ts  —  apps/timeline-gstudio001/lib/mcp
+ 143  T  graph-details-store.test.ts  —  apps/timeline-gstudio001/lib
+ 143     virtual-strip-geometry.ts  —  packages/ui/dnd-collections/virtual
+ 140     route.ts  —  apps/timeline-gstudio001/app/api/timelines/batch
+ 140     timeline-snapshot.mjs  —  apps/timeline-gstudio001/scripts
+ 139     graph-layer-frame-picker.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 139     graph-tool-buttons.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 139     use-virtual-collection-view.tsx  —  packages/ui/dnd-collections/virtual
+ 138     route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]
+ 138  T  default-layer-frame.test.ts  —  apps/timeline-gstudio001/lib
+ 138  T  renders-collection.test.ts  —  apps/timeline-gstudio001/lib/render
+ 137     firebase-media-store.ts  —  apps/timeline-gstudio001/lib
+ 137     edge-autoscroll-coordinator.ts  —  packages/ui/dnd-collections/react
+ 134     db-client.ts  —  packages/db/lib
+ 133     graph-item-details-trim-strip.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 133     bin-unreachable-timelines.mjs  —  apps/timeline-gstudio001/scripts
+ 132     audit-review-findings.mjs  —  apps/timeline-gstudio001/scripts
+ 131  T  MediaThumbnails.stories.tsx  —  packages/ui/dnd-collections
+ 130  T  trash-groups.test.ts  —  apps/timeline-gstudio001/lib
+ 130  T  waveform-cache.test.ts  —  apps/timeline-gstudio001/lib
+ 130     inspect-squatted-fixtures.mjs  —  apps/timeline-gstudio001/scripts
+ 130     make-dev-fixture.mjs  —  apps/timeline-gstudio001/scripts
+ 130  T  hydrate.test.ts  —  packages/collections-core
+ 130     use-flip-graph-animation.ts  —  packages/ui/dnd-collections/react
+ 129  T  placement.test.ts  —  packages/timeline-model
+ 128     waveform-cache.ts  —  apps/timeline-gstudio001/lib
+ 128     find-unreachable-ui.mjs  —  scripts
+ 126     audit-orphaned-timelines.mjs  —  apps/timeline-gstudio001/scripts
+ 125     graph-render-status.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 125  T  use-timeline-clips.test.ts  —  packages/ui/timeline/hooks
+ 124     smoke-test.mjs  —  apps/timeline-gstudio001/scripts/render-worker
+ 124     validate.ts  —  packages/timeline-model
+ 123     graph-item-details-trim-fields.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 123     core.ts  —  apps/timeline-gstudio001/lib/oauth
+ 122     layer-frame.ts  —  packages/timeline-model
+ 121     graph-card-badges.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 121     graph-remote-changes.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 121     count-loc.mjs  —  scripts
+ 120  T  create-collection.test.ts  —  apps/timeline-gstudio001/lib/mcp
+ 120  T  waveform-peaks.test.ts  —  packages/ui/timeline/viewport
+ 117     derive-collection-summaries.ts  —  apps/timeline-gstudio001/lib
+ 117     graph-view-events.ts  —  apps/timeline-gstudio001/lib
+ 116     graph-persistence.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 116     fixture-timeline-store.ts  —  apps/timeline-gstudio001/lib
+ 114     graph-item-details-header.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 114  T  graph-seam-scrub.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 114  T  tag-facets.test.ts  —  apps/timeline-gstudio001/lib
+ 113     asset-tombstones.ts  —  apps/timeline-gstudio001/lib
+ 113  T  collection-shortcuts.test.ts  —  apps/timeline-gstudio001/lib
+ 112     graph-seam-scrub.ts  —  apps/timeline-gstudio001/components/graph-view
+ 111  T  TrimGestureUnmount.stories.tsx  —  packages/ui/dnd-collections
+ 110     use-seeked-video.ts  —  apps/timeline-gstudio001/hooks
+ 110     timeline-app-html.ts  —  packages/timeline-widget
+ 110     use-palette-drag.ts  —  packages/ui/dnd-collections/react
+ 110  T  timeline-documents.test.ts  —  packages/ui/timeline
+ 109  T  graph-history-format.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 109     timeline-tree.ts  —  apps/timeline-gstudio001/lib/webmcp
+ 109     interaction-policy.ts  —  packages/ui/dnd-collections/react
+ 108  T  fixture-timeline-store.test.ts  —  apps/timeline-gstudio001/lib
+ 107     auth-provider.tsx  —  apps/timeline-gstudio001/components/auth
+ 107     preview-time-channel.ts  —  apps/timeline-gstudio001/components/graph-view
+ 107     measure-closure-batched-vs-per-document-reads.mjs  —  apps/timeline-gstudio001/scripts
+ 107  T  CollisionCoverage.stories.tsx  —  packages/ui/dnd-collections
+ 107  T  interaction-policy.test.ts  —  packages/ui/dnd-collections/react
+ 107     use-announcements.ts  —  packages/ui/dnd-collections/react
+ 107     use-background-clear.ts  —  packages/ui/dnd-collections/react
+ 106     route.ts  —  apps/timeline-gstudio001/app/api/renders
+ 106     graph-seam-bar-layout.ts  —  apps/timeline-gstudio001/components/graph-view
+ 105     route.ts  —  apps/timeline-gstudio001/app/api/timeline-media
+ 105     route.ts  —  apps/timeline-gstudio001/app/api/trash
+ 104     stories-helpers.ts  —  packages/ui/dnd-collections
+ 103     graph-item-details-panel-header.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 103     graph-trim-panel.tsx  —  apps/timeline-gstudio001/components/graph-view
+ 103  T  graph-trash-discard.test.ts  —  apps/timeline-gstudio001/lib
+ 103     collections-components.tsx  —  packages/ui/dnd-collections/react
+ 101  T  graph-details-neighbours.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 101  T  graph-item-details-change-note.test.ts  —  apps/timeline-gstudio001/components/graph-view
+ 101     aspect-correction.mjs  —  apps/timeline-gstudio001/scripts
+ 101     playback-skip.ts  —  packages/ui/timeline/viewport
+ 101     waveform-peaks.ts  —  packages/ui/timeline/viewport
+ 100     measure-project-query-vs-closure-walk.mjs  —  apps/timeline-gstudio001/scripts
+ 100  T  replay-guard.test.ts  —  packages/collections-core
+ 100  T  preview-items.test.ts  —  packages/timeline-model
+  99     create-collection.ts  —  apps/timeline-gstudio001/lib/mcp
+  99     render.ts  —  apps/timeline-gstudio001/lib/mcp
+  99  T  view-state.test.ts  —  packages/timeline-widget/src/app
+  98     page.tsx  —  apps/timeline-gstudio001/app/oauth/authorize
+  98     graph-item-context-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
+  98     graph-selection-actions.tsx  —  apps/timeline-gstudio001/components/graph-view
+  98     graph-rsc-payloads.ts  —  apps/timeline-gstudio001/lib
+  98     audit-dead-asset-references.mjs  —  apps/timeline-gstudio001/scripts
+  97     route.ts  —  apps/timeline-gstudio001/app/api/timelines/import
+  97  T  graph-seam-strip.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  97     load-timeline-closure.ts  —  apps/timeline-gstudio001/lib
+  97  T  patches.test.ts  —  packages/collections-core
+  96  T  preview-time-channel.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  96     view-tools.ts  —  packages/timeline-widget/src/tools
+  94     authorize-request.ts  —  apps/timeline-gstudio001/lib/oauth
+  94     node-thumbnail.tsx  —  packages/ui/dnd-collections/react
+  93  T  history.test.ts  —  packages/collections-core
+  92     graph-card-caption.tsx  —  apps/timeline-gstudio001/components/graph-view
+  92  T  authorize-request.test.ts  —  apps/timeline-gstudio001/lib/oauth
+  91     firebase-auth-session.ts  —  apps/timeline-gstudio001/lib
+  90     text-animations-word-highlight.tsx  —  .agents/skills/remotion-best-practices/rules/assets
+  89     text-animations-typewriter.tsx  —  .agents/skills/remotion-best-practices/rules/assets
+  89     route.ts  —  apps/timeline-gstudio001/app/api/timelines/batch-get
+  89  T  firestore-failure.test.ts  —  apps/timeline-gstudio001/lib
+  88  T  http-range.test.ts  —  apps/timeline-gstudio001/lib
+  88     stamp-project-id-on-timeline-documents.mjs  —  apps/timeline-gstudio001/scripts
+  87     graph-trim-preview.tsx  —  apps/timeline-gstudio001/components/graph-view
+  87  T  project-thumbnail.test.ts  —  apps/timeline-gstudio001/lib
+  86     graph-render-format.tsx  —  apps/timeline-gstudio001/components/graph-view
+  86  T  tag-write-plan.test.ts  —  apps/timeline-gstudio001/lib
+  86     index.ts  —  packages/collections-core
+  86     types.ts  —  packages/timeline-model
+  85     graph-item-details-change-note.ts  —  apps/timeline-gstudio001/components/graph-view
+  85  T  graph-layer-frame.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  84  T  graph-render-format.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
+  84  T  offline-media-store.test.ts  —  apps/timeline-gstudio001/lib
+  84  T  RovingFocusReorder.stories.tsx  —  packages/ui/dnd-collections
+  83     graph-item-content.tsx  —  apps/timeline-gstudio001/components/graph-view
+  83     graph-clipboard.ts  —  apps/timeline-gstudio001/lib
+  83     prune-empty-orphans.mjs  —  apps/timeline-gstudio001/scripts
+  83  T  render-format.test.ts  —  packages/timeline-model
+  82  T  NodeDomCoverage.stories.tsx  —  packages/ui/dnd-collections
+  81     route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]/report
+  81     audit-foreign-accounts.mjs  —  apps/timeline-gstudio001/scripts
+  81  T  tags-roundtrip.test.ts  —  packages/timeline-domain/src
+  81     default-item-content.tsx  —  packages/ui/dnd-collections/react
+  80     history-views.tsx  —  packages/ui/dnd-collections/react
+  79     route.ts  —  apps/timeline-gstudio001/app/api/assets/reclaim
+  79  T  move-cost.test.ts  —  packages/collections-core
+  78     graph-item-details-history.ts  —  apps/timeline-gstudio001/components/graph-view
+  78  T  metadata.test.ts  —  apps/timeline-gstudio001/lib/oauth
+  78     store.ts  —  apps/timeline-gstudio001/lib/oauth
+  78     audit-ownerless-timelines.mjs  —  apps/timeline-gstudio001/scripts
+  78     clip-display.ts  —  packages/timeline-model
+  78     utils.ts  —  packages/ui/timeline
+  77     graph-inline-rename.tsx  —  apps/timeline-gstudio001/components/graph-view
+  77  T  graph-remote-diff.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  77     graph-seam-strip.ts  —  apps/timeline-gstudio001/components/graph-view
+  77     tag-facets.ts  —  apps/timeline-gstudio001/lib
+  77     stamp-ownerless-timelines.mjs  —  apps/timeline-gstudio001/scripts
+  77     view-state.ts  —  packages/timeline-widget/src/app
+  76     graph-card-ghost.tsx  —  apps/timeline-gstudio001/components/graph-view
+  76     graph-collection-hover.tsx  —  apps/timeline-gstudio001/components/graph-view
+  76     graph-lane-rows.ts  —  apps/timeline-gstudio001/components/graph-view
+  76  T  graph-tool-buttons.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
+  76     graph-details-store.ts  —  apps/timeline-gstudio001/lib
+  76  T  placement.test.ts  —  apps/timeline-gstudio001/lib/webmcp
+  75     graph-save-status.tsx  —  apps/timeline-gstudio001/components/graph-view
+  75  T  use-hover-prefetch.test.ts  —  apps/timeline-gstudio001/components/projects
+  75     firebase-auth-rest.ts  —  apps/timeline-gstudio001/lib
+  75  T  timeline-tree.test.ts  —  apps/timeline-gstudio001/lib/webmcp
+  74     change-log.ts  —  apps/timeline-gstudio001/lib
+  74  T  webmcp-adapter.test.ts  —  apps/timeline-gstudio001/lib/webmcp
+  74     Clip.tsx  —  packages/timeline-widget/src/components
+  73     context-menu.tsx  —  apps/timeline-gstudio001/components/core
+  73     firestore-failure.ts  —  apps/timeline-gstudio001/lib
+  73  T  graph-clipboard.test.ts  —  apps/timeline-gstudio001/lib
+  73     history.ts  —  packages/collections-core
+  72  T  card-ghost-frames.test.ts  —  apps/timeline-gstudio001/lib
+  72  T  KeyboardDuringDrag.stories.tsx  —  packages/ui/dnd-collections
+  72     trim-handles.tsx  —  packages/ui/dnd-collections/react
+  71     graph-card-model.ts  —  apps/timeline-gstudio001/components/graph-view
+  71     firebase-admin.ts  —  apps/timeline-gstudio001/lib
+  71     offline-media-store.ts  —  apps/timeline-gstudio001/lib
+  71     cut-list.ts  —  apps/timeline-gstudio001/lib/render
+  71     job-state.ts  —  apps/timeline-gstudio001/lib/render
+  71  T  tags.test.ts  —  packages/timeline-model
+  70     route.ts  —  apps/timeline-gstudio001/app/api/oauth/authorize
+  70     route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]/export
+  70  T  preview-card-geometry.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  70  T  s3-provider.test.ts  —  apps/timeline-gstudio001/lib/assets
+  70  T  card-provenance.test.ts  —  apps/timeline-gstudio001/lib
+  69     graph-card-trim.tsx  —  apps/timeline-gstudio001/components/graph-view
+  68     layout.tsx  —  apps/timeline-gstudio001/app
+  68     graph-native-drop-insertion.ts  —  apps/timeline-gstudio001/components/graph-view
+  67  T  mcp-timeline-summary.test.ts  —  apps/timeline-gstudio001/lib
+  66     graph-add-collection-slot.tsx  —  apps/timeline-gstudio001/components/graph-view
+  66  T  render-poll.test.ts  —  apps/timeline-gstudio001/lib/render
+  65     graph-details-segmented.tsx  —  apps/timeline-gstudio001/components/graph-view
+  65     graph-node-clone.ts  —  apps/timeline-gstudio001/lib
+  65  T  hydration-skeletons.test.ts  —  apps/timeline-gstudio001/lib
+  65     metadata.ts  —  apps/timeline-gstudio001/lib/oauth
+  65  T  provider.test.ts  —  apps/timeline-gstudio001/lib/render
+  65     video-frame-url.ts  —  apps/timeline-gstudio001/lib
+  64     routes.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
+  64  T  graph-item-details-bar-reach.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  64     graph-mcp-tools.tsx  —  apps/timeline-gstudio001/components/graph-view
+  64     graph-waveform-model.ts  —  apps/timeline-gstudio001/components/graph-view
+  64     eslint.config.mjs  —  apps/timeline-gstudio001
+  64  T  map-with-concurrency.test.ts  —  apps/timeline-gstudio001/lib
+  63     main.ts  —  apps/storybook/.storybook
+  63     vitest.config.ts  —  apps/storybook
+  63     graph-native-drag-signal.ts  —  apps/timeline-gstudio001/components/graph-view
+  62     global-error.tsx  —  apps/timeline-gstudio001/app
+  62  T  role-roundtrip.test.ts  —  packages/timeline-domain/src
+  61     use-dialog-focus.ts  —  apps/timeline-gstudio001/hooks
+  60     default-layer-frame.ts  —  apps/timeline-gstudio001/lib
+  60     hydrate.ts  —  packages/collections-core
+  59     graph-history-format.ts  —  apps/timeline-gstudio001/components/graph-view
+  59     client-playback-manifest.ts  —  apps/timeline-gstudio001/lib
+  59     node-dom.ts  —  packages/ui/dnd-collections/react
+  58  T  auth-allowlist.test.ts  —  apps/timeline-gstudio001/lib
+  57     graph-view-loading.tsx  —  apps/timeline-gstudio001/components/graph-view
+  57  T  load-project-button.stories.tsx  —  apps/timeline-gstudio001/components/projects
+  57  T  derived-cache.test.ts  —  apps/timeline-gstudio001/lib
+  57  T  tool-fields.test.ts  —  apps/timeline-gstudio001/lib/webmcp
+  56     use-frame-crossfade.ts  —  apps/timeline-gstudio001/hooks
+  55     s3-provider.ts  —  apps/timeline-gstudio001/lib/assets
+  55  T  frame-override.test.ts  —  packages/ui/timeline/viewport
+  54     host.ts  —  packages/timeline-widget/src/bridge
+  53     graph-details-neighbours.ts  —  apps/timeline-gstudio001/components/graph-view
+  53     preview-card-geometry.ts  —  apps/timeline-gstudio001/components/graph-view
+  53     trash-target.tsx  —  packages/ui/dnd-collections/react
+  52     button.tsx  —  apps/timeline-gstudio001/components/core
+  51     slider.tsx  —  apps/timeline-gstudio001/components/core
+  51     graph-item-details-context.tsx  —  apps/timeline-gstudio001/components/graph-view
+  51  T  sidebar-icon-styles.test.ts  —  apps/timeline-gstudio001/components/timeline
+  51  T  project-asset-scope.test.ts  —  apps/timeline-gstudio001/lib
+  51     flat-order.ts  —  packages/timeline-domain/src
+  50     route.ts  —  apps/timeline-gstudio001/app/api/auth/login
+  50     graph-insert-placement.ts  —  apps/timeline-gstudio001/lib
+  49     route.ts  —  apps/timeline-gstudio001/app/api/assets/marked
+  49  T  graph-strip-swipe.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  49     results.ts  —  apps/timeline-gstudio001/lib/webmcp
+  49     next.config.ts  —  apps/timeline-gstudio001
+  49     live-trim.ts  —  packages/ui/dnd-collections/react
+  47     graph-project-menu.tsx  —  apps/timeline-gstudio001/components/graph-view
+  47  T  trash-provenance.test.ts  —  apps/timeline-gstudio001/lib
+  47     placement.ts  —  packages/timeline-model
+  46     error.tsx  —  apps/timeline-gstudio001/app
+  46     load-project-button.tsx  —  apps/timeline-gstudio001/components/projects
+  46     asset-references.ts  —  apps/timeline-gstudio001/lib/assets
+  46     rate-limit.ts  —  apps/timeline-gstudio001/lib
+  45     route.ts  —  apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest
+  45     route.ts  —  apps/timeline-gstudio001/app/api/timelines/closure
+  45     graph-details-context.tsx  —  apps/timeline-gstudio001/components/graph-view
+  45     graph-item-disable-toggle.tsx  —  apps/timeline-gstudio001/components/graph-view
+  45     sidebar-tooltip-label.tsx  —  apps/timeline-gstudio001/components/timeline
+  45  T  edge-autoscroll-math.test.ts  —  packages/ui/dnd-collections/react
+  44     types.ts  —  apps/timeline-gstudio001/lib/render
+  44     playwright.config.ts  —  apps/timeline-gstudio001
+  44  T  numeric.test.ts  —  packages/collections-core
+  44     TimelineStrip.tsx  —  packages/timeline-widget/src/views
+  43     graph-history-persistence.tsx  —  apps/timeline-gstudio001/components/graph-view
+  43     graph-playbar-thumbnails.tsx  —  apps/timeline-gstudio001/components/graph-view
+  43     load-project.ts  —  apps/timeline-gstudio001/components/projects
+  43     placement.ts  —  apps/timeline-gstudio001/lib/webmcp
+  42  T  cloudinary-provider.test.ts  —  apps/timeline-gstudio001/lib/assets
+  42  T  caption-tag-fit.test.ts  —  apps/timeline-gstudio001/lib
+  42     webmcp-adapter.ts  —  apps/timeline-gstudio001/lib/webmcp
+  42  T  edge-autoscroll-coordinator.test.ts  —  packages/ui/dnd-collections/react
+  41     route.ts  —  apps/timeline-gstudio001/app/api/auth/login/complete
+  40     graph-card-measure.ts  —  apps/timeline-gstudio001/components/graph-view
+  40     graph-remote-diff.ts  —  apps/timeline-gstudio001/components/graph-view
+  40     graph-view-config.ts  —  apps/timeline-gstudio001/components/graph-view
+  40     graph-trash-discard.ts  —  apps/timeline-gstudio001/lib
+  40     provider.ts  —  apps/timeline-gstudio001/lib/render
+  40  T  insert-noop.test.ts  —  packages/ui/dnd-collections/virtual
+  39     route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]/upload-ticket
+  39     graph-paste-flash.ts  —  apps/timeline-gstudio001/lib
+  38     route.ts  —  apps/timeline-gstudio001/app/api/timelines/revisions
+  37  T  sidebar-rail-preference.test.ts  —  apps/timeline-gstudio001/components/timeline
+  37     tag-write-plan.ts  —  apps/timeline-gstudio001/lib
+  37     render-format.ts  —  packages/timeline-model
+  37     tags.ts  —  packages/timeline-model
+  36     route.ts  —  apps/timeline-gstudio001/app/api/timelines
+  36     graph-native-drop-chrome.tsx  —  apps/timeline-gstudio001/components/graph-view
+  36     use-hover-prefetch.ts  —  apps/timeline-gstudio001/components/projects
+  36     types.ts  —  packages/timeline-widget/src
+  36     palette.tsx  —  packages/ui/dnd-collections/react
+  36     constants.ts  —  packages/ui/timeline
+  35     route.ts  —  apps/timeline-gstudio001/app/api/renders/[id]
+  35     graph-strip-swipe.ts  —  apps/timeline-gstudio001/components/graph-view
+  35     graph-tag-filter.tsx  —  apps/timeline-gstudio001/components/graph-view
+  35  T  timeline-ownership.test.ts  —  apps/timeline-gstudio001/lib
+  35     trash-groups.ts  —  apps/timeline-gstudio001/lib
+  35     index.ts  —  packages/timeline-domain
+  35  T  audio-roundtrip.test.ts  —  packages/timeline-domain/src
+  34  T  graph-dropped-media.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  34     format-duration.ts  —  apps/timeline-gstudio001/lib
+  34  T  hydration-target.test.ts  —  apps/timeline-gstudio001/lib
+  34     project-asset-scope.ts  —  apps/timeline-gstudio001/lib
+  34  T  results.test.ts  —  apps/timeline-gstudio001/lib/webmcp
+  34  T  utils.test.ts  —  packages/ui/timeline
+  33     preview-scroller.ts  —  apps/timeline-gstudio001/components/graph-view
+  33     collection-shortcuts.ts  —  apps/timeline-gstudio001/lib
+  33  T  frame-count-settle.test.ts  —  apps/timeline-gstudio001/lib
+  33     http-range.ts  —  apps/timeline-gstudio001/lib
+  33     apply-flag.mjs  —  apps/timeline-gstudio001/scripts
+  32     route.ts  —  apps/timeline-gstudio001/app/api/renders/claim
+  32     page.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]/graph/[[...activeTimelinePath]]
+  32     graph-dropped-media.ts  —  apps/timeline-gstudio001/components/graph-view
+  32  T  graph-project-menu.stories.tsx  —  apps/timeline-gstudio001/components/graph-view
+  32  T  graph-sub-timeline-status.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  32     preview-contexts.tsx  —  apps/timeline-gstudio001/components/graph-view
+  32     renders-collection.ts  —  apps/timeline-gstudio001/lib/render
+  32     tool-fields.ts  —  apps/timeline-gstudio001/lib/webmcp
+  31  T  cloudinary-scrub-proxy.test.ts  —  apps/timeline-gstudio001/lib
+  31     read-timeline.ts  —  apps/timeline-gstudio001/lib/mcp
+  31  T  aspect.test.ts  —  packages/timeline-model
+  30     page.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]
+  30     caption-tag-fit.ts  —  apps/timeline-gstudio001/lib
+  30     compile-timeline-manifest.ts  —  apps/timeline-gstudio001/lib
+  29     client-graph-view.tsx  —  apps/timeline-gstudio001/components/graph-view
+  29     graph-layer-frame.ts  —  apps/timeline-gstudio001/components/graph-view
+  29     provider.ts  —  apps/timeline-gstudio001/lib/assets
+  28  T  asset-deletion-window.test.ts  —  apps/timeline-gstudio001/lib
+  28     timeline-ownership.ts  —  apps/timeline-gstudio001/lib
+  28     trash-provenance.ts  —  apps/timeline-gstudio001/lib
+  28     virtual-droppable.ts  —  packages/ui/dnd-collections/react
+  27     cache-life.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
+  27  T  boot-session-key.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  27     graph-card-dimming.ts  —  apps/timeline-gstudio001/components/graph-view
+  27  T  disabled-visuals.test.ts  —  apps/timeline-gstudio001/lib
+  27     preview-items.ts  —  packages/timeline-model
+  26     graph-pending-details.ts  —  apps/timeline-gstudio001/components/graph-view
+  26     derived-cache.ts  —  apps/timeline-gstudio001/lib
+  26     ErrorBoundary.tsx  —  packages/timeline-widget/src/app
+  26     pointer-sensors.ts  —  packages/ui/dnd-collections/react
+  25     layout.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]/graph
+  25     sidebar-icon-styles.ts  —  apps/timeline-gstudio001/components/timeline
+  25  T  provider.test.ts  —  apps/timeline-gstudio001/lib/assets
+  25  T  cloudinary-public-id.test.ts  —  apps/timeline-gstudio001/lib
+  24     main.ts  —  apps/timeline-gstudio001/.storybook
+  24     graph-card-placeholders.tsx  —  apps/timeline-gstudio001/components/graph-view
+  24     card-ghost-frames.ts  —  apps/timeline-gstudio001/lib
+  24     view-transition.ts  —  apps/timeline-gstudio001/lib
+  24     container-context.ts  —  packages/ui/dnd-collections/react
+  23     sonner.tsx  —  apps/timeline-gstudio001/components/core
+  23     graph-item-details-bar-reach.ts  —  apps/timeline-gstudio001/components/graph-view
+  23     press-feedback.ts  —  apps/timeline-gstudio001/components/graph-view
+  23     make-scale-probe.mjs  —  apps/timeline-gstudio001/scripts
+  23     numeric.ts  —  packages/collections-core
+  22     tag-accent-dot.tsx  —  apps/timeline-gstudio001/components/graph-view
+  21     preview.ts  —  apps/timeline-gstudio001/.storybook
+  21     render-poll.ts  —  apps/timeline-gstudio001/lib/render
+  21     edge-autoscroll-math.ts  —  packages/ui/dnd-collections/react
+  20     graph-details-design.ts  —  apps/timeline-gstudio001/components/graph-view
+  20     graph-item-details-view-count.ts  —  apps/timeline-gstudio001/components/graph-view
+  20     map-with-concurrency.ts  —  apps/timeline-gstudio001/lib
+  20     worker-request.ts  —  apps/timeline-gstudio001/lib/render
+  19     use-mobile.ts  —  apps/timeline-gstudio001/hooks
+  19     frame-count-settle.ts  —  apps/timeline-gstudio001/lib
+  19     mcp-timeline-summary.ts  —  apps/timeline-gstudio001/lib
+  18     graph-seam-lane-size.ts  —  apps/timeline-gstudio001/components/graph-view
+  18     cloudinary-provider.ts  —  apps/timeline-gstudio001/lib/assets
+  18     types.ts  —  apps/timeline-gstudio001/lib/webmcp
+  18     vitest.config.ts  —  apps/timeline-gstudio001
+  18     use-edge-autoscroll.ts  —  packages/ui/dnd-collections/react
+  18     insert-noop.ts  —  packages/ui/dnd-collections/virtual
+  17     route.ts  —  apps/timeline-gstudio001/app/.well-known/oauth-authorization-server
+  17     route.ts  —  apps/timeline-gstudio001/app/.well-known/oauth-protected-resource
+  17     trim-preview-context.ts  —  packages/ui/dnd-collections/react
+  16     graph-gateway-primer.tsx  —  apps/timeline-gstudio001/components/graph-view
+  16     auth-allowlist.ts  —  apps/timeline-gstudio001/lib
+  16     hydration-skeletons.ts  —  apps/timeline-gstudio001/lib
+  16     build-html-module.mjs  —  packages/timeline-widget
+  16     vite.config.ts  —  packages/timeline-widget
+  15     middleware-build-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
+  15     card-provenance.ts  —  apps/timeline-gstudio001/lib
+  15     use-coarse-pointer.ts  —  apps/timeline-gstudio001/lib
+  15     engine.ts  —  packages/timeline-domain/src
+  14  T  trash-document-id.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  14     hydration-target.ts  —  apps/timeline-gstudio001/lib
+  13     graph-card-frame-loading.tsx  —  apps/timeline-gstudio001/components/graph-view
+  13     types.ts  —  apps/timeline-gstudio001/lib/assets
+  12     route.ts  —  apps/timeline-gstudio001/app/api/auth/me
+  12     skeleton.tsx  —  apps/timeline-gstudio001/components/core
+  12     graph-clip-names.tsx  —  apps/timeline-gstudio001/components/graph-view
+  12     graph-seam-preview-anchor.ts  —  apps/timeline-gstudio001/components/graph-view
+  12     graph-sub-timeline-status.ts  —  apps/timeline-gstudio001/components/graph-view
+  12     disabled-visuals.ts  —  apps/timeline-gstudio001/lib
+  12     local-provider.ts  —  apps/timeline-gstudio001/lib/render
+  12     main.tsx  —  packages/timeline-widget/src
+  11     preview.ts  —  apps/storybook/.storybook
+  11     _buildManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
+  11     loading.tsx  —  apps/timeline-gstudio001/app/timeline/[timelineId]
+  11     graph-seam-metrics.ts  —  apps/timeline-gstudio001/components/graph-view
+  11     sidebar-rail-preference.ts  —  apps/timeline-gstudio001/components/timeline
+  11     asset-deletion-window.ts  —  apps/timeline-gstudio001/lib
+  10     graph-details-motion.ts  —  apps/timeline-gstudio001/components/graph-view
+  10  T  graph-view-config.test.ts  —  apps/timeline-gstudio001/components/graph-view
+  10     bearer-token.ts  —  apps/timeline-gstudio001/lib
+  10     cloudinary-scrub-proxy.ts  —  apps/timeline-gstudio001/lib
+  10     index.ts  —  packages/timeline-model
+   9     route.ts  —  apps/timeline-gstudio001/app/api/auth/register
+   9     project-thumbnail.ts  —  apps/timeline-gstudio001/lib
+   9     at.ts  —  apps/timeline-gstudio001/lib/test-support
+   9     at.ts  —  packages/ui/test-support
+   9     types.ts  —  packages/ui/timeline
+   8     preview.css  —  apps/storybook/.storybook
+   8     boot-session-key.ts  —  apps/timeline-gstudio001/components/graph-view
+   7     postcss.config.mjs  —  apps/storybook
+   7     route.ts  —  apps/timeline-gstudio001/app/api/auth/logout
+   7     graph-item-details-shared.ts  —  apps/timeline-gstudio001/components/graph-view
+   7     registry.ts  —  apps/timeline-gstudio001/lib/assets
+   7     postcss.config.mjs  —  apps/timeline-gstudio001
+   6     read-json-body.ts  —  apps/timeline-gstudio001/lib
+   5     utils.ts  —  apps/timeline-gstudio001/lib
+   5     utils.ts  —  packages/ui/lib
+   4     registry.ts  —  apps/timeline-gstudio001/lib/render
+   4     gesture-thresholds.ts  —  packages/ui/dnd-collections/react
+   3     preview.css  —  apps/timeline-gstudio001/.storybook
+   3     trash-document-id.ts  —  apps/timeline-gstudio001/components/graph-view
+   3     bar-collection-colours-flag.ts  —  apps/timeline-gstudio001/lib
+   3     cloudinary-public-id.ts  —  apps/timeline-gstudio001/lib
+   3     index.ts  —  packages/db
+   3     constants.ts  —  packages/timeline-model
+   3     duration-format.ts  —  packages/ui/dnd-collections/react
+   2     es-toolkit-compat-get.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-isPlainObject.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-last.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-maxBy.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-minBy.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-omit.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-range.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-sortBy.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-sumBy.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-throttle.ts  —  apps/storybook/.storybook/shims
+   2     es-toolkit-compat-uniqBy.ts  —  apps/storybook/.storybook/shims
+   2     sidebar-collection-shortcuts-flag.ts  —  apps/timeline-gstudio001/lib
+   2     next-env.d.ts  —  apps/timeline-gstudio001
+   1     interception-route-rewrite-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
+   1     next-font-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
+   1     server-reference-manifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/server
+   1     _clientMiddlewareManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
+   1     _ssgManifest.js  —  apps/timeline-gstudio001/.next-turbo-probe/dev/static/development
+   1     root-params.d.ts  —  apps/timeline-gstudio001/.next-turbo-probe/dev/types
+   1     lane-tracks-flag.ts  —  apps/timeline-gstudio001/lib
+   1     timeline-documents.ts  —  apps/timeline-gstudio001/lib
+   1     index.ts  —  packages/timeline-widget
+   1     commands.ts  —  packages/ui/dnd-collections/core
+   1     graph.ts  —  packages/ui/dnd-collections/core
+   1     history.ts  —  packages/ui/dnd-collections/core
+   1     hydrate.ts  —  packages/ui/dnd-collections/core
+   1     index.ts  —  packages/ui/dnd-collections/core
+   1     intents.ts  —  packages/ui/dnd-collections/core
+   1     keyboard.ts  —  packages/ui/dnd-collections/core
+   1     numeric.ts  —  packages/ui/dnd-collections/core
+   1     patches.ts  —  packages/ui/dnd-collections/core
+   1     index.ts  —  packages/ui
+
+623 files, 96235 lines of code
+  440 source     51768
+  183 test/story 44467   (marked T)

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -437,7 +437,9 @@ puts the slider back roughly where the whole control lives today.
 
 ## PL15-009 — Remove the paired-card jiggle
 
-- Status: Not started
+- Status: Complete — the jiggle is gone; the pairing signal is now the STATIC
+  glow that already existed for reduced-motion users. Say if you wanted the
+  signal gone entirely and it is a one-line follow-up.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (children timelines shown, hover a child row's folder)
 - Area: `app/globals.css` (`collection-paired-callout`),

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1450,3 +1450,45 @@ screen. The clamp reserves exactly the stop's own room
 (`CAP_WIDTH_PX + CAP_GAP_PX`), which is why that constant had to be exported
 rather than guessed at here.
 
+## PL15-026 — The subject's blue runs past the film to the minimap
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details)
+- Area: `components/graph-view/graph-seam-ruler.tsx`
+  (`RULER_BLOCK_ACTIVE_COLOUR`),
+  `components/graph-view/graph-seam-strip-bar.tsx`
+- Screenshot: Supplied by the owner
+
+The ruler tints the active clip's stretch of scale sky — "the one thing in
+this band with a hue", and the only saturated thing up there, which is what
+makes it findable on a bar of two dozen blocks. It stopped at the ruler's own
+band, so the clip being worked on was marked ABOVE the film and nowhere else.
+
+The block continues downward now: through the film and into the space before
+the minimap, so the subject reads as a COLUMN rather than as a tab sitting over
+it.
+
+Acceptance criteria:
+
+- The active clip's tint runs from the ruler to the minimap, at the clip's own
+  width.
+- It travels with the film — panning moves it with the boxes.
+- It paints BEHIND the frames rather than washing them.
+- It takes no pointer: the lane owns every gesture on this track.
+
+**The same constant, not a matched value.** The column reads
+`RULER_BLOCK_ACTIVE_COLOUR` from the ruler rather than restating
+`rgba(56, 189, 248, 0.30)`. Two ends of one band that drifted apart would be
+worse than no band at all, which is why the ruler's constant is exported.
+
+**There was no space below the film to fill.** `bottom: 0` inside the track put
+the column flush with the frames — measured, the lane ends exactly where the
+track ends, so the gap this item is about belongs to the MINIMAP's top margin,
+not to the track. The column overhangs by that margin.
+
+**Two numbers that must agree, and only one can live here.** The overhang is a
+number in the bar; the gap is `mt-1.5` on the minimap's own root. Nothing
+connects them, so `MINIMAP_GAP_PX` is named and says so — the failure if they
+drift is a column that stops short of the map or runs into it.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -495,7 +495,10 @@ fail as a locator that never resolves.
 
 ## PL15-010 — The whole child-timeline row opens it, not just the folder
 
-- Status: Not started
+- Status: Complete — the NAME is excluded (a rename's first click would
+  otherwise expand the row and fire its hydration fetch); everything else in
+  the header toggles. Hover moved with the click, so the card call-out lights
+  from the same region that opens the row.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (children timelines shown)
 - Area: `components/graph-view/graph-sub-timelines.tsx`
@@ -542,7 +545,10 @@ open it from another.
 
 ## PL15-011 — The child row's thumbnail mirrors a real collection card
 
-- Status: Not started
+- Status: Complete — the audio placeholder was carried across too, so a
+  voice-takes collection no longer reads as empty in the tree and as audio on
+  the board. The border is a RING: a border would have widened the box and
+  pushed it off the column the negative margin exists to hold.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (children timelines shown — the thumbnail at the far right of a row header)
 - Area: `components/graph-view/graph-sub-timelines.tsx`

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1242,3 +1242,36 @@ Acceptance criteria:
   whatever is in it.
 - Clock notation and tenths are unchanged.
 
+## PL15-022 — The film strip can be drawn taller
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details — the gear menu's `size` group)
+- Area: `components/graph-view/graph-seam-lane-size.ts` (new),
+  `graph-seam-lane.tsx`, `graph-seam-strip-bar.tsx`,
+  `graph-item-details-modal.tsx`
+- Screenshot: Not captured
+
+The bar's film was one fixed height. It gets a `SM · MD · LG` picker, in the
+gear with the other settings — a posture you set and then work, which is the
+same test that put frames, card and fit there (PL15-006).
+
+`sm` is the height the bar has always drawn (48px), so nothing changes until
+the control is used. `md` is 64 and `lg` is 88.
+
+Acceptance criteria:
+
+- The picker sits in the gear menu, labelled `size`.
+- The film redraws at the chosen height; the hover card still hangs below it
+  rather than climbing into it.
+- The choice is remembered for the session and not persisted, like the reach
+  and the view count.
+
+**A CELL IS SQUARE, so this is not only a size.** `FILMSTRIP_CELL_PX` was the
+lane height, and the number of frames a clip's box is cut into is its width
+divided by that — so a taller film is a COARSER filmstrip as well as a bigger
+one. That is the actual trade, and it is why three sizes are offered rather
+than a slider: the values in between buy nothing and cost a decision.
+
+**Three sizes, not a range**, for the same reason `VIEW_COUNTS` is `[3, 5]`.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1,0 +1,779 @@
+# Punch List 15
+
+Captured 2026-08-24 from a spoken walkthrough. Items are added as they are
+dictated; each is Not started until it is worked.
+
+## PL15-001 — Square off the left edge of the active tile's pill
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `components/timeline/sidebar-icon-styles.ts`
+  (`SIDEBAR_ICON_BASE`, `SIDEBAR_ICON_PRESSED`)
+- Screenshot: Not captured
+
+The rail's active state is two layers: a blue indicator bar riding the rail's
+left boundary (`after:left-0 after:w-[3px] after:bg-sky-300`) over a lifted
+gray pill inset from the tile box (`before:inset-2 before:rounded-2xl`,
+`before:bg-zinc-800`). The bar already says "you are here" as a POSITION.
+
+Because the bar is doing that job, the pill should not also round away from
+the rail's edge. Its LEFT corners go to 90°; its right corners stay `2xl` as
+they are. A pill rounded on all four sides reads as a free-floating button
+that happens to sit near a line; squared on the left it reads as one shape
+anchored to the edge the bar marks.
+
+The rounding is currently written once, on the shared base
+(`before:rounded-2xl` in `SIDEBAR_ICON_BASE`), so this is a change to the
+class every rail tile wears, not a per-item override.
+
+Acceptance criteria:
+
+- On the rail, the active tile's gray fill has square left corners and `2xl`
+  right corners.
+- The blue indicator bar is unchanged — same position, width, height and color.
+- The glyph does not move, in either rail state (see the note on `RAIL_CLASS`:
+  geometry must not key off `rail-open`).
+- The board-options trigger the graph portals out wearing `SIDEBAR_ICON_BASE`
+  is not on `.rail`, so it keeps the fully-rounded pill.
+
+**Two things to settle when this is worked:**
+
+- **Active only, or every tile?** The fill is on the shared base; the
+  `zinc-800` value is the pressed state, but idle tiles carry a fainter fill
+  (`before:bg-zinc-900/40`) through the same rounded box. Squaring only the
+  active one means the pill changes SHAPE on activation, not just color.
+  Squaring all of them keeps one shape and lets the bar alone carry the state.
+- **Does the pill still sit inset from the left?** As spoken this is a corner
+  change only, so `inset-2` holds and the squared edge stops 8px short of the
+  bar with a gap between them. The alternative — running the fill flush to
+  `left-0` so the bar sits directly on it — is a different look and was not
+  asked for. Default to the corner change alone; check it on screen before
+  going further.
+
+## PL15-002 — Drop "Load project from file" from the board's `⋮`
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `components/graph-view/graph-project-menu.tsx`,
+  `components/graph-view/graph-project-menu.stories.tsx`
+- Screenshot: Not captured
+
+The `⋮` beside Select in the board's top row holds two items: "Export
+project…" and "Load project from file…". Load comes out. It already lives on
+the projects page as the `LoadProjectButton`, and that is where an action on
+the project SET belongs — loading replaces the whole offline board, so it is a
+library verb that happens to have been reachable from inside one.
+
+Export stays. It is genuinely a board action: it exports the project you have
+open.
+
+**This reverses a decision the menu documents.** `graph-project-menu.tsx` says
+load "stays here as well because deciding to swap projects usually happens
+while looking at one." That was the argument for two homes; the call now is
+one home, on the library page. Worth knowing it was deliberate rather than
+left over — the comment should go with the code rather than be left standing
+as a rationale for something that is no longer there.
+
+Nothing about the loading path itself changes: `loadProjectFromFile`, the
+hidden file input, the busy state and the toast-reported failures all stay,
+reached from the library button.
+
+Acceptance criteria:
+
+- The board's `⋮` offers "Export project…" and nothing else.
+- Loading a project from a file still works from the projects page, unchanged.
+- The hidden `[data-project-import-input]` and the `loadable` /
+  `process.env.NODE_ENV` dev-only guard leave the board menu with the item —
+  the library button carries its own copy of both.
+- No dead imports left behind (`loadProjectFromFile`, `useRef`, `useState` are
+  all there only for load).
+
+**Coverage to relocate, not delete:** three of the four stories in
+`graph-project-menu.stories.tsx` assert on load — `Open` checks the item is
+listed, and `LoadRefused` and `LoadNotJson` drive a file through the input and
+assert the error toasts. Those last two cover `loadProjectFromFile`'s failure
+modes, which are still live code; they belong on the library button's own
+stories now. Deleting them along with the menu item would quietly drop the
+only coverage of a bad-JSON load.
+
+**One thing to settle when this is worked:** with load gone the menu has a
+single item under a "Project" label. A `⋮` that opens to reveal one thing is a
+button with an extra click in front of it. Either it stays a menu because more
+project verbs are coming, or Export becomes a direct control in the row. Look
+at it once the item is out before deciding.
+
+## PL15-003 — The strip opens in Collections, not flat
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph?surface=strip
+- Area: `components/graph-view/graph-timeline-view.tsx` (`flatOn`),
+  `components/graph-view/graph-board.tsx` (the `Collections` `HeaderToggle`)
+- Screenshot: Not captured
+
+The strip's Collections toggle — the `Layers` control just past the Media add
+tool — is off when the strip opens. It should be ON: arriving in strip layout
+shows the run grouped into its collections, and going flat is the thing you
+choose.
+
+Two lines carry the default, and both have to flip or the change only half
+lands:
+
+- `useState(initialSurface === "strip")` (`graph-timeline-view.tsx:293`) — the
+  first arrival.
+- `setFlatOn(surface === "strip")` in the surface-change block below it — every
+  LATER arrival. It exists so "the strip is the same on every arrival", so
+  leaving it would make grid → strip re-flatten a board that opened grouped.
+
+**The reason this is worth doing, beyond preference:** flat mode refuses
+`move-nodes` (see `commandPolicy`), so as it stands the strip opens with
+drag-to-reorder OFF and nothing on screen says why. Opening in Collections
+means the strip is reorderable on arrival, and flat becomes an explicit
+trade you make.
+
+Acceptance criteria:
+
+- Opening strip layout shows collections, with the `Layers` toggle lit.
+- Switching grid → strip → grid → strip still lands in Collections each time.
+- Dragging to reorder works on arrival in strip.
+- Grid is untouched (it has no flat mode; the toggle is strip-only).
+
+**Two consequences to look at on screen before calling it done:**
+
+- **The control is now lit on arrival, which its own comment argues against.**
+  `active={!flatOn}` was written inverted precisely so the strip would not
+  "have a control that is lit on arrival and whose job is to turn itself off".
+  Flipping the default recreates that shape. Either the toggle re-orients to
+  offer the flat run (off on arrival, `active={flatOn}`, labelled for flat), or
+  it stays a lit Collections toggle and that comment gets rewritten to say why
+  that is now right. Do not leave the comment standing against the code.
+- **The time-axis group thins on arrival.** Ruler and waveform mount only
+  behind `flatOn`, along with the fence that opens their group — so the strip
+  now opens with the zoom slider alone on the right. Nothing breaks (the
+  flat-off watcher already turns both off), but the row looks different on
+  first sight and that is the change people will notice second.
+
+## PL15-004 — The strip's trim handle collar goes white
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph?surface=strip
+- Area: `components/graph-view/graph-card-trim.tsx` (`GraphTrimHandle`)
+- Screenshot: Not captured
+
+The trim handle is two parts: the 8px collar around the edge, and the grip
+line down the middle of it. At rest the collar is `bg-zinc-400/45` — grey —
+and only goes white (`bg-white/95`) once the press has settled and the handle
+is armed. Make the collar white at rest, matching the white the handle already
+uses.
+
+**This reverses "QUIET AT REST", which the file argues for at length.** The
+collar was a solid `white/85` and was deliberately dropped to grey: grey holds
+against a bright frame as well as a dark one, and blue and amber were already
+spoken for as selection and window. That reasoning is on the record; the call
+now is that the handle reads as a handle at rest. The comment block goes with
+the change rather than being left contradicting the code.
+
+Acceptance criteria:
+
+- A strip clip's trim collar is white at rest, on both edges.
+- It still holds against a bright frame — check on a white or blown-out clip,
+  not only on a dark one. That is the case grey was chosen for.
+- The grip line inside is unchanged.
+- Grid is unaffected if it draws the handle differently; strip is what was
+  asked for.
+
+**The thing this costs, and the way out:** arming currently announces itself
+by the collar going grey → white. With the collar already white there is no
+colour left to change, and arming matters — the same press pans the strip, so
+the handle has one moment to say "the next pull edits". It is not lost: the
+GRIP already changes on arm, `h-5 → h-full` and `bg-black/45 → bg-black/70`,
+which is a geometry and ink change inside the handle. Confirm by eye that the
+grip alone reads as armed. If it does not, the armed state needs its own
+value — a brighter white, or the grip going full black — rather than the
+collar going back to grey.
+
+**One thing to confirm:** "the same white as the other trim handle colors" is
+read here as `white/95`, the value already in this file for the armed state.
+If it meant the `white/85` the collar used to be, it is a one-token change —
+say which and it is done either way.
+
+## PL15-005 — Changing the view count keeps the panels it already has
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details, then use the 3 / 5 control)
+- Area: `components/graph-view/graph-item-details-modal.tsx`,
+  `components/graph-view/graph-item-details-panel.tsx`,
+  `components/graph-view/graph-item-details-view-count.ts`
+- Screenshot: Not captured
+
+Switching 3 → 5 currently plays as a full content replacement: the three
+panels animate off, then five animate on. Going 5 → 3 does the same in
+reverse. That is the wrong event. Changing the count does not change what you
+are looking at — the subject is the same clip and its neighbours are the same
+clips — so nothing that is staying should leave.
+
+What it should do:
+
+- **3 → 5.** The three panels on screen stay put and SHRINK into their new
+  width; two more grow in at the edges. Nothing else moves as a new thing.
+- **5 → 3.** The two outermost panels leave; the remaining three GROW into
+  their new width, in place.
+- The subject stays the subject throughout, at the centre, never re-entering.
+
+Only the entering and leaving panels are an appearance or a departure.
+Everything else is a resize.
+
+Acceptance criteria:
+
+- Through a 3 → 5 step, the three panels visible before the step are the same
+  DOM elements after it, with the same pictures, and their width transitions
+  rather than restarting.
+- Through a 5 → 3 step, the three that survive never fade out and back in.
+- Entering panels arrive at the edges; leaving panels leave from the edges.
+- The subject panel does not flicker, re-seek, or lose its frame at any point.
+- One clock, as the rest of the step already is — `DETAILS_STEP_MS` /
+  `DETAILS_STEP_EASING` from `graph-details-motion.ts`, not a new duration.
+
+**What the structure already gets right, so the fix is not where it looks.**
+The row renders EVERY id in the flat order, keyed by `id`, and mounts real
+panels within `MOUNTED_RADIUS = floor(viewCount / 2) + 1`. Working it through:
+at 3, visible is centre±1 and mounted is centre±2; at 5, visible is centre±2
+and mounted is centre±3. So the two panels that become visible on a 3 → 5 step
+were ALREADY mounted as real panels — they were the off-screen spares — and on
+5 → 3 the two that leave stay mounted. In neither direction is a panel that is
+visible on either side of the step mounted or unmounted. React is not throwing
+these away, so "it replaces everything" is not a keying or mounting fault.
+
+**Where it most likely IS, to confirm before fixing.** A panel decides how much
+of itself to draw from a CONTAINER QUERY on its own width — a narrow panel is
+"a frame and a name", a wide one carries its controls, and the neighbours'
+fixed height is a second rule beside it. Changing the count changes the
+neighbour width, which walks those panels across a query threshold, so their
+CONTENTS switch on a boundary while their box eases. Content appearing and
+disappearing on a threshold, on five panels at once, is what a replacement
+looks like even when the elements are the same ones.
+
+Confirm that on screen before changing anything: step 3 → 5 slowly and watch
+whether the pictures persist while the controls pop, or whether the pictures
+go too. Those are different bugs and only one of them is the container query.
+
+## PL15-006 — The bar's settings move behind a gear; reach stays out
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details — the controls row under the bar)
+- Area: `components/graph-view/graph-seam-strip-bar.tsx` (the controls row,
+  `settingsLeft` / `settingsRight`, the `fit` group),
+  `components/graph-view/graph-item-details-modal.tsx` (which builds them),
+  `components/graph-view/graph-item-details-modal.stories.tsx`
+- Screenshot: Not captured
+
+The bar's controls row carries four segmented groups. Three of them go into a
+popup behind a settings icon at the FAR RIGHT of the row; the fourth stays
+exactly where it is.
+
+Into the menu:
+
+- **frames** — `OFF · COVER · STRIP` (`data-details-bar-frames`)
+- **card** — `FOLLOW · PIN` (`data-details-bar-card`)
+- **fit** — `CLIP · ALL` (`data-seam-fit`)
+
+Staying visible, unchanged:
+
+- **reach** — `5 · 10 · 20 · ALL` (`data-details-bar-reach`)
+
+The gear sits to the RIGHT of reach, at the end of the row. The 3 · 5 view
+count in the modal's bottom-right corner is a different control in a different
+place and is not part of this.
+
+Acceptance criteria:
+
+- A settings icon is the last thing in the bar's controls row, after reach.
+- It opens a menu holding the frames, card and fit groups, each still labelled
+  and each still a one-of-N group with the same options.
+- Reach stays a visible segmented control in the row, in its current position.
+- Every setting keeps its current behaviour and its current default.
+- The menu is non-modal, like the other menus in this header — Radix's modal
+  default puts `pointer-events: none` on the body and stops the trigger
+  receiving the click that closes its own menu (the project `⋮` documents
+  this).
+
+**One behaviour that must survive the move.** The frames group is three
+segments over TWO stored settings: `OFF` sets `shown: false` and deliberately
+leaves `style` alone, so switching frames off and back on returns to the kind
+you were using. That is why the two are stored apart. It is easy to lose when
+the group is rebuilt inside a menu.
+
+**Test handles go behind a trigger.** `graph-item-details-modal.stories.tsx`
+reaches for these groups nine times, and its `play` functions click the
+segments directly. Every one of those now needs the menu opened first. There
+is no e2e reference to the three attributes, so this is contained to the
+stories — but they are the interaction suite, and a handle that no longer
+resolves fails as a timeout rather than an assertion.
+
+**One thing this could fix for free, and one decision it forces.** The `fit`
+group and `settingsRight` are both `hidden md:flex`, and `settingsLeft` is
+gated the same way — so on a narrow viewport these settings are not merely
+crowded, they are unreachable. A menu can carry them at every width. Whether
+to take that (drop the `md:` gate on the gear) or keep the current
+small-screen behaviour is a real choice: it was not asked for, and doing it
+silently would change what the modal offers on a phone. Default to
+like-for-like, and say so.
+
+## PL15-007 — The account avatar shows a broken image
+
+- Status: Not started
+- URL: http://localhost:3000/ (the rail's Account tile, bottom of the sidebar)
+- Area: `components/timeline/timeline-sidebar.tsx` (lines ~1236 and ~1273)
+- Screenshot: Not captured
+
+The Account tile at the bottom of the rail draws the browser's broken-image
+glyph instead of a face.
+
+The cause is a gap in the fallback, not a missing fallback. The tile branches
+on `user?.picture`: absent, it draws the initial letter in a circle
+(`initialOf`); present, it draws `<img src={user.picture}>` — and there is
+nothing behind that `<img>` if the request FAILS. A URL that exists but does
+not load takes the picture branch and then has nothing to fall back to, which
+is exactly the broken glyph.
+
+**Two places, same shape.** The rail tile at ~1236 and the profile popover at
+~1273 both branch this way. `initialOf` exists precisely because the ternary
+was duplicated; the error handling has to land in both or the popover keeps
+the broken glyph after the tile is fixed.
+
+**Is it dev-only?** Not in kind. `picture` comes from the Firebase ID token's
+`picture` claim (`lib/firebase-auth-session.ts`), so it is a real
+`googleusercontent` URL, not a dev fixture — and the missing error path is
+there in production too. Whether the URL is failing only on localhost is a
+separate question the code cannot answer: check the actual request (a 429 from
+Google's avatar host, a referrer-policy block, or an extension blocking it are
+all ordinary causes, and they all land as this same glyph). Worth knowing
+which, because a 429 means it will intermittently break for real users.
+
+Acceptance criteria:
+
+- An avatar that fails to load falls back to the initial-letter circle, in
+  both the rail tile and the profile popover.
+- The fallback looks identical to the no-picture case — same size, border and
+  hover treatment — so a failed load is indistinguishable from an account with
+  no photo.
+- No layout shift when the fallback swaps in.
+- An account WITH a working picture is unchanged.
+- The `relative` class stays on the image: the tile's pill is an absolute
+  `::before` and would otherwise paint a 40% black veil over the face.
+
+## PL15-008 — The preview's volume becomes an icon that reveals its slider
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (the workbench preview, with the pane open)
+- Area: `packages/ui/timeline/viewport/workbench-display-surface.tsx`
+  (`WorkbenchAudioControls`, `WorkbenchDividerTransport`),
+  `apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts`
+- Screenshot: Not captured
+
+Today the preview's audio control is a mute button and a 64px slider, always
+both, in a pill over the bottom-left of the picture. It becomes:
+
+- **The audio icon alone.** No slider until asked for.
+- **Click reveals the slider.** Click the icon again and it goes away; click
+  anywhere outside it and it goes away.
+- **The icon sits on the DIVIDER, at the far left** — the band that already
+  carries the transport, with the icon at the opposite end from the clock.
+
+Acceptance criteria:
+
+- At rest the control is one icon; the slider is not in the layout.
+- Clicking the icon shows the slider; clicking it again hides it; a click
+  outside hides it. Escape hides it too, with one explicit owner for the
+  dismiss — see the note below.
+- The slider still sets volume live while dragging, and the icon still shows
+  the silent state (`VolumeX` when muted or at zero).
+- The `audioBlocked` state still says so — a preview that was refused sound
+  for want of a user gesture must not read as merely quiet.
+- Revealing the slider does not start or stop playback: the surface below
+  toggles play on click, and these controls stop propagation for that reason.
+
+**WHAT MUTE DOES NOW HAS TO BE DECIDED.** Click currently MUTES. If click
+opens the slider instead, muting needs a home: either the icon toggles mute
+and something else opens the slider, or the slider carries mute at its zero
+end and the separate mute action goes away. As dictated the second is implied,
+but it is a real loss — mute-and-restore is one press today and would become a
+drag to zero and a drag back to a level you have to remember. Worth settling
+before building.
+
+**THE POSITION REVERSES A MEASURED DECISION, AND TWO E2E TESTS GUARD IT.**
+The file says plainly: "Volume lives INSIDE the preview, not on the divider
+beside play/pause. The divider is a resize handle first: its whole band is the
+drag target, and parking a button at its left end quietly shrank that target —
+the e2e that hovers the divider at x=20 caught it immediately."
+
+That is not a stale comment. `graph-view.spec.ts` hovers the divider at
+`x: 20` in TWO places — line 1737 (the divider's hover treatment) and line
+2718 (the transport's placement). A `size-6` button at the far left covers
+roughly x=8 to x=32, so it sits under both hover points and will intercept
+them. Expect both to fail, and expect the failure to look like a hover that
+simply stops working rather than like a moved button.
+
+So this is not "move the icon and fix a selector". Either:
+
+- the divider stays fully draggable THROUGH the icon — a pointerdown on it
+  starts the resize and only a click without drag opens the slider, which is
+  buildable but has to be got right or the icon eats resizes; or
+- the divider's left end genuinely stops being drag target, in which case
+  measure what band is left and say whether it is still a comfortable handle
+  before moving the e2e hover points. Moving the test to suit the code is only
+  honest if the answer to that is yes.
+
+This was asked for directly, so it goes in as asked. The comment argues the
+other way and the tests enforce it; both need updating deliberately, with the
+reason written down, rather than being worked around.
+
+**Where the slider appears** is unspecified and needs a decision: the divider
+is a thin band, so an inline slider would either stretch it or be cramped. A
+small popover above the icon, over the picture, is the likely answer — which
+puts the slider back roughly where the whole control lives today.
+
+## PL15-009 — Remove the paired-card jiggle
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (children timelines shown, hover a child row's folder)
+- Area: `app/globals.css` (`collection-paired-callout`),
+  `components/graph-view/graph-collection-hover.tsx`,
+  `components/graph-view/graph-collection-card.tsx`,
+  `components/graph-view/graph-sub-timelines.tsx`,
+  `tests/e2e/graph-view.spec.ts`
+- Screenshot: Not captured
+
+Hovering a child collection's folder icon makes that collection's card in the
+grid or strip scale up and settle — a 320ms elastic pulse
+(`collection-paired-callout`, `cubic-bezier(0.34, 1.56, 0.64, 1)`, out to 1.06
+then under to 0.985 and back). It goes.
+
+Acceptance criteria:
+
+- Hovering a child row's folder does not animate the card above.
+- Nothing else on the card animates in its place by accident — check a card
+  that is also selected, disabled, or mid-FLIP.
+- `prefers-reduced-motion` behaviour is unaffected (it already suppressed
+  this).
+
+**THE PAIRING SIGNAL DISAPPEARS ENTIRELY WITH IT, and that is worth a
+decision.** The card gets two classes when called out — `is-called-out-card`
+and `animate-collection-paired-callout` — and `is-called-out-card` has **no
+CSS rule anywhere**. It exists purely as an e2e handle. So the animation is
+not one of two signals, it is the only one: remove it and hovering a folder
+does nothing visible at all.
+
+That may be exactly what is wanted — the pairing is a nicety and the jiggle is
+the thing that grates. But if the intent was "keep telling me which card this
+is, just stop it bouncing", the replacement is a static treatment (a ring, a
+lifted border) held while the pointer is on the row, and that is a different
+change with different plumbing: the hold-past-leave machinery in
+`graph-collection-hover.tsx` exists ONLY to let an animation finish, and a
+static highlight wants the opposite — follow the pointer exactly, no hold.
+
+Say which. Defaulting to a straight removal.
+
+**What comes out if it is a straight removal:** the keyframes and the
+`.animate-collection-paired-callout` rule (including its two
+reduced-motion blocks), `COLLECTION_CALLOUT_KEYFRAMES_MS` /
+`COLLECTION_CALLOUT_MS` and the hold timer they document, and — if nothing
+replaces the signal — the whole `useCollectionHoverTarget` / channel path plus
+the `onPointerEnter` / `onPointerLeave` on the folder button.
+
+**Two e2e tests are built on this and both must go or be rewritten**
+(`graph-view.spec.ts`): one at ~4876 that asserts the running animation is
+named `collection-paired-callout` and that it reports `finished` rather than
+`cancelled`, and one at ~5924 that asserts `.is-called-out-card` has count 1
+and measures its box. Neither degrades gracefully — with the class gone they
+fail as a locator that never resolves.
+
+## PL15-010 — The whole child-timeline row opens it, not just the folder
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (children timelines shown)
+- Area: `components/graph-view/graph-sub-timelines.tsx`
+- Screenshot: Not captured
+
+A child timeline's row header is a 20px folder button, a name, a clip count, a
+status chip and a run of decorative frames — and only the folder button
+expands it. The whole bar should.
+
+Acceptance criteria:
+
+- Clicking anywhere on the row header toggles the timeline open or closed.
+- The folder glyph still toggles, and still shows open/closed state.
+- The row reads as clickable — a pointer cursor and a hover treatment across
+  the whole bar, not just under the folder.
+- Keyboard: one control, reachable by Tab, with `aria-expanded` on it. Not two
+  controls that do the same thing.
+
+**Three things in the row already take a click, and each needs a rule:**
+
+- **The name double-clicks to rename.** This is the real one. A single click
+  that toggles means a rename double-click toggles TWICE — back to where it
+  started — while the editor opens. Options: exclude the name from the
+  clickable area, or delay the toggle past the double-click threshold (which
+  makes every expand feel slow), or move rename onto an explicit control.
+  Excluding the name is the cheap answer and costs the least, but the name is
+  the biggest target on the bar and excluding it undercuts "the whole bar".
+- **The rename editor is an `<input>` in that row.** While it is open, clicks
+  inside it must not toggle anything.
+- **The preview frames are `aria-hidden` and deliberately not focusable**, so
+  that "the row's accessible surface is still exactly its toggle and its
+  name". Making the row clickable must not turn them into a second tab stop.
+
+**Do not wrap the row in a `<button>`.** It contains a button and, while
+renaming, an `<input>` — nested interactive elements are invalid and break
+keyboard behaviour. Put the click on the row's container and keep ONE
+accessible control (most likely the folder button, or the folder-plus-name as
+a single button with the badges outside it).
+
+**If PL15-009 keeps a pairing signal**, its hover trigger currently sits on the
+folder button alone. Whatever area becomes clickable should be the same area
+that triggers the highlight, or the row will light a card from one region and
+open it from another.
+
+## PL15-011 — The child row's thumbnail mirrors a real collection card
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (children timelines shown — the thumbnail at the far right of a row header)
+- Area: `components/graph-view/graph-sub-timelines.tsx`
+  (`data-subtimeline-thumbs`), `components/graph-view/graph-collection-card.tsx`
+  (`data-collection-mark`), `components/graph-view/graph-card-placeholders.tsx`
+- Screenshot: Not captured
+
+The thumbnail at the far right of a child timeline's row shows the
+collection's frame, and nothing else. It should read as the same object as the
+collection card it stands for:
+
+- **The collection mark over the frame** — the `Layers` glyph on its dark
+  disc, exactly as the card wears it, centred.
+- **The mark when there is NO frame too**, over the dark gradient. On the card
+  the mark is drawn whether or not there are frames, deliberately: "said once,
+  and the same way, whether the card has frames behind it or nothing at all."
+- **A slight border around the thumbnail**, on every row.
+
+Acceptance criteria:
+
+- A row whose collection has a frame shows that frame with the mark centred
+  over it.
+- A row whose collection has no frame shows the same dark gradient the card's
+  empty state uses, with the mark centred over it.
+- Every row's thumbnail carries a light border, framed or not.
+- The frames still line up on one vertical column however deeply rows nest —
+  the negative `marginRight` that cancels the ancestor panels' inset is
+  load-bearing and a border must not push the column off it.
+- The thumbnail stays `aria-hidden` and unfocusable; this is decoration, and
+  the row's accessible surface is still its toggle and its name.
+
+**THE ROW HAS NO GRADIENT TODAY — it has a flat tint.** Worth being exact,
+because "keep using that" reads as "leave it alone" and the change is the
+opposite. The row's box is `bg-zinc-950/60`, a flat dark wash that shows
+through when no frame renders. The CARD's empty state is
+`EmptyCollectionPlaceholder`: `linear-gradient(155deg, #27272a, #18181b,
+#09090b)`. They look similar at 40px and are not the same thing. Mirroring the
+card means ADOPTING that gradient here, from the shared placeholder rather
+than by retyping the stops.
+
+**The mark has to be resized, not reused as-is.** On the card it is a 40px
+`Layers` (`h-10 w-10`) inside a disc with `p-2` — sized against a card. The
+row's thumbnail is 40px tall and 72px wide in total, so the card's mark would
+cover it completely. It needs its own scale while keeping the parts that make
+it work: the disc behind the glyph (a bare glyph breaks up over a pale frame),
+`bg-black/45` on the disc as a background alpha rather than `opacity` on the
+wrapper, and the glyph's own half opacity so the frame reads through.
+
+**One thing to decide:** the card's empty state is not one placeholder but
+two — a collection that leads with audio gets the audio glyph instead of the
+gradient, because "this is sound" is truer there than "this is empty"
+(`leadsWithAudio`). Mirroring the card properly means carrying that here too.
+Doing it is more faithful; skipping it means a voice-takes collection reads as
+empty in the tree and as audio on the board. Recommend carrying it, since the
+whole point of this item is that the two agree.
+
+**Attribute reuse to watch.** If the row's mark reuses `data-collection-mark`,
+selectors that assume one mark per card will start matching rows as well —
+`graph-item-content.stories.tsx` queries it with `querySelector` in three
+places. Either give the row's mark its own attribute or check those queries
+are still scoped to a card. The e2e already reads `[data-subtimeline-thumbs]`
+(`graph-view.spec.ts:1031`); confirm what it asserts before changing the box.
+
+## PL15-012 — The drop zone goes dashed and grey
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (drag a file from the OS over the grid or the strip)
+- Area: `components/graph-view/graph-native-drop-chrome.tsx`
+  (`dropZoneClassName`)
+- Screenshot: Not captured
+
+While a drag is live, every eligible surface outlines itself and the one under
+the pointer fills in. Both states are bright sky blue:
+
+- armed — `bg-sky-400/[0.03] ring-sky-400/40`
+- hovered — `bg-sky-400/10 ring-2 ring-sky-400`
+
+It becomes a DASHED edge in a subdued grey, tint to match. The two states stay
+two states — the surface under the pointer must still be plainly the one that
+will take the drop — but the whole thing steps back.
+
+Acceptance criteria:
+
+- The eligible-surface edge is dashed and grey.
+- The hovered surface is still unmistakably distinct from a merely eligible
+  one, in grey.
+- The tint is grey rather than blue, and stays subtle enough to read over both
+  the grid's dark ground and a strip full of bright frames.
+- Nothing about the box changes when the affordance arms — see below.
+
+**A RING CANNOT BE DASHED, so this is not a value swap.** Tailwind's `ring-*`
+is a box-shadow, and box-shadows have no dash. The layout-safe way to get a
+dashed edge is `outline` with `outline-dashed` — an outline is painted outside
+the box and, like a ring, does not participate in layout. A `border` would.
+
+That matters more here than anywhere: this file's own rule is "Ring and
+background only — nothing here may change the box, or arming the affordance
+would reflow the strips mid-drag and move the very gaps being aimed at." A
+dashed border would do exactly that — arm the affordance, reflow the strip,
+and shift the gap the pointer is aiming at while it is aiming at it. Use
+`outline`, and check `outline-offset` so the dash does not sit under the
+adjacent card.
+
+**The insertion bar stays blue, on purpose.** `DROP_INDICATOR_CLASS` is a
+`bg-blue-500` line with a glow, and it answers a different question — not
+"this surface will take it" but "it will land HERE". With the zone chrome
+going grey that bar becomes the only colour in the drag, which is the right
+outcome: the precise signal keeps the accent and the ambient one gives it up.
+Not part of this item unless it looks wrong once the surround is grey.
+
+**Scope is exactly two surfaces.** `dropZoneClassName` has two consumers,
+`NativeDropGrid` and `NativeDropStrip` — the grid and the strip, and nothing
+else. This is the OS-file drag chrome; in-app card drags use the insertion
+indicator instead and are untouched.
+
+**No test asserts these colours** — nothing in the e2e or the stories reads
+the ring or its computed style — so this is safe to change on look alone. Judge
+it against a strip of bright frames as well as an empty board: grey at 3%
+opacity over a wall of pictures is close to invisible, and "subdued" must not
+become "cannot tell it armed".
+
+## PL15-013 — Count the real lines of code, per file, biggest first
+
+- Status: Not started
+- Area: `scripts/` (new), root `package.json`
+- Screenshot: Not captured
+
+**Do this LAST, after every OTHER item is complete** — including any added
+after it, since numbering is the order they were dictated and not the order
+they are worked. The counts are meant to describe the tree as it ends up, not
+as it started.
+
+Produce a list of every real source file with its count of actual code lines,
+ordered highest first, showing the file name and where it lives as a path
+relative to the repo root.
+
+Counting rules, pinned down because the vagueness is what would make the
+output useless:
+
+- **Comments are not code.** Line comments, block comments, and JSDoc — a line
+  inside a `/* … */` run counts as comment even though it carries no marker of
+  its own. This repo's files are heavily commented by design, so this rule is
+  most of what the number means.
+- **Blank lines are not code.**
+- **A line with code AND a trailing comment is code**, counted once.
+- Real source only: `.ts`, `.tsx`, `.js`, `.mjs`, `.css`. Not JSON, markdown,
+  lockfiles, or config data.
+- **Excluded entirely:** `node_modules`, `.next` (including
+  `.next/standalone`, which holds a full second copy of the app and would
+  double every count), `dist`, build output, coverage, and anything generated.
+- Tests and stories are real files and are counted — but reported so they can
+  be told apart, since a 3,000-line stories file is a different fact about the
+  codebase than a 3,000-line component.
+
+**Write it as a script, not a one-off.** `scripts/find-unreachable-ui.mjs`
+behind `npm run audit:ui` is the precedent, and this is the same kind of
+thing — a question worth asking again after the next round of work rather than
+a number produced once and pasted into a chat. `npm run audit:loc` or similar.
+
+Acceptance criteria:
+
+- One command produces the list.
+- Ordered by code lines, descending.
+- Each row shows the file and its repo-relative directory.
+- A total at the end, and a count of files scanned.
+- Re-running it after an edit changes the numbers — verify on one file rather
+  than assuming.
+
+**One thing assumed:** "relative to the root directory of this app" is read as
+the REPO root (`packages/ui/...`, `apps/timeline-gstudio001/...`), since this
+is a monorepo and a path relative to `apps/timeline-gstudio001` could not
+name a file in `packages/`. Say if the app workspace alone was meant.
+
+## PL15-014 — The bar's end stops get room, and a word
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details; set reach to `All` on a short collection so
+  both ends are real ends)
+- Area: `components/graph-view/graph-seam-lane.tsx` (`SeamEndCap`,
+  `CAP_WIDTH_PX`), `components/graph-view/graph-seam-metrics.ts`
+  (`BOX_INSET_PX`),
+  `components/graph-view/graph-item-details-modal.stories.tsx`
+- Screenshot: Not captured
+
+At the very start and very end of the bar — and only where the window has
+reached a REAL end rather than merely run out of boxes — a pale vertical mark
+is drawn just outside the first and last box (`SeamEndCap`: 6px wide, a
+gradient falling away from the film). Two changes:
+
+- **More space between the mark and the strip.** It currently sits
+  `BOX_INSET_PX` (2.5px) from the box, and that is on purpose: the same inset
+  the gap between two boxes is made of, "so the stop sits at the distance the
+  eye already reads as next thing along". Which is precisely the problem — at
+  a clip's own gap it reads as another clip's edge rather than as the end of
+  the film. It needs its own, larger inset.
+- **A word.** Something naming it as the beginning or the end, rather than
+  leaving a bare mark to be inferred.
+
+Acceptance criteria:
+
+- The start and end marks are separated from the first/last box by visibly
+  more than the gap between two adjacent boxes.
+- Each carries a short label saying which end it is.
+- Neither is drawn when the window is merely cropped — the existing
+  `atStart` / `atEnd` gate is what makes the mark mean anything and must not
+  loosen.
+- The gap is its own constant, not a reused `BOX_INSET_PX`. Sharing the number
+  is what made the two read the same; sharing it with a multiplier would put
+  the next reader back in the same place.
+
+**Where the label can physically go, which needs checking first.** The start
+cap is positioned at `atPx - CAP_WIDTH_PX - BOX_INSET_PX` — to the LEFT of the
+first box. Push it further left and, when the bar is scrolled to its
+beginning, it moves toward and possibly past x=0. A word is much wider than a
+6px mark, so the start label is the one at risk of being clipped against the
+track's left edge. Look at it scrolled hard to the start before choosing where
+the text sits: beside the mark, above or below it, or inside the leading gap
+if the strip has one to give.
+
+**Do not put the label inside the cap's own element.** The story
+`TheBarMarksTheEndsOfTheProject` asserts the cap's box against the boxes'
+(`startCap.right <= first.left + 0.5`, `endCap.left >= last.right - 0.5`).
+Those are RELATIONAL, so widening the gap passes unchanged — good. But adding
+text inside `[data-seam-cap]` grows that element's rect and would break both
+assertions for a reason that has nothing to do with what they are testing.
+Give the label its own element, and keep `[data-seam-cap]` meaning the mark.
+
+**One thing to decide:** the cap is `aria-hidden="true"` today, correctly — it
+is a graphic restating what the boxes already say. A word is different: it is
+content, and hiding readable text from assistive tech to keep an old attribute
+is the wrong way round. Either the label is announced (and the mark stays
+hidden beside it), or there is a reason it should not be. Choose deliberately
+rather than inheriting the attribute.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -5,7 +5,7 @@ dictated; each is Not started until it is worked.
 
 ## PL15-001 — Square off the left edge of the active tile's pill
 
-- Status: Not started
+- Status: Complete
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
 - Area: `components/timeline/sidebar-icon-styles.ts`
   (`SIDEBAR_ICON_BASE`, `SIDEBAR_ICON_PRESSED`)
@@ -52,7 +52,7 @@ Acceptance criteria:
 
 ## PL15-002 — Drop "Load project from file" from the board's `⋮`
 
-- Status: Not started
+- Status: Complete
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
 - Area: `components/graph-view/graph-project-menu.tsx`,
   `components/graph-view/graph-project-menu.stories.tsx`
@@ -104,7 +104,7 @@ at it once the item is out before deciding.
 
 ## PL15-003 — The strip opens in Collections, not flat
 
-- Status: Not started
+- Status: Complete
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph?surface=strip
 - Area: `components/graph-view/graph-timeline-view.tsx` (`flatOn`),
   `components/graph-view/graph-board.tsx` (the `Collections` `HeaderToggle`)
@@ -154,7 +154,7 @@ Acceptance criteria:
 
 ## PL15-004 — The strip's trim handle collar goes white
 
-- Status: Not started
+- Status: Complete — verify the armed read on a real strip
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph?surface=strip
 - Area: `components/graph-view/graph-card-trim.tsx` (`GraphTrimHandle`)
 - Screenshot: Not captured
@@ -322,7 +322,7 @@ like-for-like, and say so.
 
 ## PL15-007 — The account avatar shows a broken image
 
-- Status: Not started
+- Status: Complete
 - URL: http://localhost:3000/ (the rail's Account tile, bottom of the sidebar)
 - Area: `components/timeline/timeline-sidebar.tsx` (lines ~1236 and ~1273)
 - Screenshot: Not captured
@@ -606,7 +606,7 @@ are still scoped to a card. The e2e already reads `[data-subtimeline-thumbs]`
 
 ## PL15-012 — The drop zone goes dashed and grey
 
-- Status: Not started
+- Status: Complete
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (drag a file from the OS over the grid or the strip)
 - Area: `components/graph-view/graph-native-drop-chrome.tsx`
@@ -909,7 +909,7 @@ Acceptance criteria:
 
 ## PL15-017 — A caret under the minimap's active segment
 
-- Status: Not started
+- Status: Complete
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (open a media item's details — the minimap under the bar)
 - Area: `components/graph-view/graph-seam-minimap.tsx`,

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1170,6 +1170,39 @@ and on the branch at the moment the sub-graph expands; the one that moved names
 the cause. 207 against 380 is a large difference and should be obvious once the
 inputs are printed rather than inferred from a pass/fail.
 
+**THE MECHANISM, MEASURED — this is the useful part.** Instrumenting the clamp
+inputs at the moment of the expand gives, at this test's 1280x480 viewport:
+
+```
+innerHeight 480   rootTop -119 (clamped to 0)   mainBottom 606   scrollY 132
+```
+
+and the ceiling is
+`getViewportBoundaryBottom() - rootTop - MIN_TIMELINE_SPACE`, with
+`MIN_TIMELINE_SPACE = 260`. `getViewportBoundaryBottom` is
+`min(mainBottom, innerHeight)` = 480 here, so the ceiling is **at most
+`480 - 260 = 220`** and less once the page has scrolled — 207 is exactly
+`220 - 13` of `rootTop`.
+
+So the preview OPENS at `DEFAULT_SURFACE_HEIGHT` = 380, which is far above a
+ceiling that can never exceed 220 at this viewport. The invariant does not hold
+because 380 is legal; it holds only for as long as `clampToViewport` DOES NOT
+RUN AGAIN after the pane opens. Anything that causes one extra observer or
+scroll to fire after the expand cuts 380 down to the ceiling that was always
+there.
+
+That reframes the bug. It is not "something shrank the preview" — it is "the
+opened height was never within the clamp's own limit at this viewport, and the
+test passes only while nothing re-checks". Which is also why a bisect thrashes:
+the question is not WHICH change resized anything, it is which change added a
+re-check, and that is timing-shaped rather than layout-shaped.
+
+Two ways out, and they are a product decision rather than a test one:
+`initialSurfaceHeight` should not open the pane above its own ceiling (it
+clamps against `maxSurfaceHeight` but the restore path does not), or the test's
+480px viewport is simply below the height this pane is designed for and should
+say so.
+
 **Do not "fix" the test.** It is guarding a real invariant — the preview's
 height is the user's and content growth must not steal it — and it was written
 because the preview used to be fitted to whatever the lower pane left over.

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -695,19 +695,30 @@ become "cannot tell it armed".
 - Status: Complete. `npm run audit:loc`; the run is in
   `punch-list/PUNCH-LIST-15-loc.txt`.
 
-**The result, as of the end of this punch list: 623 files, 96,235 lines of
-code** — 51,768 across 440 source files and 44,467 across 183 tests and
-stories, which are marked `T`.
+**The result, as of the end of this punch list: 432 files, 50,928 lines of
+application code.** Full list in `punch-list/PUNCH-LIST-15-loc.txt`.
 
-That ratio is the finding. Coverage is 46% of the code in this repo by line,
-and the single largest file in the tree is the e2e suite at 5,525 — more than
-three times the largest component. Two of the top three files are stories.
+TESTS AND STORIES ARE EXCLUDED, on request and rightly. They were counted and
+marked `T` at first, on the reasoning that a 3,000-line stories file is a
+different fact about a codebase than a 3,000-line component. True — and exactly
+why they do not belong in the same list: mixed in they dominated it. The single
+largest file in the tree is the e2e suite at 5,525, two of the top three were
+stories, and a list meant to show where the CODE is was mostly showing where
+the tests are. `--tests` puts them back.
 
-Worth reading beside the counts: comments are excluded, and this repo comments
-heavily, so these numbers are much smaller than the files look. `graph-board.tsx`
-is 1,515 lines of code inside a file more than twice that.
-- Area: `scripts/` (new), root `package.json`
-- Screenshot: Not captured
+Excluding them by FILENAME was not enough. `tests/demo/foobar-demo.mjs` is 475
+lines of harness and is none of `.test.`, `.spec.` or `.stories.`, so it sat
+fifteenth among the application code. The rule is by name, by directory
+(`tests/`, `e2e/`, `test-support/`, `fixtures/`) and by job (runner configs, a
+stories helper). Maintenance scripts and the offline fixture STORE stay — those
+are real code that happens to have "fixture" in the name.
+
+For scale, with tests included it is 623 files and 96,235 lines, so coverage is
+46% of this repo by line.
+
+Comments are excluded throughout, and this repo comments heavily, so every
+number is much smaller than the file looks: `graph-board.tsx` is 1,515 lines of
+code in a file more than twice that.
 
 **Do this LAST, after every OTHER item is complete** — including any added
 after it, since numbering is the order they were dictated and not the order

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -777,3 +777,66 @@ is the wrong way round. Either the label is announced (and the mark stays
 hidden beside it), or there is a reason it should not be. Choose deliberately
 rather than inheriting the attribute.
 
+## PL15-015 — A trim edge cannot be dragged into the middle
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a video clip's details — the trim strip with the draggable window)
+- Area: `packages/ui/dnd-collections/react/trim-gesture.ts`
+  (the windowed branch of the trim reducer)
+- Screenshot: Not captured
+
+In the details modal, the trim strip's window can have either edge dragged
+deep into the clip — the start pulled to the middle and past it, the end
+likewise. It should stop: an edge is constrained, not free to swallow the
+clip.
+
+**The mechanism, found.** The reducer clamps each edge only against the OTHER
+edge:
+
+```
+trimInSeconds  = clamp(…, 0, fullDurationSeconds - trimOutSeconds)
+trimOutSeconds = clamp(…, 0, fullDurationSeconds - trimInSeconds)
+```
+
+So the two can meet. The window has no MINIMUM — the clamp forbids crossing
+and permits collapsing to zero, which is why an edge keeps travelling all the
+way through the middle and out the far side. There is no floor anywhere else
+either: `MAX_HANDLE_SHARE` only decides whether a handle is DRAWN on a short
+clip, and does nothing to a drag already under way.
+
+Acceptance criteria:
+
+- Neither edge can reduce the window below a minimum length.
+- The edge stops at that limit and stays under the pointer's control — it must
+  not jump, snap back, or drop the gesture.
+- The limit holds for both edges and for video and audio alike (one windowed
+  branch serves both).
+- Committing at the limit stores the clamped value; the previewed width and
+  the committed data still agree exactly, which is what `quantize`-then-`clamp`
+  is for.
+
+**SCOPE IS WIDER THAN THE MODAL.** `trim-gesture.ts` is the shared reducer —
+the same code backs the trim handles on the strip's CARDS. A floor added here
+lands in both places, which is almost certainly right (a card edge can collapse
+a clip today too) but is worth knowing before it is called a modal fix. The
+package has `trim-gesture.test.ts` beside it; the floor belongs there as a unit
+test, not only in a story.
+
+**Which limit was meant needs settling.** Two readings of "constrained as far
+as end points", and they are different products:
+
+- **A minimum window** — an edge may travel until some floor of remaining clip
+  and no further. This is the reading assumed above, and it is the one that
+  matches the mechanism found. A floor needs a number: one frame is the honest
+  minimum, the 0.1s quantize grid is the cheapest, and something like half a
+  second is what actually keeps a clip usable.
+- **A hard halfway stop** — neither edge may pass the midpoint, so no single
+  edge can take more than half the clip. This is closer to the words "cannot be
+  dragged to middle" but is a stronger rule, and it would forbid legitimate
+  trims (keeping the last two seconds of a ten-second take is one edge doing
+  80% of the work).
+
+Recommend the minimum window. Say which before it is built — the two are the
+same change to the same two lines and a completely different editing tool.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1275,3 +1275,55 @@ than a slider: the values in between buy nothing and cost a decision.
 
 **Three sizes, not a range**, for the same reason `VIEW_COUNTS` is `[3, 5]`.
 
+## PL15-023 — The playhead appears before the preview does
+
+- Status: Not started — cause identified below, not yet built.
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (toggle the preview pane open and watch the board)
+- Area: `components/graph-view/graph-sub-timelines.tsx` (`showPlayhead`),
+  `components/graph-view/graph-timeline-view.tsx` (`previewOn`),
+  `packages/ui/timeline/viewport/workbench-display-surface.tsx` (`chromeIn`)
+- Screenshot: Not captured
+
+Opening the preview draws the red playhead on the board immediately, while the
+pane is still sliding open. It should not appear until the preview is actually
+there.
+
+**The cause, exactly.** The board gates the line on
+`showPlayhead = previewOn && clockWindow !== undefined`, and `previewOn` flips
+the instant the toggle is pressed. The pane, meanwhile, animates open over the
+surface's reveal duration. So the gate is "has the preview been ASKED for",
+and what it needs to be is "is the preview THERE".
+
+**The same problem was already solved once, in the surface, for the same
+reason.** `chromeIn` exists so the divider and the transport fade in only once
+the pane has finished:
+
+> The divider and the transport are controls for a thing that is not there yet
+> while the pane is still opening — drawing them mid-slide puts a play button
+> on a two-inch sliver of video — so they fade in once it has finished.
+
+A playhead on the board is the same kind of thing: a readout of a preview that
+is not yet on screen. It should ride the same signal.
+
+Acceptance criteria:
+
+- The playhead does not draw until the preview pane has finished opening.
+- Closing is NOT symmetric: the chrome "ride[s] the close down still visible,
+  which reads as the board covering them rather than as two separate
+  departures", and the playhead should behave the same way.
+- A pane that is already open at first paint shows the playhead immediately —
+  there is nothing to wait for, and `chromeIn`'s `wasOpenRef` exists because
+  hiding and re-showing in that case is a flash.
+- The strip's line, the grid's line, and the sub-timeline rows' lines all
+  follow the same rule; `showPlayhead` feeds several places.
+
+**Two routes, and the cheap one is wrong.** The board could start its own timer
+for the reveal duration — but the app does not know that duration (the surface
+supplies its own default), so this would duplicate a constant across a package
+boundary and drift silently the first time the reveal is retuned. The honest
+route is for the surface to PUBLISH when it has settled: it already computes
+exactly this as `chromeIn` and already stamps `data-preview-chrome` on its own
+region, so what is missing is only a callback (or lifting that flag) so a
+sibling can read it. Prefer that.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1215,3 +1215,30 @@ say so.
 height is the user's and content growth must not steal it — and it was written
 because the preview used to be fitted to whatever the lower pane left over.
 
+## PL15-021 — The clock moves to the far left of the transport row
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details — the controls row under the bar)
+- Area: `components/graph-view/graph-seam-strip-bar.tsx`
+- Screenshot: Supplied by the owner
+
+`0:08.4 / 2:16.0` sat at the far right of the controls row, beside reach and
+the settings gear. It moves to the far LEFT, on the same line as the transport.
+
+It arrived on the right because it came down from the scrub bar with the
+transport, and the settings groups happened to end up around it. PL15-006 then
+emptied the row's left cell by folding those groups into the gear — so the row
+was carrying a bare third on one side and three controls crowded on the other.
+
+Acceptance criteria:
+
+- The clock is the leftmost thing in the controls row.
+- It stays on the transport's line: it says where playback IS, which is the
+  question the play button answers, and reading the two together is why it came
+  down out of the scrub bar at all.
+- The transport is still centred — the row is a three-column grid and the
+  middle track is what centres it, so the left cell has to keep existing
+  whatever is in it.
+- Clock notation and tenths are unchanged.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -265,7 +265,10 @@ go too. Those are different bugs and only one of them is the container query.
 
 ## PL15-006 — The bar's settings move behind a gear; reach stays out
 
-- Status: Not started
+- Status: Complete — and the gear is deliberately NOT gated on `md:` like the
+  groups it replaces, so frames/card/fit are reachable on a narrow viewport
+  for the first time. The left grid cell is kept as an empty spacer: it is
+  what centres the transport.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (open a media item's details — the controls row under the bar)
 - Area: `components/graph-view/graph-seam-strip-bar.tsx` (the controls row,

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -822,8 +822,12 @@ rather than inheriting the attribute.
 
 ## PL15-015 — A trim edge cannot be dragged into the middle
 
-- Status: Complete as the MINIMUM WINDOW reading (0.25s floor), which is the
-  half that was uncontroversial. The hard halfway stop is deliberately NOT
+- Status: Complete as the MINIMUM WINDOW reading, at ONE QUANTUM (0.1s). It
+  was 0.25s until `VirtualStrip.stories` failed asserting `0.10s / 10.00s` —
+  a shipped, tested trim the floor had quietly made impossible, which is the
+  exact risk this item warned about. The floor gave way rather than the test.
+  A larger one is a single constant, but choose it against trims people
+  actually make. The hard halfway stop is deliberately NOT
   built — it forbids legitimate trims. Say if that was what you meant; it is
   the same two lines.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -963,3 +963,138 @@ if it is not, the honest fixes are a taller rail or a caret that overlaps the
 segment's lower edge, NOT one that spills outside the rail into the controls
 below it.
 
+## PL15-018 — Bring the MCP tools back up to the app
+
+- Status: Not started
+- Area: `lib/webmcp/tools.ts`, `lib/mcp/write-handlers.ts`,
+  `components/graph-view/graph-mcp-tools.tsx`, `docs/webmcp-agent-tools.md`
+- Screenshot: Not captured
+
+The agent tool surface has fallen behind what the app can do. Bring it level.
+
+**The drift, measured rather than asserted.** There are two surfaces: the
+in-page WebMCP tools (which mutate the live store) and the server-side
+handlers behind `/api/mcp`. Counted today:
+
+- **WebMCP — 14 tools:** `read_timeline`, `move_clip`, `trim_clip`,
+  `rename_item`, `remove_clip`, `get_view_state`, `select_items`,
+  `clear_selection`, `focus`, `go_up`, `set_preview`, `play`, `pause`, `seek`.
+- **Server handlers — 8:** `move_clip`, `trim_clip`, `rename_item`,
+  `set_tags`, `remove_clip`, `set_lane`, `set_start`, `set_layer_frame`.
+
+So four write verbs exist on the server and have NO in-page equivalent:
+`set_tags`, `set_lane`, `set_start`, `set_layer_frame`. An agent working in
+the browser — the whole point of the two-writer loop — cannot tag a clip, put
+it on a lane, pin its start, or choose its layer frame, while the same agent
+hitting the endpoint can.
+
+**And things shipped since have no tool at all.** `set_disabled` is the clear
+one: enabling and disabling an item is a first-class action with its own
+command (`set-node-disabled`), its own undo clause and controls in two
+dialogs, and there is no way to ask for it. `create_collection` exists in
+`lib/mcp/` but is not registered on either surface.
+
+**The doc is stale in a way that matters.** `docs/webmcp-agent-tools.md` opens
+with "11 tools" against the 14 that are registered, and its own instruction is
+"Keep it current as decisions land." A count that is wrong by three is the
+cheapest possible signal that the decision log stopped being kept, so the doc
+is part of this item and not a footnote to it.
+
+Acceptance criteria:
+
+- The in-page surface covers every write the server handlers do — no verb an
+  agent can perform through the endpoint but not in the page.
+- `set_disabled` exists, dispatching `set-node-disabled` through the same
+  command path the dialogs use.
+- Every new tool returns the repo's `Result`-shaped rejection rather than
+  throwing, and refuses rather than guessing — the existing tools' contract.
+- Nothing is left orphaned: a tool that can move or remove a node obeys the
+  hard rule that nothing may be parentless (refuse, or route to trash).
+- `docs/webmcp-agent-tools.md` names the real tools and the real count, and
+  its decision log records what landed here.
+- Tests beside each new tool, matching the existing per-tool `.test.ts`
+  pattern in `lib/webmcp/` and `lib/mcp/`.
+
+**The trap that will waste an afternoon otherwise: the connector CACHES its
+tool list.** A newly added tool does not appear until the client refreshes it,
+and the failure mode is a tool that is definitely registered and definitely
+absent from the agent's view — which reads as a setting that does not exist
+rather than as a cache. Refresh the connector before concluding anything is
+wrong with a new tool.
+
+**Worth deciding as part of this:** whether the two surfaces should stay
+separately hand-maintained at all. They have already drifted by four verbs,
+and drifting is what two hand-written lists of the same thing do. The write
+handlers are shared logic; the registration is not. A single declaration both
+surfaces are generated from would make this the last time this item is
+written — which is a bigger change than "add four tools" and should be an
+explicit choice rather than a discovery halfway through.
+
+## PL15-019 — Dragging the Media tool opens two file pickers
+
+- Status: IN PROGRESS — a guard is applied, the DIAGNOSIS IS UNPROVEN. The
+  StrictMode theory below could not be reproduced: with the guard removed, a
+  story that wraps the component in `StrictMode` still counts exactly one
+  picker request, because React only double-invokes effects in a development
+  build of React and the storybook build is not one. So the guard is correct
+  defensive code — an effect that opens a picker should be idempotent — but it
+  is NOT established that it fixes what was reported. The decisive check named
+  below (watch the real dev app, and a production build) has not been run.
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (drag the Media tool from the controls row onto the board)
+- Area: `components/graph-view/graph-tool-buttons.tsx` (`MediaDropTarget`),
+  `apps/timeline-gstudio001/next.config.ts` (`reactStrictMode`)
+- Screenshot: Not captured
+
+Using the Media tool to add a clip opens the OS file picker, and then opens a
+second one immediately behind it. One drop, two prompts.
+
+**The cause, and it is a specific line.** The drag path parks the drop
+position and then asks for files through `MediaDropTarget`, which opens the
+picker from a MOUNT EFFECT:
+
+```
+const open = useCallback(() => inputRef.current?.click(), []);
+
+useEffect(() => {
+  if (hadUserActivation) open();
+  else promptRef.current?.focus();
+}, [hadUserActivation, open]);
+```
+
+`open()` is a side effect with no guard, fired from an effect that runs on
+mount. `reactStrictMode` is `true` in `next.config.ts`, and StrictMode
+deliberately double-invokes mount effects — mount, unmount, remount — so the
+input is clicked twice and the browser opens two pickers. `open` is a
+`useCallback` with an empty dep array, so it is stable and the second run is
+the remount rather than a changed dependency.
+
+This is exactly the class of bug StrictMode's double-invoke exists to surface:
+an effect that is not idempotent. The effect body is doing something that
+happens TO THE USER rather than something that sets up and tears down.
+
+**CONFIRM IT IS DEV-ONLY BEFORE FIXING ANYTHING.** StrictMode's double-invoke
+does not happen in a production build, so if this is the cause the deployed
+app opens one picker and only the dev server opens two. That changes the
+severity completely and is one build to check. Do that first — and if
+production ALSO doubles, the cause is something else (two `MediaDropTarget`s
+mounted at once, from the grid and strip surfaces or from a sub-timeline row,
+is the next place to look) and everything above is wrong.
+
+Acceptance criteria:
+
+- One drop of the Media tool opens exactly one picker, in dev and in
+  production.
+- Cancelling the picker still dismisses the pending drop as it does now.
+- The keyboard path is unchanged: with no user activation the prompt is
+  focused rather than a picker opened, which is the branch that makes this
+  reachable without a mouse at all.
+- The fix is a guard on the SIDE EFFECT — a ref that records the picker was
+  already opened for this pending drop — not switching StrictMode off.
+  StrictMode found a real defect here; turning it off would hide the next one.
+
+**Worth a sweep while in there.** Any other effect in this area that opens a
+picker, starts an upload, or dispatches a command on mount has the same shape
+and the same bug, and would show the same way — twice in dev, once in
+production, and nobody notices until someone watches carefully.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1412,3 +1412,41 @@ Acceptance criteria:
 - Whatever is decided about `fit` is written next to the code, since the name
   is a promise.
 
+## PL15-025 — The film holds the track's edges instead of centring past them
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open clip 2 of a long collection)
+- Area: `components/graph-view/graph-seam-strip.ts` (`clampStripOffset`, new),
+  `components/graph-view/graph-seam-strip-bar.tsx`
+- Screenshot: Supplied by the owner — clip 2 of 13, the film pushed to the
+  right-hand third and most of the track empty.
+
+The bar centres the clip you are on. That is right in the middle of a sequence
+and wrong at either end of it: centring clip 2 of 13 pushes the film most of
+the way across the track and leaves a screen of empty space beside it. It
+should travel until its own edge reaches the track's and then stop, the way any
+scroller does.
+
+**The cause is one unclamped line.** `stripCentreOffset` returns
+`containerPx / 2 - centre` and nothing bounds it, so an early subject yields a
+large positive offset and the film is simply pushed off to the right.
+
+Acceptance criteria:
+
+- At the start of a collection the film's first box sits at the left of the
+  track, not in the middle of it.
+- At the end, the last box sits at the right.
+- In the middle of a long sequence the subject still centres, unchanged.
+- A film SHORTER than the track still centres — there is no edge to hold it
+  against and nothing is being pushed off.
+- The clamp applies to a user PAN as well as the default, or a flick lands back
+  in the same gap.
+
+**The lead is not slop.** `SeamEndCap` draws the end stop and its label OUTSIDE
+the first and last boxes, at negative coordinates before the film begins — so
+holding the film flush to the track would push its own `Start` marker off
+screen. The clamp reserves exactly the stop's own room
+(`CAP_WIDTH_PX + CAP_GAP_PX`), which is why that constant had to be exported
+rather than guessed at here.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -840,3 +840,124 @@ as end points", and they are different products:
 Recommend the minimum window. Say which before it is built — the two are the
 same change to the same two lines and a completely different editing tool.
 
+## PL15-016 — The strip stutters while it is panned
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details, then drag the strip sideways)
+- Area: `components/graph-view/graph-item-details-modal.tsx` (the `swipe`
+  handlers, `dragPx`, `rowTransform`),
+  `components/graph-view/graph-item-details-panel.tsx`
+- Screenshot: Not captured
+
+Grabbing the film strip in the details modal and panning it stutters. It does
+not track the hand. Find out why, fix it, and sweep the rest of that surface's
+performance while there.
+
+**MEASURE BEFORE CHANGING ANYTHING.** This repo has already paid for the other
+order: three playback optimizations were built and then REJECTED because the
+measurement did not support them. A profile of an actual pan — frame timings,
+what is re-rendering, what is decoding — comes first, and the same profile run
+again is what says the fix worked. "It must be the re-renders" is not evidence.
+
+**The leading hypothesis, and it is a specific one.** The gesture stores its
+start coordinate in a ref, and the comment beside that ref says exactly why:
+
+> Not state: this changes on nearly every pointer move and only the ROW's
+> transform cares. A re-render per move to store a start coordinate would
+> re-render three live panels — video elements included — sixty times a second
+> for the duration of a swipe.
+
+But the OFFSET is state. `onPointerMove` calls `setDragPx(swipeOffset(dx, …))`
+on nearly every move, and `dragPx` is read by `rowTransform`, which is built in
+the modal's own render. So the re-render-per-move the ref was written to avoid
+happens anyway, one level up — and it re-renders the whole modal, which mounts
+up to `MOUNTED_RADIUS` × 2 + 1 panels, each a video element, a trim strip and
+a tag editor.
+
+If the profile agrees, the shape of the fix is to move the drag offset off the
+React render path entirely: write the transform to the row element directly
+(a ref plus a style write, or a CSS variable set on the wrapper) and keep
+`dragPx` in state only at the boundaries where a render genuinely has to
+happen — the start of the gesture and its commit. The row already opts out of
+its transition while `dragPx !== 0`, so nothing in the choreography depends on
+the value passing through render.
+
+**Do not stop at the first plausible cause.** Other candidates in the same
+area, worth including in the same profile rather than a second pass:
+
+- `rowTransform` is a `calc()` string built from `panelWidth`, itself a `min()`
+  expression — re-parsed per frame.
+- The panel under the playhead SEEKS itself while it is a neighbour, on
+  purpose, so a pan can be moving several media elements that are also seeking.
+- A pan that crosses a step boundary commits, which starts the 420ms
+  choreography — a stutter at the moment of landing is a different bug from a
+  stutter throughout, and the two must be told apart before either is fixed.
+- Container queries on panel width re-evaluate as the row moves.
+
+Acceptance criteria:
+
+- A profile of a pan, before and after, with the numbers stated — frame times
+  or dropped frames, not an impression.
+- The strip tracks the pointer through a full pan on a project with enough
+  clips to be worth panning.
+- The landing step is still one motion on one clock (`DETAILS_STEP_MS`); a
+  fix for the drag must not desynchronise the commit.
+- Whatever is found is written down beside the code, including anything that
+  turned out NOT to be the cause — the rejected candidates are the expensive
+  half of this and should not have to be re-derived.
+
+## PL15-017 — A caret under the minimap's active segment
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details — the minimap under the bar)
+- Area: `components/graph-view/graph-seam-minimap.tsx`,
+  `components/graph-view/graph-seam-lane.tsx` (`MARK_HALF_PX`,
+  `MARK_HEIGHT_PX` — the existing mark to match)
+- Screenshot: Not captured
+
+The minimap marks the clip you are on by turning its segment white and
+raising it a pixel. Add a small white triangle pointing UP, centred under that
+segment — a second, plainer signal that this is the active one.
+
+**It is the same idiom the bar already uses, which is the argument for it.**
+The minimap's own comment says the white was chosen "because that is what the
+bar above marks its active clip with — the triangle and its rule. The same
+claim in the same ink, said twice at two scales." The bar's mark
+(`data-seam-active-mark`) is a CSS-border triangle in `rgba(250,250,250,0.95)`
+sitting ABOVE the film pointing down at it. This is its twin at the smaller
+scale, below and pointing up. Build it from the same two constants rather than
+new numbers.
+
+Acceptance criteria:
+
+- A white triangle, pointing up, centred horizontally on the highlighted
+  segment.
+- It moves with the highlight — stepping to another clip moves the caret.
+- It does not overlap or obscure the segments themselves.
+- It stays inside the rail at both ends: the first and last clips' segments
+  are at the very edges, and the bar's mark already clamps for exactly this
+  reason ("a mark drawn past the end of the bar is not reporting a position at
+  all").
+- The minimap is `aria-hidden` and the caret is decoration; it stays that way.
+
+**Render it INSIDE the highlighted segment, not positioned over the rail.**
+This is the one thing that will otherwise cost an afternoon. The segments are
+flex children sized by `flexGrow: clip.showingSeconds` with per-seam
+`marginLeft`, so a segment's centre is NOT computable from a percentage of the
+rail the way the window and the playhead are (`asPercent(seconds)` works for
+those because they are positioned against total duration, not against a flex
+run). Reproducing the flex layout in arithmetic to place the caret would be a
+second implementation of the layout that drifts the moment a seam gap changes.
+A child of the centre segment at `left: 50%` with a half-width translate lets
+flex do it, and is correct at every width.
+
+**Check the vertical room first.** The rail is 14px (`h-3.5`), the segments
+are 6px (`h-1.5`) at `top-1`, and the active one grows a pixel each way — so
+the run occupies roughly y=3 to y=11 and there are about three pixels beneath
+it before the rail ends. That may be enough for a caret this small or may not;
+if it is not, the honest fixes are a taller rail or a caret that overlaps the
+segment's lower edge, NOT one that spills outside the rail into the controls
+below it.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -198,7 +198,13 @@ say which and it is done either way.
 
 ## PL15-005 — Changing the view count keeps the panels it already has
 
-- Status: Not started
+- Status: Complete — the cause was NOT the container query on CONTENT, it was
+  the one on the neighbour's HEIGHT: crossing 30rem swapped a definite value
+  for `h-auto`, which cannot be interpolated, so heights jumped in one frame
+  while widths eased. Fixing it also fixed a latent bug — at five-up every
+  neighbour was falling back to fitting its own picture, the exact "four
+  neighbours at four different heights" the fixed height was introduced to
+  prevent.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (open a media item's details, then use the 3 / 5 control)
 - Area: `components/graph-view/graph-item-details-modal.tsx`,

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -903,7 +903,11 @@ same change to the same two lines and a completely different editing tool.
 
 ## PL15-016 — The strip stutters while it is panned
 
-- Status: Not started
+- Status: Partial — the drag offset is off the React render path (it is a CSS
+  variable written straight to the row, so a pan touches one style property and
+  React is not involved). The structural cause is removed and the reasoning is
+  sound, but THE PROFILE THIS ITEM ASKS FOR HAS NOT BEEN RUN, so it is not
+  established that the stutter is gone. Do not close it on the diff.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (open a media item's details, then drag the strip sideways)
 - Area: `components/graph-view/graph-item-details-modal.tsx` (the `swipe`
@@ -1163,7 +1167,10 @@ production, and nobody notices until someone watches carefully.
 
 ## PL15-020 — A preview-height invariant regressed somewhere in this list
 
-- Status: OPEN — reproduced, NOT attributed. Raised by me, against my own work.
+- Status: OPEN — reproduced, NOT attributed, and INTERMITTENT. Raised by me,
+  against my own work. Rate measured at the end of the list: 4 of 6 passing in
+  isolation, and a full suite run that came back entirely green — so a green
+  run is NOT evidence this is fixed. `origin/main` passed it 6 of 6.
 - Area: `apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts`
   (`preview height is the user's: tree growth never steals it, and a toggle
   restores it`)

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -558,7 +558,9 @@ open it from another.
 
 ## PL15-011 — The child row's thumbnail mirrors a real collection card
 
-- Status: Complete — the audio placeholder was carried across too, so a
+- Status: Complete — SEE PL15-020: the placeholder half was briefly reverted
+  on a wrong inference and has been restored, because reverting it did not fix
+  the failing invariant either. Complete — the audio placeholder was carried across too, so a
   voice-takes collection no longer reads as empty in the tree and as audio on
   the board. The border is a RING: a border would have widened the box and
   pushed it off the column the negative margin exists to hold.
@@ -1123,4 +1125,52 @@ Acceptance criteria:
 picker, starts an upload, or dispatches a command on mount has the same shape
 and the same bug, and would show the same way — twice in dev, once in
 production, and nobody notices until someone watches carefully.
+
+## PL15-020 — A preview-height invariant regressed somewhere in this list
+
+- Status: OPEN — reproduced, NOT attributed. Raised by me, against my own work.
+- Area: `apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts`
+  (`preview height is the user's: tree growth never steals it, and a toggle
+  restores it`)
+- Screenshot: Not captured
+
+One e2e test fails on `punch-list-15` and passes on `origin/main`. It asserts
+that expanding a sub-graph must never shrink the preview pane — the preview
+opens at 380 and is measured again after a sub-graph is expanded, where it
+comes back 207.
+
+**What is established:**
+
+- `origin/main` passes it **6 times out of 6**.
+- The branch fails it, in the full suite and in isolation.
+- The whole suite is otherwise green: 176 passed, 4 skipped, this the only
+  failure.
+
+**What is NOT established, and the attempt is worth recording so it is not
+repeated blind.** A per-commit bisect gave non-monotonic answers — `d7882f3`
+(the minimap caret) failed 3/3 while `a669bf5`, which is LATER, passed 3/3,
+and the branch tip has given both 1-of-2 and 3-of-3 failures on different
+runs. So the per-commit results are measuring run-to-run variance, not the
+change under them, and every conclusion drawn from them is void. That includes
+two I drew and then disproved:
+
+- "It is the empty-collection placeholder in the sub-timeline row." Removing it
+  passed twice, then the same removal failed twice. Taking the placeholder out
+  of the flex flow did not help either, and reverting
+  `graph-sub-timelines.tsx` **entirely** to its pre-PL15-010 state still
+  failed.
+- "It is the preview's new audio island." It fails with
+  `workbench-display-surface.tsx` stashed.
+
+**Where to start, since the bisect cannot be trusted:** instrument rather than
+sample. The height comes from `initialSurfaceHeight` / `clampToViewport` in
+`workbench-display-surface.tsx`, and both derive from
+`getViewportBoundaryBottom() - rootTop`. Log those two numbers on `origin/main`
+and on the branch at the moment the sub-graph expands; the one that moved names
+the cause. 207 against 380 is a large difference and should be obvious once the
+inputs are printed rather than inferred from a pass/fail.
+
+**Do not "fix" the test.** It is guarding a real invariant — the preview's
+height is the user's and content growth must not steal it — and it was written
+because the preview used to be fitted to whatever the lower pane left over.
 

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -374,7 +374,11 @@ Acceptance criteria:
 
 ## PL15-008 — The preview's volume becomes an icon that reveals its slider
 
-- Status: Not started
+- Status: Complete — MUTE WAS KEPT as a press, inside the popover beside the
+  slider, rather than becoming "drag to zero". Losing a one-press action to
+  gain a reveal was the wrong trade. The divider's left 36px stops being drag
+  target; three e2e interaction points moved off that end, which is only
+  honest because the rest of a full-width divider remains.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (the workbench preview, with the pane open)
 - Area: `packages/ui/timeline/viewport/workbench-display-surface.tsx`
@@ -682,7 +686,8 @@ become "cannot tell it armed".
 
 ## PL15-013 — Count the real lines of code, per file, biggest first
 
-- Status: Not started
+- Status: Script written and verified (`npm run audit:loc`); the RESULT is
+  produced once every other item is done.
 - Area: `scripts/` (new), root `package.json`
 - Screenshot: Not captured
 

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1339,3 +1339,61 @@ exactly this as `chromeIn` and already stamps `data-preview-chrome` on its own
 region, so what is missing is only a callback (or lifting that flag) so a
 sibling can read it. Prefer that.
 
+## PL15-024 — Sizing the film should scale it in both axes
+
+- Status: Not started — mechanism identified, and one real conflict to settle
+  first (below).
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a media item's details, then the gear's `size` group)
+- Area: `components/graph-view/graph-seam-strip-bar.tsx` (`scale`, `fitTo`),
+  `components/graph-view/graph-seam-lane-size.ts`
+- Screenshot: Not captured
+
+PL15-022 made the film taller. It did not make it wider, so `md` and `lg`
+currently stretch each thumbnail vertically against an unchanged time scale.
+The horizontal scale should move with the height, so a bigger film means
+bigger thumbnails rather than taller ones.
+
+**Where it goes.** The bar's effective scale is one expression:
+
+```
+const scale = pxPerSecond ?? fitPixelsPerSecond(subjectCollectionSeconds, trackWidth);
+```
+
+`pxPerSecond` is null until somebody zooms or presses `fit`. Multiplying that
+result by `laneHeight / SEAM_LANE_HEIGHT_PX` scales both axes by the same
+factor — which also keeps a filmstrip CELL square and keeps the same number of
+frames per clip, so a bigger film is genuinely a bigger version of the same
+picture rather than a coarser one. (PL15-022 changes the cell count precisely
+because only one axis moved; this would undo that side effect, which is the
+better outcome and worth saying out loud.)
+
+**THE CONFLICT, which needs deciding before it is built: `fit` stops fitting.**
+`fit` means "this collection spans the track" — it computes the scale FROM the
+measured width. Multiply that result by a size factor and at `md` or `lg` the
+collection no longer fits the track, so a control whose entire promise is in
+its name stops keeping it. Three ways out:
+
+- **`fit` re-fits at the current size** — divide by the same factor inside
+  `fitTo`, so fit always fits and only the unzoomed default and manual zooms
+  carry the size factor. Keeps both promises; costs one place where the factor
+  must be applied in reverse, which is exactly the sort of thing that drifts.
+- **Size scales only the DEFAULT scale**, not an explicit zoom or fit. A user
+  who has set a scale keeps it; a user who has not gets a proportional film.
+  Least surprising, and does nothing for the case where you zoom first and
+  resize second.
+- **Accept that `fit` is a starting point, not an invariant** — simplest, and
+  the one that makes the control lie.
+
+Recommend the first. Do not build it before choosing, because the three differ
+only by a couple of lines and are very hard to tell apart from the diff after
+the fact.
+
+Acceptance criteria:
+
+- At each size the film's boxes are proportionally wider as well as taller.
+- A filmstrip cell stays square, and a clip is cut into the same number of
+  frames at every size.
+- Whatever is decided about `fit` is written next to the code, since the name
+  is a promise.
+

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -692,8 +692,20 @@ become "cannot tell it armed".
 
 ## PL15-013 — Count the real lines of code, per file, biggest first
 
-- Status: Script written and verified (`npm run audit:loc`); the RESULT is
-  produced once every other item is done.
+- Status: Complete. `npm run audit:loc`; the run is in
+  `punch-list/PUNCH-LIST-15-loc.txt`.
+
+**The result, as of the end of this punch list: 623 files, 96,235 lines of
+code** — 51,768 across 440 source files and 44,467 across 183 tests and
+stories, which are marked `T`.
+
+That ratio is the finding. Coverage is 46% of the code in this repo by line,
+and the single largest file in the tree is the e2e suite at 5,525 — more than
+three times the largest component. Two of the top three files are stories.
+
+Worth reading beside the counts: comments are excluded, and this repo comments
+heavily, so these numbers are much smaller than the files look. `graph-board.tsx`
+is 1,515 lines of code inside a file more than twice that.
 - Area: `scripts/` (new), root `package.json`
 - Screenshot: Not captured
 

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -265,7 +265,11 @@ go too. Those are different bugs and only one of them is the container query.
 
 ## PL15-006 — The bar's settings move behind a gear; reach stays out
 
-- Status: Complete — and the gear is deliberately NOT gated on `md:` like the
+- Status: Complete — SHIPPED BROKEN FIRST: the menu portals to `body` and so
+  rendered behind the modal's `z-[80]` scrim at its default `z-50`. Reported
+  from the app, not caught by the stories, which drove the menu's contents
+  without ever asking whether they were visible. Fixed and now asserted.
+  Complete — and the gear is deliberately NOT gated on `md:` like the
   groups it replaces, so frames/card/fit are reachable on a narrow viewport
   for the first time. The left grid cell is kept as an empty spacer: it is
   what centres the transport.
@@ -993,7 +997,11 @@ below it.
 
 ## PL15-018 — Bring the MCP tools back up to the app
 
-- Status: Not started
+- Status: Partial — `set_disabled` (which existed on NEITHER surface) and
+  `set_lane` are now in-page. `set_tags`, `set_start` and `set_layer_frame`
+  remain server-only; the doc's stale tool count still needs correcting. The
+  "generate both surfaces from one declaration" question in this item is
+  untouched and is the thing that stops it recurring.
 - Area: `lib/webmcp/tools.ts`, `lib/mcp/write-handlers.ts`,
   `components/graph-view/graph-mcp-tools.tsx`, `docs/webmcp-agent-tools.md`
 - Screenshot: Not captured

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -154,7 +154,10 @@ Acceptance criteria:
 
 ## PL15-004 — The strip's trim handle collar goes white
 
-- Status: Complete — verify the armed read on a real strip
+- Status: Complete, CONFIRMED BY THE OWNER in the app. The open question was
+  whether an armed handle still reads as armed once the collar is white at rest
+  — arming has no colour left to change, so the grip carries it alone (`h-5` to
+  full height, `black/45` to `black/70`). Checked on a real strip: it reads
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph?surface=strip
 - Area: `components/graph-view/graph-card-trim.tsx` (`GraphTrimHandle`)
 - Screenshot: Not captured
@@ -265,11 +268,11 @@ go too. Those are different bugs and only one of them is the container query.
 
 ## PL15-006 — The bar's settings move behind a gear; reach stays out
 
-- Status: Complete — SHIPPED BROKEN FIRST: the menu portals to `body` and so
-  rendered behind the modal's `z-[80]` scrim at its default `z-50`. Reported
-  from the app, not caught by the stories, which drove the menu's contents
-  without ever asking whether they were visible. Fixed and now asserted.
-  Complete — and the gear is deliberately NOT gated on `md:` like the
+- Status: Complete, CONFIRMED BY THE OWNER in the app. SHIPPED BROKEN FIRST:
+  the menu portals to `body` and so rendered behind the modal's `z-[80]` scrim
+  at its default `z-50`. Reported from the app, not caught by the stories,
+  which drove the menu's contents without ever asking whether they were
+  visible. Fixed, asserted as a computed z-index, and now seen working — and the gear is deliberately NOT gated on `md:` like the
   groups it replaces, so frames/card/fit are reachable on a narrow viewport
   for the first time. The left grid cell is kept as an empty spacer: it is
   what centres the transport.

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -725,7 +725,10 @@ name a file in `packages/`. Say if the app workspace alone was meant.
 
 ## PL15-014 — The bar's end stops get room, and a word
 
-- Status: Not started
+- Status: Complete — the gap is its own 40px constant and the word sits IN it,
+  between the stop and the film. Check it panned hard to either end: the start
+  stop is at a negative offset by construction and I could not clamp it (see
+  the code note), so a very narrow track could still crop it.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (open a media item's details; set reach to `All` on a short collection so
   both ends are real ends)
@@ -787,7 +790,10 @@ rather than inheriting the attribute.
 
 ## PL15-015 — A trim edge cannot be dragged into the middle
 
-- Status: Not started
+- Status: Complete as the MINIMUM WINDOW reading (0.25s floor), which is the
+  half that was uncontroversial. The hard halfway stop is deliberately NOT
+  built — it forbids legitimate trims. Say if that was what you meant; it is
+  the same two lines.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (open a video clip's details — the trim strip with the draggable window)
 - Area: `packages/ui/dnd-collections/react/trim-gesture.ts`

--- a/scripts/count-loc.mjs
+++ b/scripts/count-loc.mjs
@@ -49,12 +49,39 @@ const SKIP_DIRECTORIES = new Set([
   ".vercel",
 ]);
 
-/** A file that exists to check another one. Counted, but reported apart: a
- *  3,000-line stories file is a different fact about a codebase than a
- *  3,000-line component, and one list that does not say which is misleading. */
+/**
+ * A file that exists to check another one.
+ *
+ * EXCLUDED BY DEFAULT. They were counted and marked `T`, on the reasoning that
+ * a 3,000-line stories file is a different fact about a codebase than a
+ * 3,000-line component — which is true, and is exactly why they do not belong
+ * in the same list. Mixed in they dominate it: the largest file in this repo is
+ * the e2e suite, and two of the top three are stories, so a list meant to show
+ * where the CODE is was mostly showing where the tests are.
+ *
+ * `--tests` puts them back for the times that is the question being asked.
+ */
 function isCoverage(path) {
-  return /\.(test|spec|stories)\.[cm]?[jt]sx?$/.test(path);
+  const name = path.slice(path.lastIndexOf("/") + 1);
+  return (
+    // By NAME: the three suffixes the suites actually use.
+    /\.(test|spec|stories)\.[cm]?[jt]sx?$/.test(name) ||
+    // By PLACE. The filename pattern alone let `tests/demo/foobar-demo.mjs`
+    // through — 475 lines of harness sitting fifteenth in a list of
+    // application code, because it is neither a `.test.` nor a `.spec.` nor a
+    // `.stories.` file. Anything living in a test directory is test-related
+    // whatever it is called, and `test-support` is the same case one level up:
+    // it exists only to be imported BY tests.
+    /(^|\/)(tests?|__tests__|e2e|test-support|fixtures)\//.test(path) ||
+    // By JOB, for the handful that are neither. A runner's config and a
+    // stories helper are not application code by any reading.
+    /^(vitest|playwright)\.config\./.test(name) ||
+    /^(smoke-test|stories-helpers)\./.test(name)
+  );
 }
+
+
+const INCLUDE_TESTS = process.argv.includes("--tests");
 
 function sourceFiles(dir, found = []) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -149,6 +176,7 @@ function main() {
       };
     })
     .filter((file) => file.lines > 0)
+    .filter((file) => INCLUDE_TESTS || !file.coverage)
     // Descending by code lines; path as the tie-break so two runs over an
     // unchanged tree print the same list.
     .sort((a, b) => b.lines - a.lines || a.path.localeCompare(b.path));
@@ -158,18 +186,16 @@ function main() {
     const slash = file.path.lastIndexOf("/");
     const name = slash < 0 ? file.path : file.path.slice(slash + 1);
     const where = slash < 0 ? "." : file.path.slice(0, slash);
-    console.log(
-      `${String(file.lines).padStart(width)}  ${file.coverage ? "T" : " "}  ${name}  —  ${where}`,
-    );
+    const mark = INCLUDE_TESTS ? `  ${file.coverage ? "T" : " "}` : "";
+    console.log(`${String(file.lines).padStart(width)}${mark}  ${name}  —  ${where}`);
   }
 
-  const code = files.filter((f) => !f.coverage);
-  const cover = files.filter((f) => f.coverage);
   const sum = (list) => list.reduce((n, f) => n + f.lines, 0);
   console.log("");
   console.log(`${files.length} files, ${sum(files)} lines of code`);
-  console.log(`  ${code.length} source     ${sum(code)}`);
-  console.log(`  ${cover.length} test/story ${sum(cover)}   (marked T)`);
+  if (!INCLUDE_TESTS) {
+    console.log("  tests and stories excluded — pass --tests to include them");
+  }
 }
 
 // Only when RUN, not when imported. `codeLines` is exported so its handling of

--- a/scripts/count-loc.mjs
+++ b/scripts/count-loc.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * How many lines of REAL CODE each source file holds, biggest first.
+ *
+ * A script rather than a one-off (PL15-013), for the reason
+ * `find-unreachable-ui.mjs` is one: this is a question worth asking again after
+ * the next round of work, not a number produced once and pasted into a chat.
+ *
+ * WHAT COUNTS. A line counts when, after comments and whitespace are removed,
+ * something is left. Comments are not code — line comments, block comments and
+ * JSDoc alike, including the middle lines of a block, which carry no marker of
+ * their own and are the bulk of the commentary in this repo. Blank lines are
+ * not code. A line holding code AND a trailing comment counts once.
+ *
+ * WHY A SCANNER AND NOT A REGEX. `const url = "https://x"` is not a comment,
+ * and neither is `` `${a}//${b}` ``, and a regex literal can contain both
+ * quotes and slashes. Stripping with a pattern gets all three wrong and
+ * undercounts exactly the files that do the most string work. This walks the
+ * text once, tracking whether it is inside a string, a template, a regex or a
+ * comment — which is the smallest thing that is actually correct.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".mjs", ".cjs", ".css"]);
+
+/**
+ * Directories never descended into.
+ *
+ * `.next` earns its place twice: it holds build output, and `.next/standalone`
+ * is a COMPLETE SECOND COPY of the app. Counting it would silently double every
+ * file in `apps/timeline-gstudio001` and the totals would look plausible.
+ */
+const SKIP_DIRECTORIES = new Set([
+  "node_modules",
+  ".next",
+  ".next-dev",
+  ".git",
+  "dist",
+  "build",
+  "coverage",
+  "storybook-static",
+  "playwright-report",
+  "test-results",
+  ".turbo",
+  ".vercel",
+]);
+
+/** A file that exists to check another one. Counted, but reported apart: a
+ *  3,000-line stories file is a different fact about a codebase than a
+ *  3,000-line component, and one list that does not say which is misleading. */
+function isCoverage(path) {
+  return /\.(test|spec|stories)\.[cm]?[jt]sx?$/.test(path);
+}
+
+function sourceFiles(dir, found = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRECTORIES.has(entry.name)) continue;
+      sourceFiles(join(dir, entry.name), found);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const dot = entry.name.lastIndexOf(".");
+    if (dot < 0) continue;
+    if (!SOURCE_EXTENSIONS.has(entry.name.slice(dot))) continue;
+    found.push(join(dir, entry.name));
+  }
+  return found;
+}
+
+/**
+ * Lines with code left on them once comments are gone.
+ *
+ * The scanner is deliberately small and its states are the ones that can hide
+ * a `//`: a quoted string, a template (which can nest expressions holding more
+ * strings, so `${` depth is tracked), a regex literal, and the two comment
+ * kinds. Anything it does not recognise is code, which is the safe direction to
+ * be wrong in — a mis-scan over-counts rather than quietly reporting a file as
+ * mostly prose.
+ */
+export function codeLines(text) {
+  const lines = text.split(/\r?\n/);
+  let inBlock = false;
+  let count = 0;
+
+  for (const line of lines) {
+    let out = "";
+    let i = 0;
+    while (i < line.length) {
+      const two = line.slice(i, i + 2);
+      if (inBlock) {
+        if (two === "*/") {
+          inBlock = false;
+          i += 2;
+        } else {
+          i += 1;
+        }
+        continue;
+      }
+      if (two === "/*") {
+        inBlock = true;
+        i += 2;
+        continue;
+      }
+      if (two === "//") break; // rest of the line is comment
+      const ch = line[i];
+      if (ch === '"' || ch === "'" || ch === "`") {
+        // Consume the literal whole, so a `//` or `/*` inside it is never seen
+        // as a comment. Unterminated (a template spanning lines) simply ends
+        // the line, which still leaves the code before it counted.
+        const quote = ch;
+        out += ch;
+        i += 1;
+        while (i < line.length) {
+          if (line[i] === "\\") {
+            i += 2;
+            continue;
+          }
+          if (line[i] === quote) {
+            i += 1;
+            break;
+          }
+          i += 1;
+        }
+        out += "x";
+        continue;
+      }
+      out += ch;
+      i += 1;
+    }
+    if (out.trim().length > 0) count += 1;
+  }
+  return count;
+}
+
+function main() {
+  const files = sourceFiles(ROOT)
+    .map((absolute) => {
+      const path = relative(ROOT, absolute).split(sep).join("/");
+      return {
+        path,
+        lines: codeLines(readFileSync(absolute, "utf8")),
+        total: statSync(absolute).size,
+        coverage: isCoverage(path),
+      };
+    })
+    .filter((file) => file.lines > 0)
+    // Descending by code lines; path as the tie-break so two runs over an
+    // unchanged tree print the same list.
+    .sort((a, b) => b.lines - a.lines || a.path.localeCompare(b.path));
+
+  const width = String(files[0]?.lines ?? 0).length;
+  for (const file of files) {
+    const slash = file.path.lastIndexOf("/");
+    const name = slash < 0 ? file.path : file.path.slice(slash + 1);
+    const where = slash < 0 ? "." : file.path.slice(0, slash);
+    console.log(
+      `${String(file.lines).padStart(width)}  ${file.coverage ? "T" : " "}  ${name}  —  ${where}`,
+    );
+  }
+
+  const code = files.filter((f) => !f.coverage);
+  const cover = files.filter((f) => f.coverage);
+  const sum = (list) => list.reduce((n, f) => n + f.lines, 0);
+  console.log("");
+  console.log(`${files.length} files, ${sum(files)} lines of code`);
+  console.log(`  ${code.length} source     ${sum(code)}`);
+  console.log(`  ${cover.length} test/story ${sum(cover)}   (marked T)`);
+}
+
+// Only when RUN, not when imported. `codeLines` is exported so its handling of
+// strings, templates and regexes can be checked directly, and an import that
+// printed the whole tree as a side effect would make that impossible.
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}


### PR DESCRIPTION
Punch list 15: 26 items dictated over one session, 22 complete.

`punch-list/PUNCH-LIST-15.md` is the list. Every item carries its own status,
including the four that are not done and why.

## What landed

**The board and the rail**
- PL15-001 the active rail tile's fill squares off on the left, so it and the
  indicator bar read as one shape anchored to the rail
- PL15-002 "Load project from file" leaves the board's `⋮` — loading replaces
  the whole offline board, so it is a library verb
- PL15-003 the strip opens in Collections rather than flat, which also means it
  opens with drag-to-reorder ON
- PL15-007 the account avatar falls back when a picture FAILS, not only when it
  is absent
- PL15-009 the paired-card jiggle goes; the pairing signal stays, as the static
  glow that already existed for reduced-motion users
- PL15-010 the whole child-timeline row opens it
- PL15-011 the child row's thumbnail wears the collection mark and the card's
  own placeholders
- PL15-012 the drop zone goes dashed and grey

**The details modal**
- PL15-005 changing the view count resizes the panels it already has
- PL15-006 frames, card and fit move behind a settings gear; reach stays out
- PL15-008 the preview's volume is an icon that reveals its slider
- PL15-014 the bar's end stops get room, and a word
- PL15-017 a caret under the minimap's active segment
- PL15-021 the clock moves to the far left of the transport row
- PL15-022 the film strip can be drawn SM / MD / LG
- PL15-025 the film holds the track's edges instead of centring past them
- PL15-026 the subject's blue runs past the film to the minimap

**Elsewhere**
- PL15-015 a trim edge can no longer swallow its clip
- PL15-018 (partial) `set_disabled`, `set_lane`, `set_tags` and
  `set_layer_frame` join the in-page MCP tools
- PL15-013 `npm run audit:loc` — 432 files, 50,928 lines of application code

## Not done, and tracked in the file

- **PL15-020 — a preview-height invariant regressed, and I could not attribute
  it.** Raised against my own work. `origin/main` passes it 6 of 6; this branch
  is intermittent at 4 of 6. The mechanism IS measured: the pane opens at 380
  against a ceiling that can never exceed 220 at that viewport, so the
  invariant holds only while nothing re-checks. A green run is not evidence.
- PL15-016 the drag offset is off the React render path, but the profile the
  item asks for has not been run
- PL15-019 a guard is applied and the StrictMode diagnosis is UNPROVEN
- PL15-023 cause identified, not built
- PL15-024 blocked on a decision about what `fit` should mean

## Three green assertions that were measuring nothing

Worth reading, because each is now written into the code:

- the avatar story passed with the fix removed — the harness's fetch stub
  replaced the broken picture with the default a frame after render
- the count-change height check passed against the unfixed code — the viewport
  was too narrow to cross the threshold either state was on
- seven gear stories passed against a menu nobody could see — they drove its
  contents and never asked whether it was on screen

## Tests

807 unit, 334 stories, 177 of 181 e2e with 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)