### PR TITLE
Punch list 15 follow-ups: PL15-020 and PL15-023

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -45,6 +45,7 @@ import {
   usePreviewCardSpans,
   type PreviewTimeChannel,
 } from "./graph-preview";
+import { usePreviewSettled } from "@storyboard/ui/timeline/viewport/workbench-display-surface";
 import {
   GRID_GAP,
   GRID_UNCAPPED_HEIGHT,
@@ -128,7 +129,24 @@ function SubTimelineNode({
   // On the projection fallback a sub-row's local times don't line up with the
   // global clock, so the marker would lie — better absent for that ~2.5s.
   const clockWindow = spans?.get(id);
-  const showPlayhead = previewOn && clockWindow !== undefined;
+  // GATED ON SETTLED, NOT ON ASKED-FOR (PL15-023).
+  //
+  // `previewOn` flips the instant the toggle is pressed, and the pane then
+  // takes the reveal to slide open — so this drew the playhead over a preview
+  // that was not on screen yet, a readout of something you cannot see.
+  //
+  // `usePreviewSettled` ALREADY EXISTED and is already published to the board
+  // by context (`settled = mounted && revealed && !sliding`) — the pane's own
+  // chrome waits on the same flag, for the same reason: "controls for a thing
+  // that is not there yet while the pane is still opening". Nothing needed to
+  // be plumbed; this was one condition looking at the wrong flag.
+  //
+  // It is false through a CLOSE as well, which is right here even though the
+  // pane's chrome deliberately rides the close down: a playhead is a position
+  // in a picture, and there is no picture to be a position in once it is on
+  // its way out.
+  const previewSettled = usePreviewSettled();
+  const showPlayhead = previewOn && previewSettled && clockWindow !== undefined;
   const dims = ITEM_SIZE_DIMENSIONS[itemSize];
 
   const [expanded, setExpanded] = useState(false);

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -2556,15 +2556,33 @@ export function WorkbenchSplitPane({
     const divider = dividerRef.current;
     if (!divider) return;
 
-    const dividerHeight = divider.getBoundingClientRect().height;
     // A third of what the user can actually SEE, not of a <main> that may
     // run far below the fold — getViewportBoundaryBottom already resolves
     // that, and measuring from the root's top keeps the fraction honest
     // when the board sits below other chrome.
     const rootTop = Math.max(0, rootRef.current?.getBoundingClientRect().top ?? 0);
     const availableHeight = getViewportBoundaryBottom() - rootTop;
-    const maxSurfaceHeight = Math.max(MIN_SURFACE_HEIGHT, availableHeight - dividerHeight);
-    const nextHeight = clampSurfaceHeight(availableHeight / 3, maxSurfaceHeight);
+    // ONE CEILING, THE SAME ONE EVERY LATER CLAMP USES (PL15-020).
+    //
+    // This used to pass its own `maxSurfaceHeight` of `available - divider`,
+    // while `clampToViewport` calls `clampSurfaceHeight(height)` with no max
+    // and so falls through to `getManualMaxSurfaceHeight()` — which subtracts
+    // `MIN_TIMELINE_SPACE` (260) rather than a ~44px divider. Two ceilings
+    // more than 200px apart, and the pane opened under the loose one.
+    //
+    // So it could open at a height the very NEXT clamp would cut, and whether
+    // it did depended entirely on whether anything re-checked before you
+    // looked. That is what made `preview height is the user's` intermittent:
+    // the test asserts that growing the tree does not steal the pane's height,
+    // and the height it was defending had never been legal — it survived only
+    // while nothing asked.
+    //
+    // Measured at the 1280x480 viewport that test uses: the pane opened at 380
+    // against a manual ceiling that cannot exceed 220 there.
+    //
+    // Omitting the argument is the fix. The pane now opens at a height it can
+    // keep, and a re-check has nothing to take away.
+    const nextHeight = clampSurfaceHeight(availableHeight / 3);
 
     setSurfaceHeight((height) =>
       Math.abs(height - nextHeight) < 0.5 ? height : nextHeight,

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1248,6 +1248,34 @@ clamps against `maxSurfaceHeight` but the restore path does not), or the test's
 480px viewport is simply below the height this pane is designed for and should
 say so.
 
+**THE CEILINGS DID NOT MATCH, and fixing that did NOT fix this.** Both halves
+matter.
+
+`initialSurfaceHeight` passed its own `maxSurfaceHeight` of
+`available - dividerHeight` (~44px), while `clampToViewport` calls
+`clampSurfaceHeight(height)` with no max and falls through to
+`getManualMaxSurfaceHeight()`, which subtracts `MIN_TIMELINE_SPACE` (260). Two
+ceilings more than 200px apart, and the pane opened under the loose one — so it
+could open at a height the very next clamp would cut. That is a real defect and
+it is fixed: the open path omits the argument and uses the same ceiling as
+everything else.
+
+It did not move the failure rate. Measured across three runs after the change:
+4 of 6, then 5 of 6, then 6 of 10 — all within noise of the rate before it.
+Recorded so nobody re-derives this fix expecting it to close the item.
+
+**The residual, and it is the thing to chase next:** the ceiling itself MOVES.
+`getManualMaxSurfaceHeight` is `viewportBottom - rootTop - MIN_TIMELINE_SPACE`,
+and `rootTop` is the pane's position in the viewport — which changes with
+SCROLL. So the pane can open under a legal ceiling and be re-clamped later
+under a different one, without anything about the layout having changed, purely
+because the page scrolled between the two moments. The probe caught exactly
+this: `rootTop -119, scrollY 132` at the assert.
+
+That reframes it as a product question rather than a bug: should a pane the
+user sized shrink because the page scrolled? If not, the ceiling has to come
+from something stable rather than from the live `rootTop`.
+
 **Do not "fix" the test.** It is guarding a real invariant — the preview's
 height is the user's and content growth must not steal it — and it was written
 because the preview used to be fitted to whatever the lower pane left over.

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1342,7 +1342,10 @@ than a slider: the values in between buy nothing and cost a decision.
 
 ## PL15-023 — The playhead appears before the preview does
 
-- Status: Not started — cause identified below, not yet built.
+- Status: Complete — and it needed NO new plumbing. `usePreviewSettled()`
+  already existed and was already published to the board by context; the board
+  already imports it elsewhere. This was one condition looking at the wrong
+  flag. See the note at the end about the version I built first and threw away.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (toggle the preview pane open and watch the board)
 - Area: `components/graph-view/graph-sub-timelines.tsx` (`showPlayhead`),
@@ -1530,3 +1533,22 @@ number in the bar; the gap is `mt-1.5` on the minimap's own root. Nothing
 connects them, so `MINIMAP_GAP_PX` is named and says so — the failure if they
 drift is a column that stops short of the map or runs into it.
 
+**A CALLBACK WAS BUILT FIRST AND THROWN AWAY, and the reason is worth keeping.**
+The recommendation above was to have the surface publish `chromeIn` through a
+new callback, because "the app does not know that duration". That was right
+about the principle and wrong about the facts — the signal was already
+published, as `usePreviewSettled()`, and graph-board already consumes it a few
+hundred lines from where this change landed.
+
+The callback version also BROKE the reveal before it was replaced.
+`chromeIn` goes true, false, true around an opening pane, and pushing each edge
+out re-rendered the consumer twice at the moment the slide was starting — the
+region's own height transition then never ran at all, which
+`the preview is UNCOVERED, and its contents do not grow inside the reveal`
+caught as an empty list of transition runs. A context read costs no re-render
+in the consumer and has none of that.
+
+Two lessons, both cheap to have had earlier: look for the signal before
+building one, and be suspicious of adding a state update inside a window that
+something else is animating — which is the same family PL15-020 identifies as
+the cause of its own intermittency.


### PR DESCRIPTION
Two of the items left open by #530.

## PL15-023 — the playhead waits for the preview to be there

The board drew the red line the instant the preview was ASKED for. `previewOn`
flips at the click and the pane then takes the reveal to slide open, so the
playhead appeared over a preview that was not on screen — a readout of
something you cannot see.

**It needed no new plumbing.** `usePreviewSettled()` already exists, is already
published to the board by context (`settled = mounted && revealed && !sliding`),
and graph-board already imports it a few hundred lines from where this landed.
The pane's own chrome waits on that same flag for the same stated reason —
"controls for a thing that is not there yet while the pane is still opening".
One condition was looking at the wrong flag.

**A callback was built first and thrown away**, and the item records why. The
plan was to have the surface publish `chromeIn` through a new prop, on the
reasoning that the app does not own the reveal duration. Right principle, wrong
facts — and it broke the reveal on the way past: `chromeIn` goes true, false,
true around an opening pane, and pushing each edge out re-rendered the consumer
twice at the moment the slide was starting. The region's own height transition
then never ran at all, which `the preview is UNCOVERED, and its contents do not
grow inside the reveal` caught as an empty list of transition runs.

That is the same family PL15-020 blames for its own intermittency: a state
update landing inside a window something else is animating.

## PL15-020 — the two ceilings now agree, and that is NOT the cure

`initialSurfaceHeight` clamped against `available - dividerHeight` (~44px)
while every later clamp falls through to `getManualMaxSurfaceHeight()`, which
subtracts `MIN_TIMELINE_SPACE` — 260. Two ceilings more than 200px apart, and
the pane opened under the loose one, so it could open at a height the very next
clamp would cut. Real defect, fixed.

**It did not move the failure rate on its own** — 4 of 6, 5 of 6, 6 of 10 after
the change, all within noise of before. Committed with that measurement rather
than as a claim.

The residual is written down precisely: the ceiling MOVES, because
`getManualMaxSurfaceHeight` subtracts `rootTop`, which changes with SCROLL. So
a pane can open under a legal ceiling and be re-clamped under a different one
with nothing about the layout having changed. That is a product question —
should a pane the user sized shrink because the page scrolled? — and is left as
one.

**Behaviour change to know about:** on a short viewport the pane now opens
smaller, at its ceiling rather than above it. On an ordinary monitor that
ceiling is far above a third of the viewport, so nothing moves.

## Tests

177 of 181 e2e pass with 4 skipped — no failures, including both the reveal
test and the preview-height invariant that was failing intermittently on the
previous branch. 23 split-pane stories pass.

I am NOT calling PL15-020 closed on one green run; that is the mistake its own
item warns about. But removing a re-render from the reveal window is exactly
what it predicted would help.

## Still open after this

- PL15-016 the pan-stutter profile
- PL15-018 `set_start` is still server-only
- PL15-019 the StrictMode diagnosis needs one production build
- PL15-024 blocked on a decision about what `fit` should mean

🤖 Generated with [Claude Code](https://claude.com/claude-code)