### PR TITLE
PL15-024 — sizing the film scales the time axis, and `fit` still fits

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1365,11 +1365,55 @@ export const TheFilmCanBeDrawnTaller: Story = {
     press("LG");
     await waitFor(() => expect(lane()).toBeGreaterThan(medium));
 
-    // PUT IT BACK. Like the reach and the view count, this is remembered at
-    // module scope for the session — a story that leaves the film tall hands
-    // it to whichever story runs next in the same browser.
+    // AND THE TIME AXIS CAME WITH IT (PL15-024). PL15-022 made the film taller
+    // and left the boxes' widths alone, so `md` and `lg` stretched each
+    // thumbnail vertically against an unchanged scale. A box is wider at a
+    // bigger size, which is also what keeps a filmstrip CELL square and the
+    // frame count per clip constant.
+    const boxWidth = () => seamBoxes()[0]!.getBoundingClientRect().width;
+    const wideBox = boxWidth();
     press("SM");
     await waitFor(() => expect(lane()).toBe(small));
+    expect(wideBox).toBeGreaterThan(boxWidth());
+    press("LG");
+    await waitFor(() => expect(lane()).toBeGreaterThan(medium));
+
+    // BUT `FIT` STILL FITS, which is the half that constrains the design.
+    //
+    // `fit` means "this collection spans the track" and computes its answer
+    // FROM the measured width — so the size factor must NOT be applied on top
+    // of what it stores, or the collection would stop fitting at `md` and `lg`
+    // and a control whose whole promise is in its name would break.
+    //
+    // Asserted as INVARIANCE rather than against the track's width, and the
+    // difference matters: the bar shows the whole REACH window, which is more
+    // clips than the collection `fit clip` fits, so the boxes legitimately
+    // span wider than the track. What must hold is that fitting lands on the
+    // same scale whatever size the film is drawn at.
+    const fitNow = () => {
+      openBarSettings();
+      const group = document.querySelector<HTMLElement>("[data-seam-fit]")!;
+      const clip = Array.from(group.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.trim() === "clip",
+      )!;
+      fireEvent.click(clip);
+    };
+    const spanNow = () => {
+      const boxes = seamBoxes();
+      return (
+        boxes[boxes.length - 1]!.getBoundingClientRect().right -
+        boxes[0]!.getBoundingClientRect().left
+      );
+    };
+
+    fitNow();
+    await waitFor(() => expect(spanNow()).toBeGreaterThan(0));
+    const fittedAtLarge = spanNow();
+
+    press("SM");
+    await waitFor(() => expect(lane()).toBe(small));
+    fitNow();
+    await waitFor(() => expect(Math.abs(spanNow() - fittedAtLarge)).toBeLessThan(2));
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -338,9 +338,39 @@ export function SeamStripBar({
   // and until then the scale is computed from the width. Same "once" guarantee
   // with no second render — a re-measure cannot undo a zoom, because once
   // there IS a zoom the fallback is not consulted.
+  /**
+   * HOW MUCH BIGGER THE FILM IS THAN `sm`, and therefore how much wider a
+   * second of it should be (PL15-024).
+   *
+   * PL15-022 made the film taller and left the time axis alone, so `md` and
+   * `lg` stretched each thumbnail vertically against boxes of unchanged width.
+   * Scaling both axes by the same number makes a bigger film a bigger version
+   * of the same picture — and, because a filmstrip CELL is square, it also
+   * keeps the number of frames a clip is cut into constant, undoing the side
+   * effect PL15-022 had precisely because only one axis moved.
+   */
+  const sizeFactor = laneHeight / SEAM_LANE_HEIGHT_PX;
+
+  /**
+   * `pxPerSecond` IS THE SCALE AT `sm`, not the scale on screen.
+   *
+   * Every writer divides by `sizeFactor` and this one reader multiplies by it,
+   * which is what lets `fit` keep its promise. `fit` means "this collection
+   * spans the track" and computes its answer FROM the measured width — so if
+   * the size factor were applied on top of what it stored, the collection
+   * would stop fitting at `md` and `lg` and a control whose whole promise is
+   * in its name would break. Storing the pre-factor value means the multiply
+   * here lands exactly on the width it measured.
+   *
+   * The DEFAULT is deliberately outside that: with no zoom and no fit, the
+   * scale is a fitted width times the factor, so a bigger film opens with
+   * proportionally wider boxes and runs past the track. That is the trade this
+   * item asks for — the opening scale is a starting point, `fit` is the
+   * promise.
+   */
   const scale =
-    pxPerSecond ??
-    (trackWidth > 0 ? fitPixelsPerSecond(subjectCollectionSeconds, trackWidth) : 9);
+    (pxPerSecond ?? (trackWidth > 0 ? fitPixelsPerSecond(subjectCollectionSeconds, trackWidth) : 9)) *
+    sizeFactor;
   const strip = useMemo(() => buildSeamStrip(clips, scale), [clips, scale]);
   // The subject's own box in strip coordinates — what the active column below
   // is drawn against. `undefined` while the subject is not on the bar at all,
@@ -849,7 +879,11 @@ export function SeamStripBar({
         const to = zoomByWheel(from, event.deltaY);
         if (to === from) return;
         const anchorLocalX = event.clientX - element.getBoundingClientRect().left;
-        setPxPerSecond(to);
+        // `from` and `to` are ON-SCREEN scales — `scaleRef` tracks the value the
+        // boxes are actually drawn at — so the stored value has to come back
+        // down by the size factor, or the next read would apply it twice and a
+        // single notch would zoom by the factor as well (see `scale`).
+        setPxPerSecond(to / sizeFactor);
         // NEITHER FIT IS TRUE ANY MORE. Leaving one lit after a zoom would be
         // the control lying about the scale it names.
         setFitMode(null);
@@ -865,7 +899,7 @@ export function SeamStripBar({
     };
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => element.removeEventListener("wheel", onWheel);
-  }, [cancelHover, setOffset, stopGlide]);
+  }, [cancelHover, setOffset, sizeFactor, stopGlide]);
 
   // ── KEEPING THE PLAYHEAD IN VIEW ─────────────────────────────────────────
   //
@@ -1021,7 +1055,10 @@ export function SeamStripBar({
       const span = mode === "clip" ? subjectCollectionSeconds : totalSeconds;
       if (span <= 0) return;
       const next = fitPixelsPerSecond(span, width);
-      setPxPerSecond(next);
+      // STORED AT `sm`, read back multiplied — see `scale`. Storing the
+      // on-screen value here would make the collection stop fitting the track
+      // at `md` and `lg`.
+      setPxPerSecond(next / sizeFactor);
       setFitMode(mode);
       setFollowSuspended(false);
       // Re-centre with the NEW scale rather than the ref's old one — the ref
@@ -1037,6 +1074,7 @@ export function SeamStripBar({
     [
       centreAtPx,
       centreClipId,
+      sizeFactor,
       clips,
       setOffset,
       subjectCollectionSeconds,

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1430,8 +1430,11 @@ sibling can read it. Prefer that.
 
 ## PL15-024 — Sizing the film should scale it in both axes
 
-- Status: Not started — mechanism identified, and one real conflict to settle
-  first (below).
+- Status: Complete, built as the FIRST of the three options — `fit` re-fits at
+  the current size, so both promises hold. `pxPerSecond` is now "the scale at
+  `sm`": every writer divides by the size factor and the single reader
+  multiplies by it, which is what keeps `fit` landing on the width it measured.
+  See the end of this item for the assertion that nearly went in wrong.
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
   (open a media item's details, then the gear's `size` group)
 - Area: `components/graph-view/graph-seam-strip-bar.tsx` (`scale`, `fitTo`),
@@ -1585,3 +1588,14 @@ Two lessons, both cheap to have had earlier: look for the signal before
 building one, and be suspicious of adding a state update inside a window that
 something else is animating — which is the same family PL15-020 identifies as
 the cause of its own intermittency.
+
+**THE STORY'S FIRST ASSERTION WAS WRONG, and the right one is more useful.**
+It checked that after `fit clip` the boxes span no wider than the track — which
+failed at 3321px against 1153px and looked like the fix was broken. It was the
+assertion: the bar draws the whole REACH window, which is more clips than the
+collection `fit clip` fits, so the boxes legitimately span wider than the track.
+
+What actually has to hold is INVARIANCE: fitting must land on the same scale
+whatever size the film is drawn at. That is what the story asserts now, and it
+is a direct test of the design — `fit` computes from the measured width, so the
+size factor must not be applied on top of what it stores.


### PR DESCRIPTION
Built as the FIRST of the three options the item laid out: `fit` re-fits at the
current size, so both promises hold.

PL15-022 made the film taller and left the time axis alone, so `md` and `lg`
stretched each thumbnail vertically against boxes of unchanged width. Scaling
both axes by the same factor makes a bigger film a bigger version of the same
picture — and because a filmstrip CELL is square, it also keeps the frame count
per clip constant, undoing the side effect PL15-022 had precisely because only
one axis moved.

## The mechanism

**`pxPerSecond` is now "the scale at `sm`"**, not the scale on screen. Every
writer divides by the size factor and the single reader multiplies by it.

That is what lets `fit` keep its promise. `fit` means "this collection spans
the track" and computes its answer FROM the measured width, so applying the
factor on top of what it stored would make the collection stop fitting at `md`
and `lg` — a control whose whole promise is in its name, broken.

The wheel zoom needed the same treatment for a different reason: `scaleRef`
tracks the ON-SCREEN scale, so storing that back undivided would apply the
factor twice and make one notch zoom by the factor as well.

The **default** is deliberately outside the rule — with no zoom and no fit the
scale is a fitted width times the factor, so a bigger film opens with
proportionally wider boxes and runs past the track. The opening scale is a
starting point; `fit` is the promise.

## The story's first assertion was wrong

It checked that after `fit clip` the boxes span no wider than the track. It
failed at 3321px against 1153px and looked like the fix was broken.

It was the assertion: the bar draws the whole REACH window, which is more clips
than the collection `fit clip` fits, so the boxes legitimately span wider than
the track. What must hold is **invariance** — fitting lands on the same scale
whatever size the film is drawn at — and that is a direct test of the design
rather than of the fixture.

## Tests

53 modal stories pass. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)