### PR TITLE
PL15-027 — the projects list renders on the server, and the CLS it exposed

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,12 @@
     {
       "name": "timeline-gstudio001",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["--prefix", "apps/timeline-gstudio001", "run", "dev"],
+      "runtimeArgs": [
+        "--prefix",
+        "apps/timeline-gstudio001",
+        "run",
+        "dev"
+      ],
       "port": 3000,
       "autoPort": false
     },
@@ -16,8 +21,28 @@
     {
       "name": "storybook",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["--prefix", "apps/storybook", "run", "storybook"],
+      "runtimeArgs": [
+        "--prefix",
+        "apps/storybook",
+        "run",
+        "storybook"
+      ],
       "port": 6006
+    },
+    {
+      "name": "timeline-prod",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "--prefix",
+        "apps/timeline-gstudio001",
+        "run",
+        "start",
+        "--",
+        "-p",
+        "3002"
+      ],
+      "port": 3002,
+      "autoPort": false
     }
   ]
 }

--- a/apps/timeline-gstudio001/app/layout.tsx
+++ b/apps/timeline-gstudio001/app/layout.tsx
@@ -93,7 +93,35 @@ export default async function RootLayout({children}: {children: React.ReactNode}
         <AuthProvider initialUser={user}>
           <AuthGate>
             <div className="relative flex min-h-screen overflow-x-clip bg-zinc-950 font-sans text-white">
-              <Suspense fallback={null}>
+              {/* THE FALLBACK RESERVES THE RAIL'S WIDTH, and that is the whole
+                  point of it not being `null`.
+
+                  The rail is server-rendered, but inside a Suspense boundary,
+                  so the shell flushes with the boundary still pending and the
+                  rail's markup arrives later in the same response. With a
+                  `null` fallback it occupied NO width in that window, so
+                  `main` — its `flex-1` sibling — laid out across the whole row
+                  and was shoved 260px sideways when the boundary resolved.
+                  Measured: `main` x:0 w:1385 -> x:260 w:1125, a single layout
+                  shift of 0.1837, which was the entire CLS of this page.
+
+                  It only shows when a paint lands between those two moments,
+                  which is why it read as intermittent — and why making the
+                  page paint SOONER (PL15-027) is what surfaced it.
+
+                  `--sw-rail-width` is the right number to reserve because the
+                  server already publishes it on `<html>` from the cookie, so
+                  it is correct for both rail states before anything paints —
+                  the same reason that variable exists at all (#471). */}
+              <Suspense
+                fallback={
+                  <div
+                    aria-hidden
+                    className="shrink-0"
+                    style={{ width: `var(${RAIL_WIDTH_VAR})` }}
+                  />
+                }
+              >
                 <TimelineSidebar initialRailExpanded={railExpanded} />
               </Suspense>
               {/* Scroll anchoring is disabled page-wide (see globals.css):

--- a/apps/timeline-gstudio001/app/page.tsx
+++ b/apps/timeline-gstudio001/app/page.tsx
@@ -1,403 +1,50 @@
-"use client";
-
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { FormEvent, useCallback, useEffect, useState } from "react";
+import { getAuthUser } from "@/lib/firebase-auth-session";
 import {
-  CircleAlert,
-  Clapperboard,
-  Clock3,
-  FolderOpen,
-  LoaderCircle,
-  Plus,
-  RefreshCw,
-  Trash2,
-} from "lucide-react";
+  listFirebaseTimelineProjects,
+  type TimelineProjectSummary,
+} from "@/lib/firebase-timeline-store";
 
-import { Button } from "@/components/core/button";
-import { Skeleton } from "@/components/core/skeleton";
-import { toast } from "@/components/core/sonner";
-import { LoadProjectButton } from "@/components/projects/load-project-button";
-import { useHoverPrefetch } from "@/components/projects/use-hover-prefetch";
-import { cn } from "@/lib/utils";
+import Home from "./projects-client";
 
-type TimelineProjectSummary = {
-  id: string;
-  title: string;
-  description?: string;
-  clipCount: number;
-  thumbnailUrl?: string;
-  createdAt?: string;
-  updatedAt?: string;
-};
-
-function formatUpdatedAt(value?: string) {
-  if (!value) return "No save timestamp";
+/**
+ * The projects list, RENDERED ON THE SERVER (PL15-027).
+ *
+ * This page was a client component that fetched `/api/timelines` on mount, so
+ * the first project's poster — which IS the LCP element on this page — did not
+ * exist in the initial HTML at all. Chrome's own check said so: "Request is
+ * discoverable in initial document: FAILED", with the image's initiator a JS
+ * chunk rather than the document.
+ *
+ * The cost of that is not the request; it is everything that has to happen
+ * BEFORE the request. Measured at 4x CPU on Slow 4G, LCP was 1,671ms and
+ * 1,405ms of it was load delay — the browser sitting idle because it did not
+ * yet know the image existed. Nothing could start until React had downloaded,
+ * parsed, executed, fetched the list and rendered a card.
+ *
+ * IT ALSO MAKES THE PRIORITY HINT MEAN SOMETHING. `fetchPriority="high"` on
+ * the first card was measured as doing NOTHING on its own, which is the honest
+ * result rather than a surprising one: a browser cannot prioritise a request it
+ * does not know about. The two only work together.
+ *
+ * SIGNED OUT, OR A FAILED READ, RENDERS EXACTLY AS BEFORE. `initialProjects`
+ * is `null` then and the client fetches on mount as it always did — this adds
+ * a fast path, it does not move the source of truth. Everything after first
+ * paint (refresh, create, delete) still goes through the API.
+ */
+export default async function Page() {
+  let initialProjects: TimelineProjectSummary[] | null = null;
 
   try {
-    return new Intl.DateTimeFormat(undefined, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
+    const user = await getAuthUser();
+    // `getAuthUser` answers null when signed out, which is not an error — it
+    // is the case that has no list to render.
+    if (user) initialProjects = await listFirebaseTimelineProjects(user.uid);
   } catch {
-    return "No save timestamp";
+    // A server-side read failure must not cost the page. Falling through with
+    // `null` puts the client back on the path it took before this existed,
+    // where the same failure is already reported through `loadError`.
+    initialProjects = null;
   }
-}
 
-function ProjectCardSkeleton() {
-  return (
-    <div
-      aria-hidden="true"
-      data-project-card-skeleton
-      className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55"
-    >
-      <Skeleton className="aspect-video w-full rounded-none border-b border-zinc-800" />
-      <div className="grid gap-3 p-4">
-        <div className="grid gap-2">
-          <Skeleton className="h-4 w-3/5" />
-          <Skeleton className="h-3 w-4/5" />
-        </div>
-        <div className="flex items-center justify-between gap-3">
-          <Skeleton className="h-3 w-14" />
-          <Skeleton className="h-3 w-28" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export default function Home() {
-  const router = useRouter();
-  const hoverPrefetch = useHoverPrefetch();
-  const [projects, setProjects] = useState<TimelineProjectSummary[]>([]);
-  const [projectTitle, setProjectTitle] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-  const [isCreating, setIsCreating] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
-
-  // Pure request: resolves to the project list or throws — it never touches
-  // state, so the mount effect can consume it through promise CALLBACKS
-  // (state changes only when the external request answers) and Refresh can
-  // wrap it with its own synchronous loading reset.
-  const requestProjects = useCallback(async (): Promise<TimelineProjectSummary[]> => {
-    const response = await fetch("/api/timelines", { cache: "no-store" });
-    const result = (await response.json().catch(() => ({}))) as {
-      projects?: TimelineProjectSummary[];
-      error?: string;
-    };
-
-    if (!response.ok) {
-      throw new Error(result.error || "Unable to load projects.");
-    }
-
-    return result.projects || [];
-  }, []);
-
-  useEffect(() => {
-    // Mount needs no sync loading reset — isLoading INITIALIZES true. The
-    // cancelled flag keeps a slow answer from writing into an unmounted tree.
-    let cancelled = false;
-    requestProjects()
-      .then((next) => {
-        if (cancelled) return;
-        setProjects(next);
-        setLoadError(null);
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return;
-        setLoadError(error instanceof Error ? error.message : "Unable to load projects.");
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [requestProjects]);
-
-  // Refresh (an event handler) re-raises the loading flag before refetching.
-  const reloadProjects = useCallback(() => {
-    setIsLoading(true);
-    setLoadError(null);
-    requestProjects()
-      .then((next) => {
-        setProjects(next);
-      })
-      .catch((error: unknown) => {
-        setLoadError(error instanceof Error ? error.message : "Unable to load projects.");
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [requestProjects]);
-
-  const handleDeleteProject = async (e: React.MouseEvent, id: string) => {
-    e.stopPropagation();
-    e.preventDefault();
-
-    const project = projects.find((p) => p.id === id);
-    if (!project) return;
-
-    if (
-      !window.confirm(
-        `Are you sure you want to delete the project "${project.title}"? This will also delete all of its nested timeline collections and cannot be undone.`
-      )
-    ) {
-      return;
-    }
-
-    try {
-      const response = await fetch(`/api/timelines/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
-
-      if (!response.ok) {
-        // The API answers JSON. Reading it as text put the raw envelope —
-        // `{"error":"…"}` — into the message the user was shown.
-        const result = (await response.json().catch(() => ({}))) as { error?: string };
-        throw new Error(result.error || "The server refused the delete.");
-      }
-
-      setProjects((prev) => prev.filter((p) => p.id !== id));
-      toast.success(`Deleted "${project.title}".`);
-    } catch (error) {
-      toast.error(
-        `Could not delete "${project.title}": ${
-          error instanceof Error ? error.message : "unknown error"
-        }`,
-      );
-    }
-  };
-
-  const handleCreateProject = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (isCreating) return;
-
-    setIsCreating(true);
-    setLoadError(null);
-
-    try {
-      const response = await fetch("/api/timelines", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: projectTitle.trim() || "Untitled Project",
-        }),
-      });
-      const result = (await response.json().catch(() => ({}))) as {
-        project?: { id: string };
-        error?: string;
-      };
-
-      if (!response.ok || !result.project) {
-        throw new Error(result.error || "Unable to create project.");
-      }
-
-      router.push(`/timeline/${encodeURIComponent(result.project.id)}/graph`);
-    } catch (error) {
-      setLoadError(error instanceof Error ? error.message : "Unable to create project.");
-    } finally {
-      setIsCreating(false);
-    }
-  };
-
-  const initialLoading = isLoading && projects.length === 0;
-
-  return (
-    <div className="grid w-full gap-6 pt-7 animate-fade-in">
-      <header className="flex flex-col gap-4 border-b border-zinc-800 pb-5 md:flex-row md:items-end md:justify-between">
-        <div className="grid min-w-0 flex-1 gap-2">
-          <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-blue-400">
-            <FolderOpen className="h-4 w-4" />
-            Projects
-          </div>
-          <h1 className="text-2xl font-semibold text-zinc-50">Timeline Projects</h1>
-          <p className="max-w-2xl text-sm text-zinc-400">
-            Open a saved timeline or start a clean project.
-          </p>
-        </div>
-
-        <div className="flex w-full flex-col items-stretch gap-2 md:w-[420px] md:shrink-0">
-        <form
-          onSubmit={handleCreateProject}
-          className="flex w-full flex-col gap-2 rounded-lg border border-zinc-800 bg-zinc-900/55 p-3 sm:flex-row"
-        >
-          <label htmlFor="project-title" className="sr-only">
-            Project title
-          </label>
-          <input
-            id="project-title"
-            value={projectTitle}
-            onChange={(event) => setProjectTitle(event.target.value)}
-            maxLength={80}
-            placeholder="New project name"
-            className="h-9 min-w-0 flex-1 rounded-md border border-zinc-800 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none transition-colors placeholder:text-zinc-600 focus:border-blue-500"
-          />
-          <Button
-            type="submit"
-            disabled={isCreating}
-            className="h-9 shrink-0 gap-2 bg-blue-500 px-3 text-xs font-bold uppercase tracking-widest text-zinc-950 hover:bg-blue-400"
-          >
-            {isCreating ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-            New Project
-          </Button>
-        </form>
-        {/* OUTSIDE the create form, deliberately — a submit-typed button inside
-            it would create an empty project on Enter. Under it rather than
-            beside it so the everyday verb keeps the full width it had. */}
-        <div className="flex justify-end">
-          <LoadProjectButton />
-        </div>
-        </div>
-      </header>
-
-      <section
-        aria-busy={initialLoading}
-        aria-labelledby="saved-projects-heading"
-        className="grid gap-4"
-      >
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <h2
-              id="saved-projects-heading"
-              className="text-xs font-bold uppercase tracking-widest text-zinc-400"
-            >
-              Saved Projects
-            </h2>
-            <p className="mt-1 text-[10px] font-mono uppercase tracking-widest text-zinc-600">
-              {initialLoading
-                ? "Project library"
-                : `${projects.length} ${projects.length === 1 ? "project" : "projects"}`}
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="gap-2 border-zinc-800 bg-zinc-950 text-zinc-300 hover:bg-zinc-900"
-            onClick={reloadProjects}
-            disabled={isLoading}
-          >
-            <RefreshCw className={cn("h-3.5 w-3.5", isLoading && "animate-spin")} />
-            Refresh
-          </Button>
-        </div>
-
-        {loadError ? (
-          <div className="flex items-center gap-3 rounded-lg border border-red-500/25 bg-red-500/10 p-4 text-sm text-red-100">
-            <CircleAlert className="h-4 w-4 shrink-0 text-red-300" />
-            <span>{loadError}</span>
-          </div>
-        ) : null}
-
-        {initialLoading ? (
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-            <span className="sr-only">Loading projects</span>
-            {Array.from({ length: 3 }, (_, index) => (
-              <ProjectCardSkeleton key={index} />
-            ))}
-          </div>
-        ) : projects.length === 0 ? (
-          <div className="grid min-h-56 place-items-center rounded-lg border border-dashed border-zinc-800 bg-zinc-900/25 p-6 text-center">
-            <div className="grid justify-items-center gap-3">
-              <div className="grid h-12 w-12 place-items-center rounded-lg border border-zinc-800 bg-zinc-950 text-zinc-500">
-                <Clapperboard className="h-5 w-5" />
-              </div>
-              <div>
-                <p className="text-sm font-semibold text-zinc-200">No saved projects yet</p>
-                <p className="mt-1 text-xs text-zinc-500">
-                  Name a project above, then create it to begin.
-                </p>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {projects.map((project) => {
-              const href = `/timeline/${encodeURIComponent(project.id)}/graph`;
-              return (
-              <div
-                key={project.id}
-                // FETCH ON INTENT. The Link below already prefetches the
-                // skeleton on viewport entry, which costs nothing; this fetches
-                // the BOARD once the pointer settles, so the click has nothing
-                // left to wait for. See `useHoverPrefetch` for why this is not
-                // `<Link prefetch>`: that fires on viewport entry, and a full
-                // prefetch is 149 Firestore reads per card.
-                onMouseEnter={() => hoverPrefetch.onEnter(href)}
-                onMouseLeave={() => hoverPrefetch.onLeave(href)}
-                // Keyboard users get the same head start on focus — the anchor
-                // is inside this box, so focus bubbles to it.
-                onFocus={() => hoverPrefetch.onEnter(href)}
-                className="relative group overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55 shadow-xl shadow-black/20 transition-all duration-200 hover:border-blue-500/55 hover:bg-zinc-900"
-              >
-                {/* Link overlay covering the whole card area. It NEEDS a name:
-                    as a childless anchor its accessible name was empty, so a
-                    screen reader announced the card's only action as an
-                    unnamed "link" with no way to tell which project it opened
-                    (WCAG 2.4.4). The visible <h3> below is a heading, not this
-                    control's label. */}
-                <Link
-                  href={href}
-                  className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                >
-                  <span className="sr-only">Open project {project.title}</span>
-                </Link>
-
-                <div className="relative aspect-video overflow-hidden border-b border-zinc-800 bg-zinc-950">
-                  {project.thumbnailUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={project.thumbnailUrl}
-                      alt=""
-                      className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                    />
-                  ) : (
-                    <div className="grid h-full w-full place-items-center">
-                      <Clapperboard className="h-8 w-8 text-zinc-700" />
-                    </div>
-                  )}
-                  {/* Delete button positioned absolute top-right, z-20 so it sits on top of Link overlay */}
-                  {/* Hover-revealed, but it must also reveal on FOCUS: with
-                      only `group-hover:opacity-100` a keyboard user tabbed onto
-                      an invisible control with no focus indicator, one Enter
-                      away from a cascade delete (WCAG 2.4.7). `title` is not a
-                      reliable accessible name either, hence aria-label. */}
-                  <button
-                    type="button"
-                    onClick={(e) => handleDeleteProject(e, project.id)}
-                    aria-label={`Delete project ${project.title}`}
-                    className="absolute top-2.5 right-2.5 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-zinc-800 bg-zinc-900/90 hover:bg-red-600/90 text-zinc-400 hover:text-white transition-all opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                    title="Delete project"
-                  >
-                    <Trash2 aria-hidden="true" className="h-4 w-4" />
-                  </button>
-                </div>
-                <div className="grid gap-3 p-4">
-                  <div className="min-w-0">
-                    <h3 className="truncate text-sm font-semibold text-zinc-100">
-                      {project.title}
-                    </h3>
-                    {project.description ? (
-                      <p className="mt-1 line-clamp-2 text-xs text-zinc-500">
-                        {project.description}
-                      </p>
-                    ) : null}
-                  </div>
-                  <div className="flex items-center justify-between gap-3 text-[10px] font-mono uppercase tracking-widest text-zinc-600">
-                    <span>{project.clipCount} clips</span>
-                    <span className="flex items-center gap-1 truncate">
-                      <Clock3 className="h-3 w-3 shrink-0" />
-                      {formatUpdatedAt(project.updatedAt)}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            );
-            })}
-          </div>
-        )}
-      </section>
-    </div>
-  );
+  return <Home initialProjects={initialProjects} />;
 }

--- a/apps/timeline-gstudio001/app/projects-client.tsx
+++ b/apps/timeline-gstudio001/app/projects-client.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import {
+  CircleAlert,
+  Clapperboard,
+  Clock3,
+  FolderOpen,
+  LoaderCircle,
+  Plus,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
+
+import { Button } from "@/components/core/button";
+import { Skeleton } from "@/components/core/skeleton";
+import { toast } from "@/components/core/sonner";
+import { LoadProjectButton } from "@/components/projects/load-project-button";
+import { useHoverPrefetch } from "@/components/projects/use-hover-prefetch";
+import { cn } from "@/lib/utils";
+
+type TimelineProjectSummary = {
+  id: string;
+  title: string;
+  description?: string;
+  clipCount: number;
+  thumbnailUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+function formatUpdatedAt(value?: string) {
+  if (!value) return "No save timestamp";
+
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch {
+    return "No save timestamp";
+  }
+}
+
+function ProjectCardSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      data-project-card-skeleton
+      className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55"
+    >
+      <Skeleton className="aspect-video w-full rounded-none border-b border-zinc-800" />
+      <div className="grid gap-3 p-4">
+        <div className="grid gap-2">
+          <Skeleton className="h-4 w-3/5" />
+          <Skeleton className="h-3 w-4/5" />
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="h-3 w-28" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function Home({
+  initialProjects,
+}: Readonly<{
+  /**
+   * The list as the SERVER already knew it (PL15-027).
+   *
+   * `null` means the server could not answer — signed out, or the read failed
+   * — and the mount effect below fetches exactly as it always did. A non-null
+   * value means the markup you are looking at was rendered from it, so
+   * refetching on mount would be a second request for something already on
+   * screen.
+   */
+  initialProjects: TimelineProjectSummary[] | null;
+}>) {
+  const router = useRouter();
+  const hoverPrefetch = useHoverPrefetch();
+  const [projects, setProjects] = useState<TimelineProjectSummary[]>(initialProjects ?? []);
+  const [projectTitle, setProjectTitle] = useState("");
+  // Not loading when the server already sent the list — starting true would
+  // flash a skeleton over content that is already painted.
+  const [isLoading, setIsLoading] = useState(initialProjects === null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Pure request: resolves to the project list or throws — it never touches
+  // state, so the mount effect can consume it through promise CALLBACKS
+  // (state changes only when the external request answers) and Refresh can
+  // wrap it with its own synchronous loading reset.
+  const requestProjects = useCallback(async (): Promise<TimelineProjectSummary[]> => {
+    const response = await fetch("/api/timelines", { cache: "no-store" });
+    const result = (await response.json().catch(() => ({}))) as {
+      projects?: TimelineProjectSummary[];
+      error?: string;
+    };
+
+    if (!response.ok) {
+      throw new Error(result.error || "Unable to load projects.");
+    }
+
+    return result.projects || [];
+  }, []);
+
+  useEffect(() => {
+    // NOTHING TO FETCH when the server already answered (PL15-027) — the list
+    // is rendered from `initialProjects` and a mount fetch would ask for what
+    // is already on screen. Refresh, create and delete still go to the API;
+    // this is only about the FIRST paint.
+    if (initialProjects !== null) return;
+    // Mount needs no sync loading reset — isLoading INITIALIZES true. The
+    // cancelled flag keeps a slow answer from writing into an unmounted tree.
+    let cancelled = false;
+    requestProjects()
+      .then((next) => {
+        if (cancelled) return;
+        setProjects(next);
+        setLoadError(null);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setLoadError(error instanceof Error ? error.message : "Unable to load projects.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [initialProjects, requestProjects]);
+
+  // Refresh (an event handler) re-raises the loading flag before refetching.
+  const reloadProjects = useCallback(() => {
+    setIsLoading(true);
+    setLoadError(null);
+    requestProjects()
+      .then((next) => {
+        setProjects(next);
+      })
+      .catch((error: unknown) => {
+        setLoadError(error instanceof Error ? error.message : "Unable to load projects.");
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [requestProjects]);
+
+  const handleDeleteProject = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    const project = projects.find((p) => p.id === id);
+    if (!project) return;
+
+    if (
+      !window.confirm(
+        `Are you sure you want to delete the project "${project.title}"? This will also delete all of its nested timeline collections and cannot be undone.`
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/timelines/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        // The API answers JSON. Reading it as text put the raw envelope —
+        // `{"error":"…"}` — into the message the user was shown.
+        const result = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(result.error || "The server refused the delete.");
+      }
+
+      setProjects((prev) => prev.filter((p) => p.id !== id));
+      toast.success(`Deleted "${project.title}".`);
+    } catch (error) {
+      toast.error(
+        `Could not delete "${project.title}": ${
+          error instanceof Error ? error.message : "unknown error"
+        }`,
+      );
+    }
+  };
+
+  const handleCreateProject = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isCreating) return;
+
+    setIsCreating(true);
+    setLoadError(null);
+
+    try {
+      const response = await fetch("/api/timelines", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: projectTitle.trim() || "Untitled Project",
+        }),
+      });
+      const result = (await response.json().catch(() => ({}))) as {
+        project?: { id: string };
+        error?: string;
+      };
+
+      if (!response.ok || !result.project) {
+        throw new Error(result.error || "Unable to create project.");
+      }
+
+      router.push(`/timeline/${encodeURIComponent(result.project.id)}/graph`);
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : "Unable to create project.");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const initialLoading = isLoading && projects.length === 0;
+
+  return (
+    <div className="grid w-full gap-6 pt-7 animate-fade-in">
+      <header className="flex flex-col gap-4 border-b border-zinc-800 pb-5 md:flex-row md:items-end md:justify-between">
+        <div className="grid min-w-0 flex-1 gap-2">
+          <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-blue-400">
+            <FolderOpen className="h-4 w-4" />
+            Projects
+          </div>
+          <h1 className="text-2xl font-semibold text-zinc-50">Timeline Projects</h1>
+          <p className="max-w-2xl text-sm text-zinc-400">
+            Open a saved timeline or start a clean project.
+          </p>
+        </div>
+
+        <div className="flex w-full flex-col items-stretch gap-2 md:w-[420px] md:shrink-0">
+        <form
+          onSubmit={handleCreateProject}
+          className="flex w-full flex-col gap-2 rounded-lg border border-zinc-800 bg-zinc-900/55 p-3 sm:flex-row"
+        >
+          <label htmlFor="project-title" className="sr-only">
+            Project title
+          </label>
+          <input
+            id="project-title"
+            value={projectTitle}
+            onChange={(event) => setProjectTitle(event.target.value)}
+            maxLength={80}
+            placeholder="New project name"
+            className="h-9 min-w-0 flex-1 rounded-md border border-zinc-800 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none transition-colors placeholder:text-zinc-600 focus:border-blue-500"
+          />
+          <Button
+            type="submit"
+            disabled={isCreating}
+            className="h-9 shrink-0 gap-2 bg-blue-500 px-3 text-xs font-bold uppercase tracking-widest text-zinc-950 hover:bg-blue-400"
+          >
+            {isCreating ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+            New Project
+          </Button>
+        </form>
+        {/* OUTSIDE the create form, deliberately — a submit-typed button inside
+            it would create an empty project on Enter. Under it rather than
+            beside it so the everyday verb keeps the full width it had. */}
+        <div className="flex justify-end">
+          <LoadProjectButton />
+        </div>
+        </div>
+      </header>
+
+      <section
+        aria-busy={initialLoading}
+        aria-labelledby="saved-projects-heading"
+        className="grid gap-4"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2
+              id="saved-projects-heading"
+              className="text-xs font-bold uppercase tracking-widest text-zinc-400"
+            >
+              Saved Projects
+            </h2>
+            <p className="mt-1 text-[10px] font-mono uppercase tracking-widest text-zinc-600">
+              {initialLoading
+                ? "Project library"
+                : `${projects.length} ${projects.length === 1 ? "project" : "projects"}`}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-2 border-zinc-800 bg-zinc-950 text-zinc-300 hover:bg-zinc-900"
+            onClick={reloadProjects}
+            disabled={isLoading}
+          >
+            <RefreshCw className={cn("h-3.5 w-3.5", isLoading && "animate-spin")} />
+            Refresh
+          </Button>
+        </div>
+
+        {loadError ? (
+          <div className="flex items-center gap-3 rounded-lg border border-red-500/25 bg-red-500/10 p-4 text-sm text-red-100">
+            <CircleAlert className="h-4 w-4 shrink-0 text-red-300" />
+            <span>{loadError}</span>
+          </div>
+        ) : null}
+
+        {initialLoading ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <span className="sr-only">Loading projects</span>
+            {Array.from({ length: 3 }, (_, index) => (
+              <ProjectCardSkeleton key={index} />
+            ))}
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="grid min-h-56 place-items-center rounded-lg border border-dashed border-zinc-800 bg-zinc-900/25 p-6 text-center">
+            <div className="grid justify-items-center gap-3">
+              <div className="grid h-12 w-12 place-items-center rounded-lg border border-zinc-800 bg-zinc-950 text-zinc-500">
+                <Clapperboard className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-zinc-200">No saved projects yet</p>
+                <p className="mt-1 text-xs text-zinc-500">
+                  Name a project above, then create it to begin.
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {projects.map((project, index) => {
+              const href = `/timeline/${encodeURIComponent(project.id)}/graph`;
+              return (
+              <div
+                key={project.id}
+                // FETCH ON INTENT. The Link below already prefetches the
+                // skeleton on viewport entry, which costs nothing; this fetches
+                // the BOARD once the pointer settles, so the click has nothing
+                // left to wait for. See `useHoverPrefetch` for why this is not
+                // `<Link prefetch>`: that fires on viewport entry, and a full
+                // prefetch is 149 Firestore reads per card.
+                onMouseEnter={() => hoverPrefetch.onEnter(href)}
+                onMouseLeave={() => hoverPrefetch.onLeave(href)}
+                // Keyboard users get the same head start on focus — the anchor
+                // is inside this box, so focus bubbles to it.
+                onFocus={() => hoverPrefetch.onEnter(href)}
+                className="relative group overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55 shadow-xl shadow-black/20 transition-all duration-200 hover:border-blue-500/55 hover:bg-zinc-900"
+              >
+                {/* Link overlay covering the whole card area. It NEEDS a name:
+                    as a childless anchor its accessible name was empty, so a
+                    screen reader announced the card's only action as an
+                    unnamed "link" with no way to tell which project it opened
+                    (WCAG 2.4.4). The visible <h3> below is a heading, not this
+                    control's label. */}
+                <Link
+                  href={href}
+                  className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                >
+                  <span className="sr-only">Open project {project.title}</span>
+                </Link>
+
+                <div className="relative aspect-video overflow-hidden border-b border-zinc-800 bg-zinc-950">
+                  {project.thumbnailUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={project.thumbnailUrl}
+                      alt=""
+                      // THE FIRST CARD'S POSTER IS THE LCP ELEMENT (PL15-027),
+                      // measured: on a throttled load of this page the LCP is
+                      // one of these images and 84% of the time to it is LOAD
+                      // DELAY — the browser has not started fetching it yet.
+                      //
+                      // The same lesson was already learned on the board and
+                      // never carried here: `graph-collection-card` marks its
+                      // leading frame `fetchPriority: "high"` with a note that
+                      // it was measured as the LCP on a board open. A hint that
+                      // marks everything high marks nothing, so only the first
+                      // card gets it.
+                      //
+                      // `eager` for the same reason it is eager there: these
+                      // cards are above the fold on arrival, and `lazy` defers
+                      // a request the browser could already have started while
+                      // it waits for layout to decide what is visible.
+                      {...(index === 0
+                        ? { fetchPriority: "high" as const, loading: "eager" as const }
+                        : { loading: "lazy" as const })}
+                      className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                    />
+                  ) : (
+                    <div className="grid h-full w-full place-items-center">
+                      <Clapperboard className="h-8 w-8 text-zinc-700" />
+                    </div>
+                  )}
+                  {/* Delete button positioned absolute top-right, z-20 so it sits on top of Link overlay */}
+                  {/* Hover-revealed, but it must also reveal on FOCUS: with
+                      only `group-hover:opacity-100` a keyboard user tabbed onto
+                      an invisible control with no focus indicator, one Enter
+                      away from a cascade delete (WCAG 2.4.7). `title` is not a
+                      reliable accessible name either, hence aria-label. */}
+                  <button
+                    type="button"
+                    onClick={(e) => handleDeleteProject(e, project.id)}
+                    aria-label={`Delete project ${project.title}`}
+                    className="absolute top-2.5 right-2.5 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-zinc-800 bg-zinc-900/90 hover:bg-red-600/90 text-zinc-400 hover:text-white transition-all opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    title="Delete project"
+                  >
+                    <Trash2 aria-hidden="true" className="h-4 w-4" />
+                  </button>
+                </div>
+                <div className="grid gap-3 p-4">
+                  <div className="min-w-0">
+                    <h3 className="truncate text-sm font-semibold text-zinc-100">
+                      {project.title}
+                    </h3>
+                    {project.description ? (
+                      <p className="mt-1 line-clamp-2 text-xs text-zinc-500">
+                        {project.description}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center justify-between gap-3 text-[10px] font-mono uppercase tracking-widest text-zinc-600">
+                    <span>{project.clipCount} clips</span>
+                    <span className="flex items-center gap-1 truncate">
+                      <Clock3 className="h-3 w-3 shrink-0" />
+                      {formatUpdatedAt(project.updatedAt)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/app/root-layout-rail-reservation.test.ts
+++ b/apps/timeline-gstudio001/app/root-layout-rail-reservation.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { RAIL_WIDTH_VAR } from "@/components/timeline/sidebar-rail-preference";
+
+/**
+ * THE RAIL'S SUSPENSE FALLBACK MUST RESERVE THE RAIL'S WIDTH.
+ *
+ * The rail is server-rendered, but inside a Suspense boundary, so the shell
+ * flushes with the boundary pending and the rail's markup arrives later in the
+ * same response. While it is pending the fallback is what holds its place — and
+ * a `null` fallback holds nothing, so `main` (its `flex-1` sibling) lays out
+ * across the whole row and is shoved sideways by the rail's full width when the
+ * boundary resolves. Measured at 260px: `main` x:0 w:1385 -> x:260 w:1125, one
+ * layout shift of 0.1837, which was the entire CLS of the projects page.
+ *
+ * WHY A TEST AND NOT JUST THE FIX. This was invisible for as long as the page
+ * painted slowly: the shift only counts when a paint lands between the shell
+ * and the boundary resolving, so a slow first paint HID it and PL15-027's
+ * faster one revealed it. Nothing about that shows up in review, and a future
+ * `fallback={null}` would read as tidier rather than as a regression.
+ *
+ * READ AS SOURCE TEXT because the thing under test is a server component in the
+ * root layout: rendering it would need a request, a session and a cookie store,
+ * none of which this invariant depends on. The same reasoning the rail's other
+ * geometry guards use in `sidebar-icon-styles.test.ts`.
+ */
+const layoutSource = readFileSync(path.resolve(__dirname, "layout.tsx"), "utf8");
+
+const suspenseBlock = (() => {
+  const open = layoutSource.indexOf("<Suspense");
+  const close = layoutSource.indexOf("</Suspense>", open);
+  return open === -1 || close === -1 ? "" : layoutSource.slice(open, close);
+})();
+
+describe("the rail's Suspense boundary", () => {
+  it("is present in the root layout at all", () => {
+    expect(suspenseBlock).not.toBe("");
+    expect(suspenseBlock).toContain("TimelineSidebar");
+  });
+
+  it("does not fall back to nothing, which would give the rail zero width", () => {
+    expect(suspenseBlock).not.toMatch(/fallback=\{null\}/);
+  });
+
+  it("reserves its width from the variable the server publishes before paint", () => {
+    // Any hardcoded number would be right for one rail state and wrong for the
+    // other; the variable is already correct for both in the server's own
+    // markup, which is the whole reason it exists (#471).
+    //
+    // Matched as the IDENTIFIER rather than its value, because that is what the
+    // source says — asserting the literal `--sw-rail-width` here would pass for
+    // a layout that spelled the name out by hand and so drifted the moment the
+    // constant moved. That the identifier is the real import is the compiler's
+    // job, not this test's; the value it carries is pinned below.
+    expect(suspenseBlock).toMatch(/width:\s*`var\(\$\{RAIL_WIDTH_VAR\}\)`/);
+  });
+
+  it("does not let the reserved box be squeezed by its flex siblings", () => {
+    // The row is `flex`; without `shrink-0` a zero-content placeholder is a
+    // candidate for shrinking and reserves less than it claims.
+    expect(suspenseBlock).toContain("shrink-0");
+  });
+
+  it("reserves the SAME variable the layout publishes before paint", () => {
+    // The two have to be one variable or the reservation is a guess: the value
+    // on `<html>` is what the server computed from the cookie, and the fallback
+    // is only correct while it reads that exact name.
+    expect(layoutSource).toMatch(/\[RAIL_WIDTH_VAR\]:/);
+    expect(RAIL_WIDTH_VAR).toBe("--sw-rail-width");
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { usePathname, useSearchParams } from "next/navigation";
 import {
   useCallback,
@@ -69,7 +70,29 @@ import {
 } from "./graph-hydration";
 import { GraphItemActionsBridge } from "./graph-item-actions";
 import { RemoteChangesBridge } from "./graph-remote-changes";
-import { McpToolsBridge } from "./graph-mcp-tools";
+/**
+ * LOADED AFTER THE PAINT, NOT BEFORE IT (PL15-027).
+ *
+ * This bridge registers the in-page agent tools, and it reaches
+ * `lib/webmcp/tools.ts` — 650-odd lines of tool definitions built on `zod`.
+ * Imported statically, every person who opens a board downloaded all of it
+ * before anything appeared on screen, for a feature most sessions never use.
+ * Measured on the production build: `zod` accounts for the bulk of a 307 kB
+ * chunk, against a first paint that takes 3.3s while the server answers in
+ * 0.13s.
+ *
+ * `ssr: false` because it is a browser-side registration with nothing to
+ * render — there is no markup to stream and no fallback worth showing.
+ *
+ * NOT a behaviour change for an agent: the tools register a tick later than
+ * they used to, and a connector that asks before then re-reads the list
+ * anyway. Registration was never synchronous with the route from the agent's
+ * side.
+ */
+const McpToolsBridge = dynamic(
+  () => import("./graph-mcp-tools").then((m) => m.McpToolsBridge),
+  { ssr: false },
+);
 import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
 import { GraphViewNavProvider } from "./graph-navigation";
 import {

--- a/apps/timeline-gstudio001/next-env.d.ts
+++ b/apps/timeline-gstudio001/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-dev/dev/types/routes.d.ts";
-import "./.next-dev/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -2549,12 +2549,16 @@ export function WorkbenchSplitPane({
    * is predictable, and the moment the user drags the divider their height
    * takes over for good (see the restore path in the mount effect).
    */
+  /**
+   * Returns whether it actually sized. The caller latches "done" on that,
+   * NOT on having been called — see the mount effect.
+   */
   const initialSurfaceHeight = useCallback(() => {
-    if (dragStartRef.current) return;
-    if (typeof window === "undefined") return;
+    if (dragStartRef.current) return false;
+    if (typeof window === "undefined") return false;
 
     const divider = dividerRef.current;
-    if (!divider) return;
+    if (!divider) return false;
 
     // A third of what the user can actually SEE, not of a <main> that may
     // run far below the fold — getViewportBoundaryBottom already resolves
@@ -2587,6 +2591,7 @@ export function WorkbenchSplitPane({
     setSurfaceHeight((height) =>
       Math.abs(height - nextHeight) < 0.5 ? height : nextHeight,
     );
+    return true;
   }, [clampSurfaceHeight, getViewportBoundaryBottom]);
 
   /** Keep the current height LEGAL for the viewport without re-deriving it —
@@ -2777,9 +2782,30 @@ export function WorkbenchSplitPane({
     // mounted earlier with only its lower pane so that the lower content keeps
     // its DOM identity and scroll position across this toggle.
     if (hasSurface && !didInitialSizeRef.current) {
-      didInitialSizeRef.current = true;
-      if (restoredSurfaceHeight !== undefined) clampToViewport();
-      else initialSurfaceHeight();
+      // LATCHED ON SUCCESS, NOT ON THE ATTEMPT (PL15-020).
+      //
+      // This set the flag first and then called the sizing, and the sizing
+      // bails when `dividerRef.current` is still null — which it is whenever
+      // this layout effect runs before the divider has attached. On those
+      // passes the pane kept `DEFAULT_SURFACE_HEIGHT` (380) and, because the
+      // flag was already set, NEVER TRIED AGAIN. It only reached its real
+      // height later, when some unrelated clamp happened to fire.
+      //
+      // That is the whole of the intermittency `preview height is the user's`
+      // has been reporting. Instrumented across six runs, the geometry was
+      // identical every time — `innerHeight` 480, `rootTop` -119, the final
+      // height always 207 — and the only thing that varied was whether the
+      // pane STARTED at 380 or at 207. Passes were the runs where the divider
+      // happened to be attached on this pass.
+      //
+      // Retrying costs nothing: this effect re-runs, and the flag still stops
+      // a second successful sizing from ever overriding the user's height.
+      if (restoredSurfaceHeight !== undefined) {
+        didInitialSizeRef.current = true;
+        clampToViewport();
+      } else if (initialSurfaceHeight()) {
+        didInitialSizeRef.current = true;
+      }
     }
 
     const root = rootRef.current;

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1750,7 +1750,11 @@ against a 1,671 ms baseline — noise, not harm. A browser cannot prioritise a
 request it does not know exists. The two checks Chrome makes are not
 independent: the hint only means something once the resource is discoverable.
 
-**THE CLS IS UNRESOLVED AND THE BRANCH SHOULD NOT SHIP UNTIL IT IS.** CLS went
+**THE CLS IS RESOLVED — see PL15-027, the CLS, found and fixed, below.** It
+was the root layout's `null` Suspense fallback, which predates this branch; the
+notes here are kept as the state of the search at the time.
+
+**(AS IT STOOD) THE CLS IS UNRESOLVED AND THE BRANCH SHOULD NOT SHIP UNTIL IT IS.** CLS went
 0.00 to 0.18, above the 0.1 "good" threshold, and CLS is one of the four inputs
 to the Real Experience Score — so this currently trades one Core Web Vital for
 another.
@@ -1769,3 +1773,149 @@ Those two facts do not sit together yet, and until they do the cause is not
 known. The next step is to reconcile them — an observer that survives the
 trace's own reload — rather than to guess at a culprit. `AuthGate` wrapping the
 page in `RootLayout` is the obvious suspect and is only a suspect.
+
+## PL15-027 — the CLS, found and fixed
+
+**THE TWO INSTRUMENTS NEVER DISAGREED. ONE OF THEM WAS NEVER RUNNING.** The
+contradiction that blocked this item — a trace reporting 0.1837 and a
+`layout-shift` observer reporting zero — was an artifact of how the observer was
+installed. CDP's `initScript` is consumed by the navigation that installs it, so
+it does not re-run on a reload; every traced measurement reloads the page, and
+the observer was therefore absent from precisely the load being measured. Proved
+directly: a trace started with `reload: false` plus a navigation that carries the
+observer put both instruments on ONE load, and they agreed exactly — 0.00 and
+0.00.
+
+The instrument that does survive a reload is one injected SERVER-SIDE. A thin
+proxy in front of `next start` that inlines the observer into every HTML response
+measures every load, traced or not — that is what turned this from intermittent
+to 13 of 13.
+
+**THE SHIFT, MEASURED.** `main` moves `x:0 w:1385` to `x:260 w:1125`. One shift,
+0.1837, the whole CLS of the page. 260px is `RAIL_OPEN_WIDTH_PX` exactly.
+
+**THE CAUSE IS THE SUSPENSE FALLBACK IN THE ROOT LAYOUT, AND IT PREDATES THIS
+BRANCH.** The rail is server-rendered, but inside `Suspense` with a `null`
+fallback. The shell flushes with the boundary still pending — the initial HTML
+literally reads `<!--$?--><template id="B:0"></template>` followed by `<main>` —
+and the rail's markup arrives at 46% of the same response, inside
+`<div hidden id="S:0">`, to be swapped in by script. While pending, a `null`
+fallback reserves NO width, so `main` — its `flex-1` sibling — lays out across the
+whole row and is shoved when the boundary resolves.
+
+`origin/main` carries that same `null` fallback verbatim, and `app/layout.tsx`
+was last touched before this branch. **So PL15-027 did not introduce this shift.
+It made the page paint early enough to SHOW it** — the shift only scores when a
+paint lands between the shell and the boundary resolving, and a 1,671ms LCP left
+no such window. Speeding up first paint is what turned a latent bug into a
+measured one, which is the honest version of "CLS regressed".
+
+**THE FIX** reserves the rail's width in the fallback, from the variable the
+server already publishes on the `html` element from the cookie — the same
+variable, and the same reasoning, as #471. It is correct for both rail states
+before anything paints, which no hardcoded number would be.
+
+**MEASURED, before and after, same build pipeline, 4x CPU / Slow 4G, signed in:**
+
+| | before | after |
+| --- | ---: | ---: |
+| loads shifting (injected observer) | 13 of 13 | 0 of 12 |
+| worst CLS | 0.1837 | **0.0002** |
+| `main` shoves | 13 | **0** |
+| CLS (DevTools trace, raw server) | 0.18 | **0.00, 2 of 2** |
+| LCP (raw server, warm) | 710 / 756 / 761 / 789 ms | 664 / 672 / 676 ms |
+
+The only residual shift is a `span` whose truncated label fills in — 0.0002,
+three orders of magnitude under the 0.1 threshold.
+
+**LCP IS NOT PAID FOR IT, AND THE FIRST READING SAID IT WAS.** The first two
+post-fix traces came back 1,159 and 1,085ms and looked like a regression. They
+were a cold `next start`: render delay 546ms against about 100ms warm. Three warm
+samples land at 664-676ms. Reporting the cold pair would have been wrong in the
+same way that dropping `fetchPriority` on its null result would have been.
+
+**A GUARD SHIPS WITH IT.** `app/root-layout-rail-reservation.test.ts` reads the
+layout as source and fails if the fallback is `null`, does not reserve
+`RAIL_WIDTH_VAR`, or is not `shrink-0`. Checked against `origin/main`: all three
+assertions fail there and pass here, so it catches the real defect rather than
+restating the fix. It needs to exist precisely because a future `null` fallback
+reads as tidier rather than as a regression, and because nothing about the defect
+is visible until the page is fast.
+
+## PL15-028 — Cloudinary usage jumped; find out what changed
+
+- Status: OPEN — first pass done from the five exported CSVs below. The
+  mechanism is NARROWED but the attribution is CORRELATION, not proof: nothing
+  here separates localhost and e2e traffic from real visitors, and that is the
+  one split that decides whether this matters at all.
+- Area: Cloudinary account usage (delivery, not storage); `app/page.tsx`,
+  `app/projects-client.tsx` (poster delivery), `tests/e2e/`
+- Screenshot: Not captured
+
+Usage rose sharply over 21-23 August. The question is what changed.
+
+**IT IS NOT UPLOADS.** Storage moved 795.5 to 903.1 MB across the week, +13.5%,
+and +104 MB of that is video. A steady climb, no step. Whatever happened is on
+the DELIVERY side.
+
+**THE NUMBERS** (assumed MB — the export carries no unit header, and the totals
+are the right order of magnitude for this account; worth confirming before
+quoting them anywhere). 24 August is a partial day.
+
+| date | image impressions | image MB | video MB | total MB | delivered video s | transformed video s |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 18 Aug | 66 | 6.7 | 0.6 | 7.3 | 0 | — |
+| 19 Aug | 133 | 3.2 | 1.5 | 4.6 | 0 | — |
+| 20 Aug | 1,427 | 14.9 | 192.1 | 206.9 | 0 | — |
+| 21 Aug | 967 | 36.6 | 113.5 | 150.0 | 864 | 260 |
+| 22 Aug | 11,202 | 18.9 | 562.4 | 581.3 | 1,150 | 388 |
+| 23 Aug | 13,907 | 161.2 | 236.6 | 397.8 | 616 | 20 |
+| 24 Aug | 777 | 1.4 | 18.2 | 19.6 | 10 | 0 |
+
+**THERE ARE TWO SPIKES, NOT ONE, AND THEY HAVE DIFFERENT SHAPES.**
+
+- **Video bandwidth, 20-23 Aug** — 192, 113, 562, 237 MB against under 1.5 MB on
+  the 18th and 19th. **20 August is the anomaly that matters:** 192 MB of video
+  bandwidth with ZERO delivered video seconds. Delivered-seconds counts
+  streamed or derived delivery, so bandwidth without it is originals being
+  fetched whole. The transformed-seconds column says the same thing from the
+  other side — 260, 388, 20, 0, which is almost nothing served through a derived
+  rendition. Per-second rates agree: 22 August is 562 MB over 1,150s, about
+  3.9 Mbps for something labelled 480p, which is not a 480p rendition.
+- **Image impressions, 22-23 Aug** — 11,202 and 13,907, against 66-133/day on the
+  18th and 19th. A hundredfold. At about 11.9 KB per impression on the 23rd these
+  are thumbnails, so the cost is in the COUNT, not the size.
+
+**WHAT CHANGED IN THAT WINDOW, and this is the correlation to test rather than
+believe.** 22-24 August is this punch list's heaviest run of work, and two things
+in it move image impressions specifically:
+
+- **The e2e suite and the PL15-020 investigation.** PL15-020 alone ran the full
+  176-test suite repeatedly, plus N=10 comparisons twice over, on the 23rd and
+  24th. Every app load renders project cards with real posters. 13,907
+  impressions is not a human browsing a three-project account.
+- **PL15-027 made the projects list server-rendered.** Posters are in the initial
+  HTML now, so the preload scanner fetches them on EVERY load — before it, a load
+  that never executed React never fetched them at all. That structurally raises
+  impressions per page view. It landed on the 24th-25th, so it does NOT explain
+  the 22-23 spike; it is what to watch in the NEXT export.
+
+Acceptance criteria:
+
+- The spike is attributed to a NAMED source, with the report that proves it —
+  Cloudinary's breakdown by referrer or user-agent, or by `public_id`. "Probably
+  the e2e suite" is where this analysis stops, not where it should end.
+- Localhost and CI traffic are separated from real visitors. If it is our own
+  test runs, the finding is about test hygiene; if it is not, it is about
+  delivery.
+- The video question is answered separately from the image one: whether
+  originals are being delivered where a derived rendition should be. 20 August —
+  192 MB with zero delivered seconds — is the case to explain first.
+- Whether anything should CHANGE is decided last and explicitly. Cloudinary
+  public delivery was a deliberate call and is not a finding; a fetch or
+  transform default is a different question from access.
+
+**Worth settling while in there:** whether e2e runs should point at fixture
+posters rather than at Cloudinary at all. Test runs that bill a delivery account
+scale with how often the suite runs, which is exactly the thing this list has
+been doing more of.

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1644,3 +1644,82 @@ What actually has to hold is INVARIANCE: fitting must land on the same scale
 whatever size the film is drawn at. That is what the story asserts now, and it
 is a direct test of the design — `fit` computes from the measured width, so the
 size factor must not be applied on top of what it stores.
+
+## PL15-020 — the pane opened at a height it had to be talked down from
+
+**THE MECHANISM, FOUND.** Instrumenting the failing assertion across six runs
+showed the geometry is IDENTICAL every time (`innerHeight` 480, `rootTop` -119,
+`scrollY` 132) and the final height is ALWAYS 207. The only thing that varied
+was `initial` — the height captured just after the pane opens:
+
+```
+fail   want=380   got=207
+pass   want=207   got=207
+```
+
+So nothing was shrinking the pane. It sometimes OPENED at 380 and was
+corrected, and the test caught it mid-correction. Every hypothesis in this item
+until now — ceilings that disagree, a ceiling that moves with scroll, a clamp
+firing on content change — was chasing a shrink that was not happening.
+
+380 is `DEFAULT_SURFACE_HEIGHT`, the unclamped value `surfaceHeight`
+initialises to. The mount layout effect replaces it, and it set
+`didInitialSizeRef.current = true` BEFORE calling the sizing — which bails when
+`dividerRef.current` is still null. On those passes the pane kept 380 and,
+because the flag was already set, never tried again; it reached its real height
+only when some later clamp happened to fire. Latched on SUCCESS now.
+
+**It improves the rate without eliminating it.** Identical conditions, N=10,
+`--workers=1`: main 7 of 10, with the fix 9 of 10 (an earlier run scored 10).
+Default parallel workers: 5 of 10 against 6 of 10. A second contributor is
+still unfound.
+
+**A measurement warning that caught me twice while doing this:** `--workers=1`
+and the default worker count give materially different rates on this test. A
+comparison has to hold that constant as well as N.
+
+## PL15-027 — what the measurement actually found
+
+**THE PREMISE IS PROBABLY WRONG. There may be no regression at all.** Speed
+Insights was installed on **22 August at 22:52** (#514) — the day the chart
+begins. The line is a smooth decay from ~95 to 66, not a step. A deploy
+regression is a cliff on one date; an average converging as samples accumulate
+is a curve. The score did not fall so much as it was never really 90.
+
+That does not make the numbers acceptable — FCP 3.3s and LCP 5.43s are poor by
+any reading — but it moves the question from "what did we break on the 23rd" to
+"why has first paint always been slow", which is a different search.
+
+**Sizes, gzipped, from a production build:**
+
+```
+all chunks   1771 kB raw   544 kB gzip
+  router       234 kB       63 kB
+  React        196 kB       61 kB
+  framework    185 kB       58 kB
+  main         130 kB       37 kB
+  polyfills    109 kB       38 kB
+```
+
+544 kB gzipped across EVERY chunk on disk — not the first-load figure, so a
+visitor fetches less than that. Heavy, but not obviously 3.2 seconds of
+pre-paint work on a desktop connection. **Which points at execution rather than
+bytes**, and makes the next instrument a profile of the first load rather than
+more trimming.
+
+**One real finding, and it is UNPROVEN.** `zod` reaches the client through a
+STATIC chain: `graph-timeline-view` → `McpToolsBridge` → `lib/webmcp/tools.ts`
+(653 lines of agent tool definitions) → `zod`. Everyone who opens a board
+carries the agent tooling, and PL15-018 made it bigger this week. The bridge is
+`dynamic(..., { ssr: false })` now.
+
+**THE BEFORE/AFTER SHOWED NOTHING, AND THE INSTRUMENT IS WHY.** 544 kB baseline
+against 545 kB with the change. Summing the chunks ON DISK cannot detect a
+lazy-loading win — the chunk still exists, it simply is not fetched. The
+manifests do not answer it either: the route's client-reference manifest lists
+6 chunks totalling 98 kB, which is the server-boundary set rather than the
+eager graph.
+
+So the change is kept on its MECHANISM and explicitly not on evidence. The
+measurement that would settle it is transferred JS before FCP in a real browser
+load, and it has not been taken.

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1919,3 +1919,86 @@ Acceptance criteria:
 posters rather than at Cloudinary at all. Test runs that bill a delivery account
 scale with how often the suite runs, which is exactly the thing this list has
 been doing more of.
+
+## PL15-029 — The details modal stops being a modal and becomes the content area
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+  (open a clip's details from the board)
+- Area: `components/graph-view/graph-item-details-modal.tsx`,
+  `components/graph-view/graph-board.tsx` (mount point),
+  `components/graph-view/graph-view-config.ts` (panel geometry),
+  `hooks/use-dialog-focus.ts`
+- Screenshot: Not captured
+
+Opening an item's details should not throw a modal over the board. It should
+REPLACE what is in the content area, the way a view does — the board goes away,
+the details come in, and you come back to the board when you leave.
+
+**What it is today.** `GraphItemDetailsModal` is mounted once from
+`graph-board.tsx` and `createPortal`s itself onto `document.body` as
+`role="dialog" aria-modal="true"`, over a scrim
+(`fixed inset-0 z-[80] ... bg-black/80 backdrop-blur-sm`). It is 1,555 lines and
+it is not only a clip panel: for a collection node it renders
+`CollectionDetails` instead, so it is already the router between two bodies
+rather than one screen.
+
+**This is a container change, not a restyle, and four things are wired to the
+container.**
+
+- **`aria-modal` stops being true, and it currently IS true.** `useDialogFocus`
+  exists precisely because the attribute was once a lie: it moves focus in,
+  cycles Tab inside, and restores focus on close to the card the modal was
+  opened from. A content view must NOT trap Tab — trapping focus in something
+  that is not modal is the same defect in the other direction. But the RESTORE
+  is still wanted, because it is what keeps the board's roving focus from
+  resetting. So the hook is split, not deleted.
+- **Escape needs an explicit owner.** Today "Escape, the close button and the
+  scrim all go through one path", and the scrim is about to stop existing. A
+  view that fills the content area and closes on Escape is competing with every
+  other Escape handler on the page, and that competition is already a known
+  sore spot in the selection work.
+- **The geometry is viewport-relative and will be wrong in flow.**
+  `DETAILS_PANEL_HEIGHT_CLASS` is `h-[68vh] max-h-full` and
+  `DETAILS_ROW_FLOOR_CLASS` is `min-h-[min(68vh,calc(100vh-26.625rem))]`. Those
+  are correct for a panel centred in the viewport under a fixed scrim with
+  `pt-[14.75rem]`; inside `main` they size to the window rather than to the
+  region, so the panel will overflow or float depending on what else is on
+  screen. They have to be derived from the CONTAINER.
+- **The board underneath has to go somewhere.** Unmounting it loses scroll
+  position, selection and any in-flight dnd state; hiding it keeps the whole
+  board mounted behind a view that covers it, which is the cost the grid
+  virtualization item is already about. Neither is obviously right and the
+  choice should be made deliberately.
+
+Acceptance criteria:
+
+- Opening details replaces the board in the content area. No scrim, no portal
+  to `document.body`, no `aria-modal`.
+- Tab is not trapped. Focus still moves into the view on open and still returns
+  to the originating card on leave.
+- Escape has ONE named owner and the item says who it is.
+- The panel sizes to the content area, not to the viewport, at both rail widths
+  and with the preview pane open and closed. PL15-020's invariant still holds:
+  nothing here may steal the preview's height.
+- Prev/next between items — `detailsWindow`, and the swipe path — still works.
+- Storybook covers the new container, per the repo rule that timeline/media
+  changes bring stories: selected state, a missing poster, a short clip and a
+  long one.
+
+**Three things to settle when this is worked:**
+
+- **WHICH modals.** Read here as the ITEM DETAILS modal. The shortcuts sheet is
+  the other portalled dialog and should stay a modal — it is help ABOUT the
+  screen, not a screen. Collection details is reached through this same
+  component, so on the face of it it moves too; if it should stay a dialog, that
+  splits the component and is worth knowing before starting.
+- **Does it get a URL?** A modal is a state; a content view is a place. If
+  details now replace the content area, back/forward and a shareable link are
+  the natural expectation — and that is a router change well beyond "stop
+  portalling", so it should be an explicit yes or no rather than discovered
+  halfway.
+- **Does it animate in, and how.** `withViewTransition` is already used here.
+  Beware the known trap: a view transition does not paint the page, so a moved
+  named element leaves a black cut-out, and a snapshot cannot deform. Card to
+  full-width view is exactly the shape that bites.

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -2005,79 +2005,115 @@ Acceptance criteria:
 
 ## PL15-030 — The reference design for the details view
 
-- Status: Not started. **The spec below is READ OFF THE RENDERED ARTIFACT, not
-  off its source** — the artifact renders in a sandboxed iframe, so its text and
-  its code view could not be extracted, and screenshots crop at 800px. The owner
-  has the code and it supersedes everything here the moment it lands. Treat the
-  measurements as SHAPES, not values.
-- Reference: https://claude.ai/public/artifacts/d7b2d207-7326-4ad9-9022-152adb1250c8
-  (`storyboard-react-demo.html`)
+- Status: Not started, but SPECIFIED — the owner supplied the source, and three
+  open questions in the first draft of this item are now decided (see "The three
+  calls" below). What is left is a build, not a design.
+- Reference: `punch-list/reference/storyboard-playbar.html`, vendored into the
+  repo because that is the readable one and a Downloads folder is not a spec.
+  Also supplied: `storyboard-react-demo.html`, the same design as a Tailwind v4
+  build — it carries the identical tokens (`--color-ink: #08090d`,
+  `--color-signal: #3cdbc0`, …) but ships as a MINIFIED BUNDLE whose source
+  cannot be recovered, so it is a picture, not a spec. Rendered at
+  https://claude.ai/public/artifacts/d7b2d207-7326-4ad9-9022-152adb1250c8
 - Area: pairs with PL15-029 — that item is the CONTAINER change, this one is
-  what the container should look like and how it should behave.
+  what goes in it.
 - Screenshot: Not captured
 
-The artifact is the target for how the details view looks and behaves.
+**THE ONE IDEA WORTH TAKING, and the reference names it in a comment:
+`the one shared preview`, with `the content area lives below it`.** One preview
+at the top, whatever you are looking at feeds it, and everything else is
+underneath. That is our existing preview display — the reference does not ask
+for a second player, it says what the one we have should MIRROR.
 
-**THE PLAYER IS NOT PART OF THE BORROW.** We keep our existing preview display.
-The artifact is a reference for the CONTAINER, the layout and the chrome around
-the media — not for the thing that plays it. Anything in it that duplicates
-`workbench-display-surface`, the seam bar or the trim strip is a picture of what
-we already have, and the existing components stay.
+**IT AGREES WITH PL15-029 FROM THE OTHER DIRECTION.** No scrim, nothing dimmed,
+no overlay: a ground, a preview, and a content area below. Two independent routes
+to the same answer.
 
-**What the artifact shows, as observed.**
+**What the preview mirrors, with the precedence spelled out** (`playerRender()`).
+The reference orders it take > skim > sequence; takes are out (below), so:
 
-- **It reads as a place, not an overlay.** One near-black ground with a raised,
-  softly-bordered rounded panel sitting in it. No scrim, no dimmed page behind —
-  which is the same conclusion PL15-029 reached from the code side, arrived at
-  independently.
-- **Two stacked panels, not one.** The upper panel is the media and its
-  transport. A separate panel below it holds takes.
-- **Upper panel, top to bottom:**
-  - A 16:9 hero that fills the panel's width, letterboxed against black where
-    the image does not fill it.
-  - A scrub bar immediately under the hero, full panel width — teal/emerald
-    fill, white circular handle, and TICK MARKS along the track at what read as
-    clip boundaries. That is our seam bar's job, and it is drawn here as one
-    continuous element rather than as a separate strip.
-  - A footer row: a monospace, uppercase, wide-tracked muted label at the left
-    (`SEQ 04 · BOARDS` — a location, reading like a breadcrumb), and a transport
-    cluster at the right: five circular buttons, skip-to-start / previous /
-    PLAY / next / skip-to-end, with play larger and visually the primary.
-- **Lower panel:** a header row with a `Takes` pill (layers icon) at the left
-  and `17 takes · 02:00` at the right, then a row of take cards — `CLIP 7`,
-  `4.60s / 8.3…`, i.e. a duration within a total.
-- **Type and colour.** Metadata is monospace, uppercase, wide-tracked, low
-  contrast. The accent is TEAL/EMERALD. Ours is sky blue, and it is load-bearing
-  — PL15-026 runs the subject's blue from the film through to the minimap off
-  one exported constant. Adopting a teal would mean moving that constant, not
-  adding a second accent.
+- **Skimming** — hovering or scrubbing the ruler skims frames straight into the
+  player. Label is `SH nn · <section>`, time is `tc(skim) / tc(DUR)`.
+- **Otherwise** — the sequence playhead. Label `SEQ 04 · <section>`, time
+  `tc(t) / tc(DUR)`.
+- **The scrub fill tracks `t`, never the skim.** Skimming changes the FRAME and
+  the LABEL and leaves the fill where playback is. That is the detail that makes
+  skimming feel like looking rather than like seeking, and it is easy to lose.
 
-**Things this raises that the artifact cannot answer, and the code may not
-either:**
+**The preview is dismissible, and that is a real behaviour, not a nicety.**
+`setPlayerOpen()` animates height 0 <-> `scrollHeight` with opacity over **340ms**
+and `prefers-reduced-motion` short-circuits to `display:none` with no animation
+at all. Two controls: a toggle in the content area's header and a close on the
+player itself. Two details worth copying exactly:
 
-- **The transport is five buttons where ours is fewer.** Skip-to-start and
-  skip-to-end are new verbs, and "next/previous" here is ambiguous between the
-  next CLIP and the next TAKE. PL15-029's prev/next already means item, so the
-  two must not collide.
-- **Takes are a concept we do not have.** `17 takes` implies alternates per
-  clip. Nothing in the model carries that today, so this is either a rename of
-  something existing or a data-model item of its own — worth knowing which
-  before any of it is built.
-- **The details bar has a settled contract already**, including two behaviours
-  that were tried, reversed, and stay reversed. If the artifact's scrub or
-  transport contradicts them, the contract wins unless the owner says
-  otherwise — that is exactly the kind of thing a fresh reference design
-  quietly re-litigates.
+- It calls `playerRender()` BEFORE animating open, so the frame is current the
+  moment it reappears rather than one frame stale.
+- It scrolls the window to top on open, because the preview and the playbar
+  share the viewport — reopening the preview otherwise pushes the playbar out of
+  view.
+
+**The transport is start / prev / play / next / end**, and it is bounded rather
+than wrapping: prev and next go `disabled` at the ends. `start` sets the time to
+0 AND scrolls the viewport to 0; `end` sets it to `DUR` and scrolls to the end —
+time and scroll move together, which is what stops the playhead ending up
+somewhere you cannot see.
+
+**The playbar is the larger half, and most of it maps onto things we already
+have** — so the value here is the geometry and the gestures, not new concepts:
+
+- `--pxs: 44px` per second, deliberately mirrored in CSS and JS.
+- A 40px ruler with ticks and labels; 26px labelled section lanes, where clicking
+  a section smooth-scrolls the viewport to it.
+- A 150px filmstrip of shots built from per-frame cells, `cursor: grab`, with
+  real INERTIA — a fling with momentum and an explicit `cancelMomentum` on every
+  competing interaction.
+- A playhead in three parts: a line, a **timecode chip** (`--chip #f3f6f9`), and
+  a triangle; it gains a glow while playing.
+- A hover ghost that previews where a click would land.
+- A 28px minimap: drag the window to pan, click to jump, with its own playhead in
+  `--alarm #ff5c5c` — a different colour from the selection accent on purpose.
+- Timecode is `mm:ss:ff`, frames included.
+- A first-run coach mark, dismissed by the first skim — "the lesson is learned by
+  doing". The file explicitly notes the "seen" flag must be persisted by the app,
+  which is the part a copy would drop.
+
+**The three calls, made by the owner:**
+
+- **TAKES ARE OUT.** The deck of swipeable takes with the centre card active, the
+  `17 takes · 02:00` header, the `TAKE · SH nn` player source, and the
+  "auditioning: keep rolling on the next take" autoplay all drop. This is the
+  simplification that collapses the player's three-way precedence to two, and it
+  removes the only concept in the reference that our model does not have.
+- **PREV/NEXT MEAN THE NEXT CLIP.** Unambiguous now, and it settles the collision
+  the first draft flagged: PL15-029's item-level prev/next and this transport are
+  the same verb on the same thing, so there is one behaviour to build, not two
+  that have to be told apart.
+- **THE ACCENT STAYS SKY BLUE.** The reference's `--signal: #3cdbc0` teal is NOT
+  adopted. PL15-026 already runs the subject's blue from the film through to the
+  minimap off one exported constant, and that constant remains the single source
+  — the reference's teal is read as "there is one accent and it is used
+  consistently", which we already do, in our colour.
 
 Acceptance criteria:
 
-- The container matches the artifact's composition: a panel in the content area,
-  no scrim, media over a full-width scrub bar with clip ticks, a location label
-  left and a transport cluster right, takes in their own panel below.
-- Our preview display is the thing inside it. No second player.
-- The accent is decided ONCE and applied from the existing exported constant,
-  not restated.
-- Every transport verb has one unambiguous target — clip or take or item — and
-  the item names it.
-- Stories cover it, per the repo rule: selected state, missing poster, short and
-  long clips, a many-take row.
+- One preview, at the top, and it is the EXISTING preview display. No second
+  player anywhere in the tree.
+- The preview mirrors skim over sequence, with the labels and timecodes above,
+  and the scrub fill follows playback rather than the skim.
+- The preview can be dismissed and restored, from both controls, with the
+  reduced-motion path taking no animation; the frame is current on reopen and
+  the playbar stays in view.
+- Transport is start / prev / play / next / end, prev/next step CLIPS and
+  disable at the ends, and start/end move time and scroll together.
+- The accent comes from the existing exported constant. No teal is introduced.
+- Stories cover it per the repo rule: selected state, missing poster, short and
+  long clips, a many-clip timeline — plus the reduced-motion dismiss path, which
+  is the branch a story is the only cheap way to see.
+
+**One thing still to settle:** the reference loads **Martian Mono** and **Spline
+Sans Mono** from Google Fonts and uses them for every label. Our root layout says
+Grandstander is the only custom font and everything else rides `font-sans` — on
+purpose. Two new families for metadata is a typographic decision and a
+first-paint cost (the rail's own CLS fix in PL15-027 is what a late font does to
+a layout), so it should be an explicit yes or no rather than arriving with the
+component.

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -1723,3 +1723,49 @@ eager graph.
 So the change is kept on its MECHANISM and explicitly not on evidence. The
 measurement that would settle it is transferred JS before FCP in a real browser
 load, and it has not been taken.
+
+## PL15-027 — the server-rendered list, measured
+
+Same conditions throughout: production build, 4x CPU, Slow 4G, `/`.
+
+| | client-fetched | server-rendered |
+| --- | ---: | ---: |
+| LCP | 1,671 ms | **768 / 909 ms** |
+| Load delay | 1,405 ms | **402 / 275 ms** |
+| TTFB | 152 ms | 312 / 481 ms |
+| CLS | 0.00 | **0.18** |
+
+**LCP roughly halves and load delay drops by about a second**, which is exactly
+the mechanism the insight named: the poster is in the initial HTML now, so the
+preload scanner starts it instead of waiting for React to download, parse,
+execute, fetch the list and render a card.
+
+**TTFB rises ~160-330ms** because the server now does the Firestore read. That
+is a real trade and a good one — a few hundred milliseconds on the server
+bought about a second on the client.
+
+**`fetchPriority` ALONE DID NOTHING, and that is the honest result rather than
+a surprising one.** Applied without the server render it measured 2,095 ms
+against a 1,671 ms baseline — noise, not harm. A browser cannot prioritise a
+request it does not know exists. The two checks Chrome makes are not
+independent: the hint only means something once the resource is discoverable.
+
+**THE CLS IS UNRESOLVED AND THE BRANCH SHOULD NOT SHIP UNTIL IT IS.** CLS went
+0.00 to 0.18, above the 0.1 "good" threshold, and CLS is one of the four inputs
+to the Real Experience Score — so this currently trades one Core Web Vital for
+another.
+
+What is known about it:
+
+- It reproduces in TRACED loads, 2 of 2, as a single shift of 0.1837 about a
+  second in. DevTools reports "no potential root causes identified".
+- A `layout-shift` PerformanceObserver installed before navigation sees **zero
+  shifts** — on a normal navigation and on a hard reload with the cache
+  ignored.
+- The before/after comparison is like-for-like (both traced), which argues the
+  regression is real rather than an artifact.
+
+Those two facts do not sit together yet, and until they do the cause is not
+known. The next step is to reconcile them — an observer that survives the
+trace's own reload — rather than to guess at a culprit. `AuthGate` wrapping the
+page in `RootLayout` is the obvious suspect and is only a suspect.

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -2002,3 +2002,82 @@ Acceptance criteria:
   Beware the known trap: a view transition does not paint the page, so a moved
   named element leaves a black cut-out, and a snapshot cannot deform. Card to
   full-width view is exactly the shape that bites.
+
+## PL15-030 — The reference design for the details view
+
+- Status: Not started. **The spec below is READ OFF THE RENDERED ARTIFACT, not
+  off its source** — the artifact renders in a sandboxed iframe, so its text and
+  its code view could not be extracted, and screenshots crop at 800px. The owner
+  has the code and it supersedes everything here the moment it lands. Treat the
+  measurements as SHAPES, not values.
+- Reference: https://claude.ai/public/artifacts/d7b2d207-7326-4ad9-9022-152adb1250c8
+  (`storyboard-react-demo.html`)
+- Area: pairs with PL15-029 — that item is the CONTAINER change, this one is
+  what the container should look like and how it should behave.
+- Screenshot: Not captured
+
+The artifact is the target for how the details view looks and behaves.
+
+**THE PLAYER IS NOT PART OF THE BORROW.** We keep our existing preview display.
+The artifact is a reference for the CONTAINER, the layout and the chrome around
+the media — not for the thing that plays it. Anything in it that duplicates
+`workbench-display-surface`, the seam bar or the trim strip is a picture of what
+we already have, and the existing components stay.
+
+**What the artifact shows, as observed.**
+
+- **It reads as a place, not an overlay.** One near-black ground with a raised,
+  softly-bordered rounded panel sitting in it. No scrim, no dimmed page behind —
+  which is the same conclusion PL15-029 reached from the code side, arrived at
+  independently.
+- **Two stacked panels, not one.** The upper panel is the media and its
+  transport. A separate panel below it holds takes.
+- **Upper panel, top to bottom:**
+  - A 16:9 hero that fills the panel's width, letterboxed against black where
+    the image does not fill it.
+  - A scrub bar immediately under the hero, full panel width — teal/emerald
+    fill, white circular handle, and TICK MARKS along the track at what read as
+    clip boundaries. That is our seam bar's job, and it is drawn here as one
+    continuous element rather than as a separate strip.
+  - A footer row: a monospace, uppercase, wide-tracked muted label at the left
+    (`SEQ 04 · BOARDS` — a location, reading like a breadcrumb), and a transport
+    cluster at the right: five circular buttons, skip-to-start / previous /
+    PLAY / next / skip-to-end, with play larger and visually the primary.
+- **Lower panel:** a header row with a `Takes` pill (layers icon) at the left
+  and `17 takes · 02:00` at the right, then a row of take cards — `CLIP 7`,
+  `4.60s / 8.3…`, i.e. a duration within a total.
+- **Type and colour.** Metadata is monospace, uppercase, wide-tracked, low
+  contrast. The accent is TEAL/EMERALD. Ours is sky blue, and it is load-bearing
+  — PL15-026 runs the subject's blue from the film through to the minimap off
+  one exported constant. Adopting a teal would mean moving that constant, not
+  adding a second accent.
+
+**Things this raises that the artifact cannot answer, and the code may not
+either:**
+
+- **The transport is five buttons where ours is fewer.** Skip-to-start and
+  skip-to-end are new verbs, and "next/previous" here is ambiguous between the
+  next CLIP and the next TAKE. PL15-029's prev/next already means item, so the
+  two must not collide.
+- **Takes are a concept we do not have.** `17 takes` implies alternates per
+  clip. Nothing in the model carries that today, so this is either a rename of
+  something existing or a data-model item of its own — worth knowing which
+  before any of it is built.
+- **The details bar has a settled contract already**, including two behaviours
+  that were tried, reversed, and stay reversed. If the artifact's scrub or
+  transport contradicts them, the contract wins unless the owner says
+  otherwise — that is exactly the kind of thing a fresh reference design
+  quietly re-litigates.
+
+Acceptance criteria:
+
+- The container matches the artifact's composition: a panel in the content area,
+  no scrim, media over a full-width scrub bar with clip ticks, a location label
+  left and a transport cluster right, takes in their own panel below.
+- Our preview display is the thing inside it. No second player.
+- The accent is decided ONCE and applied from the existing exported constant,
+  not restated.
+- Every transport verb has one unambiguous target — clip or take or item — and
+  the item names it.
+- Stories cover it, per the repo rule: selected state, missing poster, short and
+  long clips, a many-take row.

--- a/punch-list/reference/storyboard-playbar.html
+++ b/punch-list/reference/storyboard-playbar.html
@@ -1,0 +1,1430 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Storyboard · Playbar</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Martian+Mono:wght@400;600&family=Spline+Sans+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+/* ============================================================
+   TOKENS — restyle the whole component from here
+   ============================================================ */
+:root{
+  --ink:        #08090d;   /* stage background            */
+  --panel-hi:   #14181f;   /* bar surface, top            */
+  --panel-lo:   #0b0d12;   /* bar surface, bottom         */
+  --stroke:     rgba(255,255,255,.07);
+  --groove:     rgba(255,255,255,.045);
+  --slate:      #79828f;   /* quiet labels                */
+  --slate-hi:   #aeb7c4;   /* emphasized labels           */
+  --signal:     #3cdbc0;   /* selection teal              */
+  --signal-soft:rgba(60,219,192,.14);
+  --alarm:      #ff5c5c;   /* playhead red (minimap)      */
+  --chip:       #f3f6f9;   /* playhead timecode chip      */
+
+  --mono: "Spline Sans Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --wide: "Martian Mono", var(--mono);
+
+  --r-card: 12px;
+  --pxs: 44px;             /* pixels per second (mirrored in JS) */
+}
+
+*{ box-sizing:border-box; margin:0; padding:0; }
+html,body{ height:100%; }
+body{
+  background:var(--ink);
+  color:var(--slate);
+  font-family:var(--mono);
+  display:grid; place-items:center;
+  overflow-x:hidden;
+  -webkit-user-select:none; user-select:none;
+}
+body::before{ /* faint stage light */
+  content:""; position:fixed; inset:0; pointer-events:none;
+  background:
+    radial-gradient(60% 40% at 50% -5%, rgba(60,219,192,.05), transparent 70%),
+    radial-gradient(70% 50% at 50% 115%, rgba(255,140,80,.04), transparent 70%);
+}
+
+.stage{ width:100%; padding:44px 24px 40px; }
+
+/* ---------- meta strip above the bar ---------- */
+.meta{
+  position:relative;
+  display:flex; justify-content:space-between; align-items:center;
+  padding:0 6px 12px;
+  font-family:var(--wide); font-size:9.5px; font-weight:600;
+  letter-spacing:.22em; text-transform:uppercase; color:var(--slate);
+}
+.meta .dot{
+  display:inline-block; width:6px; height:6px; border-radius:50%;
+  background:var(--signal); box-shadow:0 0 8px rgba(60,219,192,.7);
+  margin-right:10px; vertical-align:1px;
+  animation:pulse 2.6s ease-in-out infinite;
+}
+.meta.playing .dot{ animation-duration:.9s; }
+@keyframes pulse{ 0%,100%{opacity:.55} 50%{opacity:1} }
+.meta .sep{ color:#3a414b; padding:0 8px; }
+.meta-r{ color:#5b636f; font-weight:400; letter-spacing:.18em; }
+
+/* ---------- the playbar shell ---------- */
+.playbar{
+  position:relative;
+  background:linear-gradient(180deg, var(--panel-hi), #0e1117 55%, var(--panel-lo));
+  border:1px solid var(--stroke);
+  border-radius:18px;
+  padding:14px 0 12px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.05),
+    0 40px 90px -40px rgba(0,0,0,.9),
+    0 8px 30px -18px rgba(0,0,0,.8);
+}
+
+/* ---------- scrolling viewport ---------- */
+.viewport{
+  overflow-x:auto; overflow-y:hidden;
+  overscroll-behavior-x:contain;
+  scrollbar-width:none;
+  -webkit-mask-image:linear-gradient(90deg, transparent 0, #000 26px, #000 calc(100% - 26px), transparent 100%);
+          mask-image:linear-gradient(90deg, transparent 0, #000 26px, #000 calc(100% - 26px), transparent 100%);
+}
+.viewport::-webkit-scrollbar{ display:none; }
+
+.content{ position:relative; padding-bottom:14px; touch-action:none; }
+
+/* ---------- ruler ---------- */
+.ruler{ position:relative; height:40px; margin-bottom:10px; cursor:ew-resize; }
+/* ---------- labeled sections ---------- */
+.lane{ position:relative; height:26px; cursor:ew-resize; }
+.seclabel{
+  position:absolute; top:4px; left:0; display:inline-flex; align-items:center; gap:6px;
+  font-family:var(--wide); font-size:9px; font-weight:600;
+  letter-spacing:.16em; text-transform:uppercase; color:#8b95a3;
+  white-space:nowrap; cursor:pointer; transition:color .15s ease;
+}
+.seclabel:hover{ color:#dbe2ea; }
+.seclabel svg{ width:11px; height:11px; opacity:.7; flex:none; }
+.rbase{
+  position:absolute; bottom:0; height:2px; border-radius:1px;
+  background:rgba(255,255,255,.08);
+}
+.secdiv{
+  position:absolute; top:24px; bottom:14px; width:1px; z-index:1;
+  background:linear-gradient(180deg, rgba(255,255,255,.1), rgba(255,255,255,.04));
+  pointer-events:none;
+}
+.mm-sec{
+  position:absolute; top:6px; bottom:2px; width:1px;
+  background:rgba(255,255,255,.16); transform:translateX(-2px);
+  pointer-events:none;
+}
+.tick{ position:absolute; bottom:0; width:1px; background:rgba(150,160,175,.22); height:6px; }
+.tick.t2{ height:10px; background:rgba(150,160,175,.34); }
+.tick.t10{ height:15px; background:rgba(190,200,214,.5); }
+.tlabel{
+  position:absolute; top:3px; transform:translateX(5px);
+  font-size:10px; font-weight:500; letter-spacing:.05em; color:#69727f;
+  pointer-events:none;
+}
+.tlabel.big{ color:var(--slate-hi); font-weight:600; }
+
+/* selected-shot range capsule on the ruler */
+.range{
+  position:absolute; bottom:0; height:5px; border-radius:3px;
+  background:linear-gradient(90deg, rgba(60,219,192,.75), var(--signal));
+  box-shadow:0 0 12px rgba(60,219,192,.55), 0 0 2px rgba(60,219,192,.9);
+  transition:left .28s cubic-bezier(.22,1,.3,1), width .28s cubic-bezier(.22,1,.3,1);
+}
+
+/* ---------- filmstrip ---------- */
+.strip{ position:relative; height:150px; cursor:grab; }
+.strip.panning, .strip.panning .shot{ cursor:grabbing; }
+
+.shot{
+  position:absolute; top:0; height:100%;
+  display:flex; overflow:hidden;
+  border-radius:var(--r-card);
+  background:#000;
+  cursor:pointer;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.05),
+    0 0 0 1px rgba(255,255,255,.09),
+    0 10px 24px -14px rgba(0,0,0,.9);
+  transition:box-shadow .18s ease, transform .18s ease;
+}
+.shot:hover{
+  transform:translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.07),
+    0 0 0 1px rgba(255,255,255,.2),
+    0 14px 28px -14px rgba(0,0,0,.95);
+}
+.shot.selected{
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.08),
+    0 0 0 1.5px var(--signal),
+    0 0 0 5px var(--signal-soft),
+    0 14px 34px -12px rgba(60,219,192,.35);
+}
+
+.frame{ position:relative; height:100%; }
+.frame + .frame{ border-left:1px solid rgba(0,0,0,.7); }
+.frame::before{ /* lens vignette */
+  content:""; position:absolute; inset:0;
+  background:radial-gradient(130% 120% at 50% 42%, transparent 52%, rgba(0,0,0,.5) 100%);
+}
+.frame::after{ /* film grain */
+  content:""; position:absolute; inset:0; opacity:.13; pointer-events:none;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E");
+  mix-blend-mode:overlay;
+}
+
+.shot .tag{
+  position:absolute; z-index:2; top:8px; left:9px;
+  font-size:9px; font-weight:600; letter-spacing:.09em;
+  color:#d7dde6; padding:3px 7px; border-radius:5px;
+  background:rgba(8,10,14,.72);
+  border:1px solid rgba(255,255,255,.09);
+  backdrop-filter:blur(4px);
+  opacity:0; transform:translateY(-2px);
+  transition:opacity .18s ease, transform .18s ease;
+  pointer-events:none; white-space:nowrap;
+}
+.shot:hover .tag, .shot.selected .tag{ opacity:1; transform:translateY(0); }
+.shot.selected .tag{ border-color:rgba(60,219,192,.45); color:#c8fff4; }
+
+/* selection underline beneath the strip */
+.underline{
+  position:absolute; bottom:-9px; height:3px; border-radius:2px;
+  background:var(--signal);
+  box-shadow:0 0 10px rgba(60,219,192,.6);
+  transition:left .28s cubic-bezier(.22,1,.3,1), width .28s cubic-bezier(.22,1,.3,1);
+}
+
+/* ---------- hover ghost ---------- */
+.ghost{
+  position:absolute; top:26px; bottom:14px; width:1px; left:0;
+  background:rgba(255,255,255,.16);
+  opacity:0; pointer-events:none; z-index:5;
+}
+.content:hover .ghost.on{ opacity:1; }
+
+/* ---------- playhead ---------- */
+.playhead{ position:absolute; top:0; bottom:14px; left:0; width:0; z-index:30; pointer-events:none; }
+.ph-line{
+  position:absolute; top:27px; bottom:0; left:-1px; width:2px;
+  background:linear-gradient(180deg, #fff, rgba(255,255,255,.35));
+  box-shadow:0 0 10px rgba(255,255,255,.4);
+}
+.ph-chip{
+  position:absolute; top:0; left:0; transform:translateX(-50%);
+  background:var(--chip); color:#0b0e13;
+  font-size:10.5px; font-weight:600; letter-spacing:.03em;
+  padding:3px 8px 2px; border-radius:6px;
+  box-shadow:0 2px 10px rgba(0,0,0,.55), 0 0 0 1px rgba(0,0,0,.25);
+  pointer-events:auto; cursor:ew-resize; white-space:nowrap;
+  transition:box-shadow .2s ease;
+}
+.is-playing .ph-chip{ box-shadow:0 2px 10px rgba(0,0,0,.55), 0 0 0 1px rgba(0,0,0,.25), 0 0 14px rgba(60,219,192,.45); }
+.ph-tri{
+  position:absolute; top:20px; left:0; transform:translateX(-50%);
+  width:0; height:0; border:5px solid transparent; border-bottom:none;
+  border-top:6px solid var(--chip);
+  filter:drop-shadow(0 1px 2px rgba(0,0,0,.5));
+}
+
+/* ---------- top player: the one shared preview ---------- */
+.p-slot{ margin-bottom:22px; }
+.p-slot.anim{ overflow:hidden; transition:height .32s cubic-bezier(.22,1,.3,1), opacity .25s ease; }
+.player{
+  position:relative;
+  background:linear-gradient(180deg, var(--panel-hi), #0e1117 55%, var(--panel-lo));
+  border:1px solid var(--stroke); border-radius:18px;
+  padding:14px 14px 10px;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.05), 0 40px 90px -40px rgba(0,0,0,.9);
+}
+.p-close{
+  position:absolute; top:24px; right:24px; z-index:5;
+  width:26px; height:26px; border-radius:7px; padding:0;
+  background:rgba(8,10,14,.62); border:1px solid rgba(255,255,255,.12);
+  color:#aab3c0; font-size:12px; line-height:1; cursor:pointer; backdrop-filter:blur(4px);
+  transition:color .15s ease, border-color .15s ease;
+}
+.p-close:hover{ color:#eef2f7; border-color:rgba(255,255,255,.3); }
+
+/* ---------- main content area: everything below the preview ---------- */
+.area{
+  background:linear-gradient(180deg, #10131a, #0b0d12);
+  border:1px solid var(--stroke); border-radius:18px;
+  padding:14px 16px 14px; overflow:hidden;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.04), 0 40px 90px -40px rgba(0,0,0,.85);
+}
+.area-head{
+  display:grid; grid-template-columns:1fr auto 1fr; align-items:center;
+  margin-bottom:14px;
+}
+.a-chip{
+  justify-self:start; display:inline-flex; align-items:center; gap:7px;
+  padding:5px 11px; border-radius:8px;
+  background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.09);
+  font-size:10.5px; font-weight:500; color:#cfd7e1; letter-spacing:.03em;
+}
+.a-chip svg{ width:12px; height:12px; opacity:.75; }
+.a-count{ font-size:10px; color:#68717d; letter-spacing:.1em; }
+.a-preview{
+  justify-self:end; display:inline-flex; align-items:center; gap:7px;
+  padding:5px 11px; border-radius:8px; cursor:pointer;
+  background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.1);
+  font-family:var(--mono); font-size:10.5px; font-weight:500; color:#96a0ad; letter-spacing:.03em;
+  transition:color .15s ease, border-color .15s ease, background .15s ease;
+}
+.a-preview svg{ width:13px; height:13px; }
+.a-preview:hover{ color:#d5dce5; border-color:rgba(255,255,255,.22); }
+.a-preview.on{ color:var(--signal); border-color:rgba(60,219,192,.45); background:rgba(60,219,192,.07); }
+.p-view{
+  position:relative; height:clamp(180px, 30vh, 320px); border-radius:12px; overflow:hidden;
+  background:#000; box-shadow:inset 0 0 0 1px rgba(255,255,255,.08);
+  display:grid; place-items:center;
+}
+.p-frame{ height:100%; aspect-ratio:16/9; }
+.p-bar{ position:relative; height:16px; margin:10px 2px 6px; cursor:pointer; touch-action:none; }
+.p-bar::before{
+  content:""; position:absolute; left:0; right:0; top:50%; transform:translateY(-50%);
+  height:3px; border-radius:2px; background:rgba(255,255,255,.1);
+}
+.p-fill{
+  position:absolute; left:0; top:50%; transform:translateY(-50%); height:3px;
+  border-radius:2px; background:var(--signal);
+  box-shadow:0 0 8px rgba(60,219,192,.5); pointer-events:none;
+}
+.p-fill::after{
+  content:""; position:absolute; right:-4px; top:50%; transform:translateY(-50%);
+  width:9px; height:9px; border-radius:50%; background:#f3f6f9;
+  box-shadow:0 1px 4px rgba(0,0,0,.6);
+}
+.p-notch{
+  position:absolute; top:50%; transform:translateY(-50%);
+  width:1px; height:8px; background:rgba(255,255,255,.25); pointer-events:none;
+}
+.p-row{ display:grid; grid-template-columns:1fr auto 1fr; align-items:center; padding:0 2px; }
+.p-src{
+  font-family:var(--wide); font-size:8.5px; font-weight:600;
+  letter-spacing:.2em; text-transform:uppercase; color:#7d8794; white-space:nowrap;
+}
+.p-ctl{ display:flex; gap:10px; }
+.p-time{ justify-self:end; font-size:10.5px; color:#a7b0bd; letter-spacing:.04em; }
+.clip.active .c-view{ cursor:pointer; }
+
+/* the top time zone lights up under the pointer */
+.playbar::before{
+  content:""; position:absolute; left:0; right:0; top:0; height:82px;
+  border-radius:18px 18px 0 0;
+  background:linear-gradient(180deg, rgba(60,219,192,.055), rgba(60,219,192,0));
+  opacity:0; transition:opacity .25s ease; pointer-events:none;
+}
+.playbar.top-hot::before{ opacity:1; }
+
+/* one-time hint, centered on the meta line between the seq title and stats */
+.coach{
+  position:absolute; left:50%; top:-4px;
+  transform:translate(-50%, 5px);
+  display:flex; align-items:center; gap:7px;
+  padding:3px 10px; border-radius:99px;
+  background:#11151c; border:1px solid rgba(60,219,192,.32);
+  color:#bfe6dc; font-family:var(--mono); font-size:9.5px; font-weight:500;
+  letter-spacing:.08em; text-transform:none; white-space:nowrap;
+  box-shadow:0 8px 22px -10px rgba(0,0,0,.8), 0 0 14px -6px rgba(60,219,192,.3);
+  opacity:0; pointer-events:none; z-index:5;
+  transition:opacity .35s ease, transform .35s ease;
+}
+.coach.show{ opacity:1; transform:translate(-50%, 0); }
+.coach-dot{
+  width:6px; height:6px; border-radius:50%; background:var(--signal);
+  box-shadow:0 0 8px rgba(60,219,192,.8); flex:none;
+  animation:pulse 1.6s ease-in-out infinite;
+}
+
+/* ---------- minimap ---------- */
+.minimap{ padding:16px 22px 2px; }
+.mm-track{ position:relative; height:28px; cursor:pointer; touch-action:none; }
+.mm-track::before{ /* groove */
+  content:""; position:absolute; left:0; right:0; top:10px; height:8px; border-radius:4px;
+  background:rgba(255,255,255,.035);
+  box-shadow:inset 0 1px 3px rgba(0,0,0,.6);
+}
+.mm-shot{
+  position:absolute; top:11px; height:6px; border-radius:3px;
+  background:#343b45; pointer-events:none;
+  transition:background .2s ease, box-shadow .2s ease;
+}
+.mm-shot.inview{ background:#4c5561; }
+.mm-shot.sel{ background:var(--signal); box-shadow:0 0 8px rgba(60,219,192,.55); }
+
+.mm-window{
+  position:absolute; top:3px; height:22px; border-radius:7px;
+  background:rgba(255,255,255,.05);
+  border:1px solid rgba(255,255,255,.28);
+  cursor:grab; z-index:3;
+  transition:border-color .15s ease, background .15s ease;
+}
+.mm-window:hover{ border-color:rgba(255,255,255,.45); background:rgba(255,255,255,.075); }
+.mm-track.dragging, .mm-track.dragging .mm-window{ cursor:grabbing; }
+.mm-window::before, .mm-window::after{
+  content:""; position:absolute; top:50%; transform:translateY(-50%);
+  width:3px; height:9px; border-radius:2px; background:rgba(255,255,255,.55);
+  opacity:0; transition:opacity .15s ease;
+}
+.mm-window::before{ left:4px; } .mm-window::after{ right:4px; }
+.mm-window:hover::before, .mm-window:hover::after{ opacity:1; }
+
+.mm-ph{ position:absolute; top:1px; bottom:5px; width:2px; z-index:4; pointer-events:none;
+  background:var(--alarm); box-shadow:0 0 8px rgba(255,92,92,.6); transform:translateX(-1px); }
+.mm-ph i{
+  position:absolute; bottom:-8px; left:50%; transform:translateX(-50%);
+  border:4px solid transparent; border-top:none; border-bottom:5px solid var(--alarm);
+}
+
+/* ============================================================
+   Clip deck — swipeable takes, center card active
+   ============================================================ */
+.deck{
+  position:relative; height:480px; margin:20px 0 4px;
+  -webkit-mask-image:linear-gradient(90deg, transparent 0, #000 5%, #000 95%, transparent 100%);
+          mask-image:linear-gradient(90deg, transparent 0, #000 5%, #000 95%, transparent 100%);
+}
+.deck.dragging, .deck.dragging .clip{ cursor:grabbing; }
+.clip{
+  position:absolute; top:50%; left:50%; width:clamp(300px, 30vw, 440px);
+  transform:translate(-50%,-50%);
+  padding:12px 14px;
+  background:linear-gradient(180deg, #141821, #0c0f14);
+  border:1px solid rgba(255,255,255,.08); border-radius:16px;
+  box-shadow:0 34px 80px -36px rgba(0,0,0,.95), inset 0 1px 0 rgba(255,255,255,.05);
+  cursor:grab; will-change:transform, opacity, filter;
+}
+.clip.active{
+  border-color:rgba(255,255,255,.15);
+  box-shadow:0 44px 96px -38px rgba(0,0,0,.98), 0 0 0 1px rgba(60,219,192,.12),
+             0 0 34px -14px rgba(60,219,192,.35), inset 0 1px 0 rgba(255,255,255,.07);
+}
+/* shared cinematic treatment: vignette + grain */
+.cine{ position:relative; overflow:hidden; }
+.cine::before{
+  content:""; position:absolute; inset:0;
+  background:radial-gradient(130% 120% at 50% 42%, transparent 52%, rgba(0,0,0,.5) 100%);
+}
+.cine::after{
+  content:""; position:absolute; inset:0; opacity:.12; pointer-events:none;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E");
+  mix-blend-mode:overlay;
+}
+.c-head{ display:flex; align-items:center; gap:10px; }
+.c-id{ font-family:var(--wide); font-size:8.5px; font-weight:600; letter-spacing:.2em; text-transform:uppercase; color:#77808d; }
+.c-dur{ margin-left:auto; font-size:10.5px; color:#5d6570; }
+.c-dur b{ color:#e6ecf3; font-weight:600; }
+.c-dur i{ font-style:normal; color:#3c434d; padding:0 2px; }
+.c-menu{ background:none; border:0; color:#6a7380; font-size:15px; line-height:1; cursor:pointer; padding:2px 4px; border-radius:6px; }
+.c-menu:hover{ color:#cfd7e1; background:rgba(255,255,255,.06); }
+.c-title{ margin:7px 0 10px; font-size:12.5px; font-weight:500; color:#d3dae4; letter-spacing:.01em;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.c-view{ position:relative; aspect-ratio:2/1; border-radius:10px; overflow:hidden; background:#000; box-shadow:inset 0 0 0 1px rgba(255,255,255,.08); }
+.c-frame{ position:absolute; inset:0; }
+.c-bar{ display:flex; align-items:center; gap:12px; margin:9px 2px 8px; }
+.c-play{
+  width:26px; height:26px; border-radius:50%; border:1px solid rgba(255,255,255,.14);
+  background:rgba(255,255,255,.05); color:#c6cfda; cursor:pointer;
+  display:grid; place-items:center; padding:0; transition:border-color .15s ease, color .15s ease, box-shadow .15s ease;
+}
+.c-play svg{ width:10px; height:10px; fill:currentColor; }
+.c-play:hover{ border-color:rgba(60,219,192,.5); color:var(--signal); }
+.clip.playing .c-play{ border-color:rgba(60,219,192,.6); color:var(--signal); box-shadow:0 0 12px -4px rgba(60,219,192,.6); }
+.c-cut, .c-srct{ font-size:10px; color:#68717d; letter-spacing:.05em; }
+.c-cut b, .c-srct b{ color:#dfe6ee; font-weight:600; }
+.c-srct{ margin-left:auto; }
+.c-strip{ position:relative; display:flex; height:48px; border-radius:8px; overflow:hidden; background:#05070a;
+  box-shadow:0 0 0 1px rgba(255,255,255,.08); }
+.c-cell{ flex:1 1 0; }
+.c-shade{ position:absolute; top:0; bottom:0; background:rgba(4,6,9,.72); pointer-events:none; }
+.c-shade.l{ left:0; } .c-shade.r{ right:0; }
+.c-playline{ position:absolute; top:0; bottom:0; width:2px; background:var(--signal);
+  box-shadow:0 0 8px rgba(60,219,192,.7); opacity:0; transition:opacity .15s ease; pointer-events:none; }
+.clip.playing .c-playline{ opacity:1; }
+.c-win{
+  position:absolute; top:1px; bottom:1px; border-radius:7px;
+  border:2px solid var(--chip); cursor:grab;
+  box-shadow:0 0 0 1px rgba(0,0,0,.65), 0 2px 12px rgba(0,0,0,.5);
+}
+.c-win:active{ cursor:grabbing; }
+.c-h{ position:absolute; top:0; bottom:0; width:11px; cursor:ew-resize; }
+.c-h.l{ left:-6px; } .c-h.r{ right:-6px; }
+.c-h::after{ content:""; position:absolute; top:50%; left:50%; transform:translate(-50%,-50%);
+  width:2px; height:12px; border-radius:1px; background:rgba(10,13,18,.85); }
+.c-io{ display:flex; align-items:center; gap:8px; margin-top:9px;
+  font-size:9.5px; letter-spacing:.1em; color:#68717d; }
+.c-io input{
+  width:62px; padding:3px 6px; text-align:center;
+  font-family:var(--mono); font-size:11px; font-weight:600; color:var(--signal);
+  background:#0a0d13; border:1px solid rgba(255,255,255,.1); border-radius:7px; outline:none;
+}
+.c-io input:focus{ border-color:rgba(60,219,192,.55); }
+.c-io .arr{ color:#454c56; }
+.c-total{ margin-left:auto; font-size:11px; font-weight:600; color:#dfe6ee; letter-spacing:.02em; }
+.c-tags{ display:flex; flex-wrap:wrap; align-items:center; gap:6px; margin-top:10px; min-height:24px; }
+.chip{ display:inline-flex; align-items:center; gap:6px; padding:3px 5px 3px 9px; border-radius:7px;
+  background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.09);
+  font-size:9.5px; letter-spacing:.05em; color:#bac3cf; }
+.chip .x{ background:none; border:0; padding:0 3px; color:#6b7480; font-size:11px; cursor:pointer; line-height:1; }
+.chip .x:hover{ color:#ff8585; }
+.c-add{ width:24px; height:22px; border-radius:7px; border:1px dashed rgba(255,255,255,.22);
+  background:none; color:#77808d; font-size:12px; line-height:1; cursor:pointer; }
+.c-add:hover{ border-color:rgba(60,219,192,.55); color:var(--signal); }
+.c-tagin{ width:76px; padding:3px 7px; font-family:var(--mono); font-size:10px; color:#d5dce5;
+  background:#0a0d13; border:1px solid rgba(60,219,192,.4); border-radius:7px; outline:none; }
+.c-win:hover{ box-shadow:0 0 0 1px rgba(0,0,0,.65), 0 2px 12px rgba(0,0,0,.5), 0 0 14px rgba(255,255,255,.22); }
+.clip:not(.active) .c-play, .clip:not(.active) .c-menu, .clip:not(.active) input,
+.clip:not(.active) .c-tags{ pointer-events:none; }
+
+/* ---------- transport buttons (shared by the player) ---------- */
+.t-btn{
+  width:30px; height:30px; border-radius:50%; border:1px solid rgba(255,255,255,.14);
+  background:rgba(255,255,255,.05); color:#c6cfda; cursor:pointer;
+  display:grid; place-items:center; padding:0;
+  transition:border-color .15s ease, color .15s ease, box-shadow .15s ease;
+}
+.t-btn svg{ width:11px; height:11px; fill:currentColor; }
+.t-btn:hover{ border-color:rgba(60,219,192,.5); color:var(--signal); }
+.t-btn:disabled{ opacity:.3; pointer-events:none; }
+.t-main{ width:38px; height:38px; border-color:rgba(255,255,255,.2); }
+.t-main svg{ width:13px; height:13px; }
+.t-main.playing{ border-color:rgba(60,219,192,.6); color:var(--signal); box-shadow:0 0 16px -5px rgba(60,219,192,.7); }
+
+/* ---------- footer hints ---------- */
+.hints{
+  padding:16px 6px 0; text-align:center;
+  font-size:9.5px; letter-spacing:.12em; color:#4c545f;
+}
+.hints b{ color:#8e98a5; font-weight:600; }
+.hints .sep{ padding:0 10px; color:#333a43; }
+
+@media (prefers-reduced-motion: reduce){
+  *, *::before, *::after{ transition:none !important; animation:none !important; }
+}
+</style>
+</head>
+<body>
+<main class="stage">
+
+  <div class="p-slot" id="pSlot">
+    <section class="player" id="player" aria-label="Preview player">
+      <button class="p-close" id="pClose" title="Close preview">✕</button>
+      <div class="p-view"><div class="p-frame cine" id="pFrame"></div></div>
+    <div class="p-bar" id="pBar" title="Seek"><div class="p-fill" id="pFill"></div></div>
+    <div class="p-row">
+      <span class="p-src" id="pSrc">SEQ 04</span>
+      <div class="p-ctl">
+        <button class="t-btn" id="tStart" title="Jump to start"><svg viewBox="0 0 12 12"><path d="M2.2 1.5h1.7v9H2.2zM10.4 1.5v9L4.9 6z"/></svg></button>
+        <button class="t-btn" id="tPrev" title="Previous take"><svg viewBox="0 0 12 12"><path d="M9.5 1.5v9L3.2 6z"/></svg></button>
+        <button class="t-btn t-main" id="tPlay" title="Play sequence"><svg viewBox="0 0 12 12"><path d="M3 1.5v9l7.5-4.5z"/></svg></button>
+        <button class="t-btn" id="tNext" title="Next take"><svg viewBox="0 0 12 12"><path d="M2.5 1.5v9L8.8 6z"/></svg></button>
+        <button class="t-btn" id="tEnd" title="Jump to end"><svg viewBox="0 0 12 12"><path d="M8.1 1.5h1.7v9H8.1zM1.6 1.5v9L7.1 6z"/></svg></button>
+      </div>
+      <span class="p-time" id="pTime">00:00:00 / 02:00:00</span>
+    </div>
+    </section>
+  </div>
+
+  <section class="area">
+    <header class="area-head">
+      <span class="a-chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 2 9 5-9 5-9-5Z"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg>Takes</span>
+      <span class="a-count" id="areaCount">17 takes · 02:00</span>
+      <button class="a-preview on" id="pToggle" title="Hide preview"><svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><rect x="1.5" y="2.5" width="11" height="7.5" rx="1.5"/><path d="M5 12.2h4"/></svg>Preview</button>
+    </header>
+
+  <div class="meta">
+    <div class="meta-l"><span class="dot"></span>Seq 04 — Night Drive<span class="sep">/</span><span style="color:#525a66">Act I</span></div>
+    <div class="coach" id="coach"><span class="coach-dot"></span>Hover the ruler to preview frames</div>
+    <div class="meta-r" id="metaR">24 fps · 17 shots · 02:00:00</div>
+  </div>
+
+  <section class="playbar" id="playbar" aria-label="Storyboard timeline">
+    <div class="viewport" id="viewport">
+      <div class="content" id="content">
+        <div class="lane" id="lane"></div>
+        <div class="ruler" id="ruler"><div class="range" id="range"></div></div>
+        <div class="strip" id="strip"><div class="underline" id="underline"></div></div>
+        <div class="ghost" id="ghost"></div>
+        <div class="playhead" id="playhead">
+          <div class="ph-chip" id="chip">00:00:00</div>
+          <div class="ph-tri"></div>
+          <div class="ph-line"></div>
+        </div>
+      </div>
+    </div>
+    <div class="minimap">
+      <div class="mm-track" id="mmTrack" aria-label="Sequence navigator">
+        <div class="mm-window" id="mmWindow"></div>
+        <div class="mm-ph" id="mmPh"><i></i></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="deck" id="deck" aria-label="Clip takes">
+    <div class="deck-track" id="deckTrack"></div>
+  </section>
+  </section>
+
+  <div class="hints">
+    <b>space</b> play<span class="sep">·</span><b>← →</b> step<span class="sep">·</span>swipe or tap <b>clips</b><span class="sep">·</span>drag handles to <b>trim</b><span class="sep">·</span>flick strip to <b>pan</b><span class="sep">·</span>hover ruler to <b>preview</b>
+  </div>
+
+</main>
+
+<script>
+/* ============================================================
+   Model
+   ============================================================ */
+const PXS = 44;          // pixels per second — keep in sync with --pxs
+const DUR = 120;         // sequence length (s)
+const FPS = 24;
+
+/* Procedural “cinematography” for placeholder frames.
+   Swap these for real thumbnails: each .frame just takes a background. */
+const LOOKS = {
+  fadeOut:     "radial-gradient(120% 110% at 50% 45%, #0d0f14 0%, #05060a 60%, #020304 100%)",
+  nightBlack:  "radial-gradient(120% 100% at 32% 42%, #131722 0%, #0a0d13 45%, #04050a 100%)",
+  nightBlack2: "radial-gradient(110% 100% at 68% 40%, #10141d 0%, #080a10 50%, #030408 100%)",
+  screenGlow:  "linear-gradient(78deg, rgba(4,6,10,.96) 0%, rgba(4,6,10,.96) 46%, rgba(4,6,10,0) 60%), radial-gradient(42% 58% at 70% 46%, #cdeeff 0%, #7cc7e4 30%, #1c4a5e 62%, #071018 88%, #04070b 100%)",
+  darkGlance:  "radial-gradient(55% 78% at 72% 48%, #3d4b58 0%, #1a232c 46%, #070b10 100%)",
+  listener:    "linear-gradient(84deg, rgba(6,6,10,.92) 0%, rgba(6,6,10,0) 34%), radial-gradient(62% 86% at 60% 44%, #c4a9a4 0%, #8a656b 30%, #3a2a33 62%, #120d13 100%)",
+  emberProfile:"radial-gradient(30% 55% at 22% 30%, rgba(255,171,94,.45) 0%, rgba(255,171,94,0) 70%), radial-gradient(62% 88% at 34% 55%, #c1662b 0%, #7c3d18 38%, #2b1309 72%, #0b0502 100%)",
+  faceWarmC:   "radial-gradient(52% 72% at 52% 44%, #eda65e 0%, #b06a2c 36%, #401e0c 74%, #100702 100%)",
+  faceWarmSad: "radial-gradient(48% 66% at 47% 42%, #d69150 0%, #94571f 40%, #33170a 76%, #0d0602 100%)",
+  goldenPair:  "radial-gradient(26% 60% at 80% 50%, rgba(10,6,3,.9) 0%, rgba(10,6,3,0) 70%), radial-gradient(70% 96% at 26% 48%, #f2b873 0%, #bd7a3c 40%, #4a220e 78%, #140903 100%)",
+  gruffClose:  "radial-gradient(58% 80% at 56% 46%, #d99b58 0%, #9a5c26 38%, #38190a 74%, #0e0603 100%)",
+  redheadTurn: "radial-gradient(24% 34% at 46% 20%, rgba(224,108,54,.55) 0%, rgba(224,108,54,0) 70%), radial-gradient(56% 78% at 48% 50%, #cf8e4d 0%, #8f5522 42%, #331708 76%, #0d0502 100%)",
+  duoProfiles: "radial-gradient(24% 62% at 74% 52%, rgba(6,4,3,.92) 0%, rgba(6,4,3,0) 66%), radial-gradient(64% 90% at 30% 50%, #d79a56 0%, #9a5c24 40%, #3a1b0a 76%, #0f0603 100%)",
+  greenShirt:  "linear-gradient(0deg, rgba(30,44,26,.85) 0%, rgba(30,44,26,0) 30%), radial-gradient(60% 82% at 46% 40%, #e0a869 0%, #9c6330 40%, #33190b 76%, #0e0603 100%)",
+  shadowHat:   "radial-gradient(30% 60% at 84% 46%, rgba(255,158,84,.4) 0%, rgba(255,158,84,0) 60%), radial-gradient(70% 100% at 40% 55%, #241811 0%, #120b07 55%, #060303 100%)",
+  carCool:     "radial-gradient(30% 44% at 20% 62%, rgba(255,176,112,.3) 0%, rgba(255,176,112,0) 70%), radial-gradient(64% 86% at 66% 40%, #47617c 0%, #22303f 46%, #0a0f15 100%)",
+  startled:    "radial-gradient(50% 70% at 60% 44%, #e9b98a 0%, #a3703f 40%, #3a2313 74%, #0f0905 100%)",
+  duskWide:    "linear-gradient(90deg, rgba(5,6,9,.9) 0%, rgba(5,6,9,0) 40%), radial-gradient(92% 120% at 82% 42%, #ff9d54 0%, #a04c1e 42%, #2a1208 76%, #090402 100%)",
+  streetDay:   "linear-gradient(0deg, rgba(40,36,30,.7) 0%, rgba(40,36,30,0) 35%), radial-gradient(80% 100% at 50% 30%, #cfd8de 0%, #9aa4ad 40%, #55534e 75%, #2a2621 100%)",
+  storefront:  "linear-gradient(0deg, rgba(30,20,10,.75) 0%, rgba(30,20,10,0) 40%), radial-gradient(70% 90% at 55% 45%, #e8b459 0%, #b57e2e 40%, #5a3a14 78%, #1d1206 100%)",
+  bwPlate:     "linear-gradient(100deg, #0f0f10 0%, #2c2c2e 28%, #bfbfc2 52%, #39393b 78%, #121213 100%)",
+  vanPop:      "radial-gradient(46% 70% at 42% 55%, #e5762b 0%, #a34d15 45%, #402209 78%, #120a04 100%)"
+};
+
+/* shot = { s: start, f: [[duration, look], …] } */
+const SHOTS = [
+  { s:0,     f:[[3.2,"fadeOut"],[3.3,"nightBlack2"]] },
+  { s:6.5,   f:[[2.8,"duskWide"],[2.7,"emberProfile"]] },
+  { s:12,    f:[[7.6,"nightBlack"]] },
+  { s:19.6,  f:[[1.1,"darkGlance"],[1.4,"screenGlow"]] },
+  { s:22.1,  f:[[3.5,"listener"]] },
+  { s:25.6,  f:[[2.8,"emberProfile"],[2.9,"faceWarmC"],[2.7,"faceWarmSad"]] },
+  { s:34.0,  f:[[2.1,"goldenPair"],[2.5,"gruffClose"]] },
+  { s:38.6,  f:[[1.7,"redheadTurn"],[1.9,"duoProfiles"],[1.9,"faceWarmSad"]] },
+  { s:44.1,  f:[[2.9,"greenShirt"],[2.7,"shadowHat"],[2.9,"redheadTurn"]] },
+  { s:52.6,  f:[[3.4,"carCool"],[3.3,"startled"]] },
+  { s:59.3,  f:[[3.4,"faceWarmC"],[3.3,"nightBlack2"]] },
+  { s:66.0,  f:[[3.0,"darkGlance"],[3.0,"listener"],[3.0,"emberProfile"]] },
+  { s:75.0,  f:[[4.2,"carCool"],[4.3,"goldenPair"]] },
+  { s:83.5,  f:[[2.8,"faceWarmSad"],[2.9,"duoProfiles"],[2.8,"greenShirt"]] },
+  { s:92.0,  f:[[4.5,"streetDay"],[4.5,"vanPop"]] },
+  { s:101.0, f:[[3.1,"storefront"],[3.2,"streetDay"],[3.2,"bwPlate"]] },
+  { s:110.5, f:[[5.0,"storefront"],[4.5,"streetDay"]] }
+];
+SHOTS.forEach(sh => sh.e = sh.s + sh.f.reduce((a,[d]) => a + d, 0));
+
+/* labeled sections — named ranges of shots */
+const SECTIONS = [
+  { name:"Cold Open",  a:0,  b:2  },
+  { name:"Boards",     a:3,  b:9  },
+  { name:"Reference",  a:10, b:13 },
+  { name:"Locations",  a:14, b:16 }
+];
+SECTIONS.forEach(x => { x.s = SHOTS[x.a].s; x.e = SHOTS[x.b].e; });
+
+/* ============================================================
+   DOM build
+   ============================================================ */
+const $ = id => document.getElementById(id);
+const playbar=$("playbar"), viewport=$("viewport"), content=$("content"),
+      ruler=$("ruler"), strip=$("strip"), rangeEl=$("range"), underEl=$("underline"),
+      ghost=$("ghost"), lane=$("lane"),
+      playhead=$("playhead"), chip=$("chip"),
+      pFrame=$("pFrame"), pSrc=$("pSrc"), pTime=$("pTime"), pFill=$("pFill"), pBar=$("pBar"),
+      tStart=$("tStart"), tPrev=$("tPrev"), tPlay=$("tPlay"), tNext=$("tNext"), tEnd=$("tEnd"),
+      mmTrack=$("mmTrack"), mmWindow=$("mmWindow"), mmPh=$("mmPh");
+
+content.style.width = DUR * PXS + "px";
+
+/* ruler ticks + labels */
+{
+  const fr = document.createDocumentFragment();
+  for (let i = 0; i <= DUR; i++){
+    const t = document.createElement("div");
+    t.className = "tick" + (i % 10 === 0 ? " t10" : i % 2 === 0 ? " t2" : "");
+    t.style.left = i * PXS + "px";
+    fr.appendChild(t);
+    if (i % 2 === 0 && i < DUR){
+      const l = document.createElement("span");
+      l.className = "tlabel" + (i % 10 === 0 ? " big" : "");
+      l.style.left = i * PXS + "px";
+      l.textContent = i + "s";
+      fr.appendChild(l);
+    }
+  }
+  ruler.appendChild(fr);
+}
+
+/* shot cards + frames */
+const shotEls = SHOTS.map((sh, i) => {
+  const el = document.createElement("div");
+  el.className = "shot";
+  el.dataset.i = i;
+  el.style.left  = sh.s * PXS + 2 + "px";
+  el.style.width = (sh.e - sh.s) * PXS - 4 + "px";
+  const dur = sh.e - sh.s;
+  sh.f.forEach(([d, look]) => {
+    const f = document.createElement("div");
+    f.className = "frame";
+    f.style.width = (d / dur * 100) + "%";
+    f.style.background = LOOKS[look];
+    el.appendChild(f);
+  });
+  const tag = document.createElement("span");
+  tag.className = "tag";
+  tag.textContent = "SH " + String(i + 1).padStart(2, "0") + " · " + dur.toFixed(1) + "s";
+  el.appendChild(tag);
+  strip.appendChild(el);
+  return el;
+});
+
+/* minimap shot bars */
+const mmEls = SHOTS.map(sh => {
+  const b = document.createElement("div");
+  b.className = "mm-shot";
+  b.style.left  = (sh.s / DUR * 100) + "%";
+  b.style.width = "calc(" + ((sh.e - sh.s) / DUR * 100) + "% - 2px)";
+  mmTrack.insertBefore(b, mmWindow);
+  return b;
+});
+
+/* sections: sticky labels, segmented ruler base, boundary dividers, minimap notches */
+const LAYERS_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 2 9 5-9 5-9-5Z"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg>';
+const secEls = SECTIONS.map((sec, i) => {
+  const base = document.createElement("div");
+  base.className = "rbase";
+  base.style.left  = sec.s * PXS + 3 + "px";
+  base.style.width = (sec.e - sec.s) * PXS - 6 + "px";
+  ruler.appendChild(base);
+
+  if (i > 0){
+    const div = document.createElement("div");
+    div.className = "secdiv";
+    div.style.left = sec.s * PXS + "px";
+    content.appendChild(div);
+    const notch = document.createElement("div");
+    notch.className = "mm-sec";
+    notch.style.left = (sec.s / DUR * 100) + "%";
+    mmTrack.insertBefore(notch, mmWindow);
+  }
+
+  const el = document.createElement("div");
+  el.className = "seclabel";
+  el.innerHTML = LAYERS_ICON + "<span>" + sec.name + "</span>";
+  el.addEventListener("pointerdown", ev => ev.stopPropagation());
+  el.addEventListener("click", () => viewport.scrollTo({ left: sec.s * PXS - 24, behavior: "smooth" }));
+  lane.appendChild(el);
+  return el;
+});
+
+/* labels stay pinned to the viewport edge while their section is in view */
+function updateLabels(){
+  const sl = viewport.scrollLeft;
+  secEls.forEach((el, i) => {
+    const sec = SECTIONS[i];
+    const min = sec.s * PXS + 4;
+    const max = Math.max(min, sec.e * PXS - el.offsetWidth - 12);
+    el.style.transform = "translateX(" + clamp(sl + 30, min, max) + "px)";
+  });
+}
+
+/* ============================================================
+   State + rendering
+   ============================================================ */
+let t = 0, sel = -1, playing = false, scrubbing = false, mmDrag = null, skimT = null;
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const pad = n => String(n).padStart(2, "0");
+const tc = v => pad(Math.floor(v / 60)) + ":" + pad(Math.floor(v % 60)) + ":" + pad(Math.floor((v % 1) * FPS));
+
+function setT(v){
+  t = clamp(v, 0, DUR);
+  playhead.style.transform = "translateX(" + t * PXS + "px)";
+  chip.textContent = tc(t);
+  mmPh.style.left = (t / DUR * 100) + "%";
+  playerRender();
+}
+
+function select(i){
+  if (i === sel) return;
+  if (sel >= 0){ shotEls[sel].classList.remove("selected"); mmEls[sel].classList.remove("sel"); }
+  sel = i;
+  const sh = SHOTS[i];
+  shotEls[i].classList.add("selected");
+  mmEls[i].classList.add("sel");
+  const l = sh.s * PXS + 2, w = (sh.e - sh.s) * PXS - 4;
+  rangeEl.style.left = underEl.style.left = l + "px";
+  rangeEl.style.width = underEl.style.width = w + "px";
+  revealShot(i);                                      // keep the shot in view…
+  goDeck(i);                                          // …and the deck centered on it
+}
+
+/* ---------- hover / scrub preview overlay ---------- */
+function frameAt(v){
+  let si = SHOTS.findIndex(sh => v >= sh.s && v < sh.e);
+  if (si < 0) si = v >= DUR ? SHOTS.length - 1 : 0;
+  const sh = SHOTS[si];
+  let acc = sh.s, look = sh.f[sh.f.length - 1][1];
+  for (const [d, l] of sh.f){ if (v < acc + d){ look = l; break; } acc += d; }
+  const sec = SECTIONS.find(x => si >= x.a && si <= x.b);
+  return { si, look, sec: sec ? sec.name : "" };
+}
+/* ---------- the one top player mirrors whatever is active: take > skim > sequence ---------- */
+function clipLook(cl){
+  return LOOKS[cl.seq[Math.min(cl.seq.length - 1, Math.floor(cl.playT / cl.src * cl.seq.length))]];
+}
+function playerRender(){
+  const takeCl = CLIPS.find(c => c.playing);
+  if (takeCl){
+    pFrame.style.background = clipLook(takeCl);
+    pSrc.textContent = "TAKE · SH " + pad(CLIPS.indexOf(takeCl) + 1);
+    pTime.textContent = Math.max(0, takeCl.playT - takeCl.in).toFixed(2) + "s / " + (takeCl.out - takeCl.in).toFixed(2) + "s";
+  } else if (skimT != null && !playing){
+    const f = frameAt(skimT);
+    pFrame.style.background = LOOKS[f.look];
+    pSrc.textContent = "SH " + pad(f.si + 1) + " · " + f.sec;
+    pTime.textContent = tc(skimT) + " / " + tc(DUR);
+  } else {
+    const f = frameAt(t);
+    pFrame.style.background = LOOKS[f.look];
+    pSrc.textContent = "SEQ 04 · " + f.sec;
+    pTime.textContent = tc(t) + " / " + tc(DUR);
+  }
+  pFill.style.width = (t / DUR * 100) + "%";
+}
+
+/* hover / scrub on the ruler skims frames straight into the player */
+function updatePreview(x){
+  dismissCoach();                                     // the lesson is learned by doing
+  skimT = clamp(x / PXS, 0, DUR);
+  playerRender();
+}
+function hidePreview(){
+  if (skimT == null) return;
+  skimT = null;
+  playerRender();
+}
+
+/* first-run coach mark — session-only here; persist a "seen" flag in your app */
+const coach = $("coach");
+let coached = false;
+const coachIn  = setTimeout(() => { if (!coached) coach.classList.add("show"); }, 900);
+const coachOut = setTimeout(dismissCoach, 12000);
+function dismissCoach(){
+  if (coached) return;
+  coached = true;
+  clearTimeout(coachIn); clearTimeout(coachOut);
+  coach.classList.remove("show");
+  setTimeout(() => coach.remove(), 400);
+}
+
+function syncWindow(){
+  const cw = content.offsetWidth, vw = viewport.clientWidth, sl = viewport.scrollLeft;
+  mmWindow.style.left  = (sl / cw * 100) + "%";
+  mmWindow.style.width = (vw / cw * 100) + "%";
+  const s0 = sl / PXS, s1 = (sl + vw) / PXS;
+  SHOTS.forEach((sh, i) => mmEls[i].classList.toggle("inview", sh.e > s0 && sh.s < s1));
+  updateLabels();
+}
+viewport.addEventListener("scroll", () => requestAnimationFrame(syncWindow));
+new ResizeObserver(syncWindow).observe(viewport);
+
+/* ============================================================
+   Scrubbing on the ruler / strip
+   ============================================================ */
+function seekClient(cx){
+  const r = viewport.getBoundingClientRect();
+  setT((cx - r.left + viewport.scrollLeft) / PXS);
+}
+function edgeScroll(cx){
+  const r = viewport.getBoundingClientRect();
+  if (cx < r.left + 50)       viewport.scrollLeft -= (r.left + 50 - cx) * .35;
+  else if (cx > r.right - 50) viewport.scrollLeft += (cx - (r.right - 50)) * .35;
+}
+
+/* ---------- inertia (strip fling) ---------- */
+let pan = null, mo = null;
+function cancelMomentum(){ if (mo){ cancelAnimationFrame(mo.raf); mo = null; } }
+function startMomentum(v){
+  if (Math.abs(v) < 0.05) return;
+  mo = { v, last: performance.now() };
+  const step = ts => {
+    if (!mo) return;
+    const dt = Math.min(ts - mo.last, 50); mo.last = ts;
+    viewport.scrollLeft -= mo.v * dt;
+    mo.v *= Math.pow(0.94, dt / 16.7);                  // exponential friction
+    const max = content.offsetWidth - viewport.clientWidth;
+    if (Math.abs(mo.v) < 0.02 || viewport.scrollLeft <= 0 || viewport.scrollLeft >= max - .5){ mo = null; return; }
+    mo.raf = requestAnimationFrame(step);
+  };
+  mo.raf = requestAnimationFrame(step);
+}
+
+content.addEventListener("pointerdown", e => {
+  if (e.button !== 0) return;
+  cancelMomentum();
+  content.setPointerCapture(e.pointerId);
+  if (e.target.closest(".strip")){
+    /* drag pans the strip with momentum; a quick tap still selects + seeks */
+    pan = { x0:e.clientX, sl0:viewport.scrollLeft, lastX:e.clientX, lastT:performance.now(),
+            v:0, moved:false, card:e.target.closest(".shot") };
+    strip.classList.add("panning");
+    playbar.classList.remove("top-hot");
+    ghost.classList.remove("on");
+    hidePreview();                                    // grabbing to pan — clear hover overlays immediately
+  } else {
+    scrubbing = true;
+    stopAllClips();                                   // scrubbing the sequence claims the player
+    ghost.classList.remove("on");
+    seekClient(e.clientX);
+    const r = viewport.getBoundingClientRect();
+    updatePreview(clamp(e.clientX - r.left + viewport.scrollLeft, 0, DUR * PXS));
+  }
+});
+content.addEventListener("pointermove", e => {
+  if (pan){
+    const now = performance.now(), dt = now - pan.lastT;
+    if (dt > 0) pan.v = pan.v * .7 + ((e.clientX - pan.lastX) / dt) * .3;   // smoothed px/ms
+    pan.lastX = e.clientX; pan.lastT = now;
+    viewport.scrollLeft = pan.sl0 - (e.clientX - pan.x0);
+    if (!pan.moved && Math.abs(e.clientX - pan.x0) > 4) pan.moved = true;
+    return;
+  }
+  const r = viewport.getBoundingClientRect();
+  const x = clamp(e.clientX - r.left + viewport.scrollLeft, 0, DUR * PXS);
+  if (scrubbing){
+    playbar.classList.add("top-hot");
+    edgeScroll(e.clientX);
+    seekClient(e.clientX);
+  } else {
+    if (mo) return;                                   // coasting — keep overlays hidden
+    if (!e.target.closest(".lane, .ruler, .ph-chip")){
+      playbar.classList.remove("top-hot");
+      ghost.classList.remove("on");                   // hovering the strip — no overlays
+      hidePreview();
+      return;
+    }
+    playbar.classList.add("top-hot");
+    ghost.style.left = x + "px";
+    ghost.classList.add("on");
+  }
+  updatePreview(x);
+});
+function endPointer(e){
+  if (pan){
+    strip.classList.remove("panning");
+    if (!pan.moved){                                    // tap → select + seek
+      if (pan.card) select(+pan.card.dataset.i);
+      seekClient(e.clientX);
+    } else {
+      if (performance.now() - pan.lastT > 80) pan.v = 0; // held still before release
+      startMomentum(clamp(pan.v, -3.5, 3.5));
+    }
+    pan = null;
+  }
+  scrubbing = false;
+}
+content.addEventListener("pointerup", endPointer);
+content.addEventListener("pointercancel", () => { if (pan){ strip.classList.remove("panning"); pan = null; } scrubbing = false; });
+content.addEventListener("pointerleave",  () => { playbar.classList.remove("top-hot"); ghost.classList.remove("on"); hidePreview(); });
+
+/* wheel = horizontal pan */
+viewport.addEventListener("wheel", e => {
+  cancelMomentum();
+  viewport.scrollLeft += e.deltaY + e.deltaX;
+  e.preventDefault();
+}, { passive:false });
+
+/* ============================================================
+   Minimap: drag window to pan, click to jump
+   ============================================================ */
+mmTrack.addEventListener("pointerdown", e => {
+  cancelMomentum();
+  const cw = content.offsetWidth, vw = viewport.clientWidth, tw = mmTrack.clientWidth;
+  if (e.target !== mmWindow){
+    const ratio = (e.clientX - mmTrack.getBoundingClientRect().left) / tw;
+    viewport.scrollLeft = ratio * cw - vw / 2;
+  }
+  mmDrag = { x: e.clientX, sl: viewport.scrollLeft };
+  mmTrack.setPointerCapture(e.pointerId);
+  mmTrack.classList.add("dragging");
+});
+mmTrack.addEventListener("pointermove", e => {
+  if (!mmDrag) return;
+  const cw = content.offsetWidth, tw = mmTrack.clientWidth;
+  viewport.scrollLeft = mmDrag.sl + (e.clientX - mmDrag.x) * (cw / tw);
+});
+const mmEnd = () => { mmDrag = null; mmTrack.classList.remove("dragging"); };
+mmTrack.addEventListener("pointerup", mmEnd);
+mmTrack.addEventListener("pointercancel", mmEnd);
+
+/* ============================================================
+   Playback + keys
+   ============================================================ */
+let last = 0;
+function follow(){
+  const vw = viewport.clientWidth, x = t * PXS, sl = viewport.scrollLeft;
+  if (x > sl + vw * .82)  viewport.scrollLeft = x - vw * .82;
+  else if (x < sl + 40)   viewport.scrollLeft = Math.max(0, x - 40);
+}
+function frameLoop(ts){
+  if (!playing) return;
+  setT(t + (ts - last) / 1000);
+  last = ts;
+  follow();
+  if (t >= DUR) return togglePlay(false);
+  requestAnimationFrame(frameLoop);
+}
+function togglePlay(force){
+  playing = force !== undefined ? force : !playing;
+  if (playing && t >= DUR) setT(0);
+  if (playing){ hidePreview(); cancelMomentum(); dismissCoach(); playbar.classList.remove("top-hot"); stopAllClips(); }
+  playbar.classList.toggle("is-playing", playing);
+  document.querySelector(".meta").classList.toggle("playing", playing);
+  syncTransport();
+  playerRender();
+  if (playing){ last = performance.now(); requestAnimationFrame(frameLoop); }
+}
+
+window.addEventListener("keydown", e => {
+  if (e.target.closest("input")) return;
+  const nav = e.code === "Space" || e.key === "ArrowRight" || e.key === "ArrowLeft" || e.key === "Home" || e.key === "End";
+  if (nav) cancelMomentum();
+  if (e.code === "Space"){ e.preventDefault(); togglePlay(); }
+  else if (e.key === "ArrowRight"){ e.preventDefault(); setT(t + (e.shiftKey ? 1 : 1 / FPS)); follow(); }
+  else if (e.key === "ArrowLeft"){  e.preventDefault(); setT(t - (e.shiftKey ? 1 : 1 / FPS)); follow(); }
+  else if (e.key === "Home"){ setT(0); viewport.scrollLeft = 0; }
+  else if (e.key === "End"){  setT(DUR); viewport.scrollLeft = content.offsetWidth; }
+});
+
+/* ============================================================
+   Clip deck — swipeable takes, center card active
+   ============================================================ */
+/* one take card per shot — the deck and the timeline share selection */
+const MODELS = ["H3 4-ref", "ref2va", "minimax-h3", "comfy-cloud H3"];
+const CLIPS = SHOTS.map((sh, i) => {
+  const dur = sh.e - sh.s;
+  const head = +(0.4 + (i * 37 % 23) / 10).toFixed(2);   // deterministic source handles
+  const tail = +(0.6 + (i * 53 % 17) / 10).toFixed(2);
+  const secName = SECTIONS.find(x => i >= x.a && i <= x.b).name;
+  const model = MODELS[i % MODELS.length];
+  return {
+    n: "SH " + String(i + 1).padStart(2, "0") + " — " + secName + " take (" + model + ", seed " + (100 + (i * 97) % 880) + ")",
+    src: +(head + dur + tail).toFixed(2),
+    in: head,
+    out: +(head + dur).toFixed(2),
+    seq: sh.f.map(fr => fr[1]),
+    tags: [secName.toLowerCase().replace(/\s+/g, "-"), "SH" + String(i + 1).padStart(2, "0"), model.split(" ")[0].toLowerCase()],
+    shot: i
+  };
+});
+const deck = $("deck"), deckTrack = $("deckTrack");
+const REDUCED = matchMedia("(prefers-reduced-motion: reduce)").matches;
+const PLAY_SVG  = '<svg viewBox="0 0 12 12"><path d="M3 1.5v9l7.5-4.5z"/></svg>';
+const PAUSE_SVG = '<svg viewBox="0 0 12 12"><path d="M2.5 1.5h2.6v9H2.5zM6.9 1.5h2.6v9H6.9z"/></svg>';
+const CELLS = 16;
+
+/* deck state — declared before cards build so their first renders can read it */
+let deckPos = 6, deckTarget = 6, deckNear = -1, deckRaf = 0, deckDrag = null, deckSp = 480;   // boots on the selected shot
+let pendingAutoplay = -1, deckJustDragged = 0;
+
+function wireClip(el, cl){
+  const q = s => el.querySelector(s);
+  const stripEl = q(".c-strip"), win = q(".c-win"),
+        shadeL = q(".c-shade.l"), shadeR = q(".c-shade.r"),
+        line = q(".c-playline"), frame = q(".c-frame"),
+        inF = q(".c-in"), outF = q(".c-out"), total = q(".c-total"),
+        trimD = q(".c-trim"), cutB = q(".c-cut b"), srcB = q(".c-srct b"),
+        playBtn = q(".c-play"), tags = q(".c-tags"), addBtn = q(".c-add");
+
+  cl.playT = cl.in; cl.playing = false;
+  const lookAt = v => cl.seq[Math.min(cl.seq.length - 1, Math.floor(v / cl.src * cl.seq.length))];
+
+  function tickUI(){
+    line.style.left = (cl.playT / cl.src * 100) + "%";
+    cutB.textContent = Math.max(0, cl.playT - cl.in).toFixed(2) + "s";
+    srcB.textContent = cl.playT.toFixed(2) + "s";
+    frame.style.background = LOOKS[lookAt(cl.playT)];
+    playerRender();                                    // mirror into the main player
+  }
+  function render(){
+    const l = cl.in / cl.src * 100, r = cl.out / cl.src * 100;
+    win.style.left = l + "%"; win.style.width = (r - l) + "%";
+    shadeL.style.width = l + "%"; shadeR.style.width = (100 - r) + "%";
+    inF.value = cl.in.toFixed(2); outF.value = cl.out.toFixed(2);
+    const d = cl.out - cl.in;
+    total.textContent = trimD.textContent = d.toFixed(2) + "s";
+    tickUI();
+  }
+
+  /* play the trimmed range */
+  let raf = 0, lastTs = 0;
+  function stopPlay(){
+    if (!cl.playing) return;
+    cl.playing = false; cancelAnimationFrame(raf);
+    el.classList.remove("playing");
+    playBtn.innerHTML = PLAY_SVG;
+    syncTransport();
+    playerRender();
+  }
+  function startPlay(){
+    CLIPS.forEach(o => { if (o !== cl && o._stop) o._stop(); });
+    if (playing) togglePlay(false);                    // one source at a time
+    if (cl.playT >= cl.out - .01) cl.playT = cl.in;
+    cl.playing = true; el.classList.add("playing");
+    playBtn.innerHTML = PAUSE_SVG;
+    syncTransport();
+    lastTs = performance.now();
+    const step = ts => {
+      if (!cl.playing) return;
+      cl.playT += (ts - lastTs) / 1000; lastTs = ts;
+      if (cl.playT >= cl.out){ cl.playT = cl.out; tickUI(); stopPlay(); cl.playT = cl.in; setTimeout(tickUI, 260); return; }
+      tickUI();
+      raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+  }
+  cl._stop = stopPlay;
+  cl._play = startPlay;
+  playBtn.addEventListener("pointerdown", e => e.stopPropagation());
+  playBtn.addEventListener("click", () => cl.playing ? stopPlay() : startPlay());
+
+  /* trim dragging: handles resize, window body slides */
+  let td = null;
+  win.addEventListener("pointerdown", e => {
+    e.stopPropagation();
+    const rect = stripEl.getBoundingClientRect();
+    const mode = e.target.classList.contains("c-h") ? (e.target.classList.contains("l") ? "l" : "r") : "m";
+    td = { mode, rect, off:(e.clientX - rect.left) / rect.width * cl.src - cl.in, len: cl.out - cl.in };
+    win.setPointerCapture(e.pointerId);
+    stopPlay();
+    if (!el.classList.contains("active")){
+      /* trimming a back card: clarify and lift it while working —
+         filter/opacity/z only, never transform, so the handle stays under the cursor */
+      el.style.filter = "brightness(.97) saturate(1)";
+      el.style.opacity = ".98";
+      el.style.zIndex = 40;
+    }
+  });
+  win.addEventListener("pointermove", e => {
+    if (!td) return;
+    const v = (e.clientX - td.rect.left) / td.rect.width * cl.src;
+    if (td.mode === "l")      cl.in  = clamp(v, 0, cl.out - .2);
+    else if (td.mode === "r") cl.out = clamp(v, cl.in + .2, cl.src);
+    else { cl.in = clamp(v - td.off, 0, cl.src - td.len); cl.out = cl.in + td.len; }
+    cl.playT = cl.in;
+    render();
+  });
+  const tdEnd = () => { if (td){ td = null; layoutDeck(); } };   // settle a lifted back card
+  win.addEventListener("pointerup", tdEnd);
+  win.addEventListener("pointercancel", tdEnd);
+
+  /* editable in/out fields */
+  function commit(){
+    const a = parseFloat(inF.value), b = parseFloat(outF.value);
+    if (!isNaN(a)) cl.in  = clamp(a, 0, cl.src - .2);
+    if (!isNaN(b)) cl.out = clamp(b, cl.in + .2, cl.src);
+    if (cl.in > cl.out - .2) cl.in = clamp(cl.out - .2, 0, cl.src);
+    cl.playT = cl.in; render();
+  }
+  [inF, outF].forEach(f => {
+    f.addEventListener("change", commit);
+    f.addEventListener("keydown", e => { e.stopPropagation(); if (e.key === "Enter") f.blur(); });
+    f.addEventListener("pointerdown", e => e.stopPropagation());
+  });
+
+  /* tags: × removes, + adds via inline input */
+  tags.addEventListener("pointerdown", e => e.stopPropagation());
+  tags.addEventListener("click", e => {
+    if (e.target.classList.contains("x")) e.target.closest(".chip").remove();
+  });
+  addBtn.addEventListener("click", () => {
+    if (tags.querySelector(".c-tagin")) return;
+    const f = document.createElement("input");
+    f.className = "c-tagin"; f.placeholder = "tag"; f.spellcheck = false;
+    tags.insertBefore(f, addBtn); f.focus();
+    const done = () => {
+      const v = f.value.trim();
+      if (v){
+        const s = document.createElement("span");
+        s.className = "chip"; s.append(v);
+        const x = document.createElement("button");
+        x.className = "x"; x.title = "Remove tag"; x.textContent = "×";
+        s.appendChild(x);
+        tags.insertBefore(s, f);
+      }
+      f.remove();
+    };
+    f.addEventListener("blur", done);
+    f.addEventListener("keydown", e => { e.stopPropagation(); if (e.key === "Enter") f.blur(); if (e.key === "Escape"){ f.value = ""; f.blur(); } });
+  });
+
+  /* clicking the frame plays this take in the main player */
+  q(".c-view").addEventListener("click", () => {
+    if (el.classList.contains("active") && performance.now() - deckJustDragged > 250)
+      cl.playing ? stopPlay() : startPlay();
+  });
+
+  render();
+}
+
+const cardEls = CLIPS.map((cl, i) => {
+  const el = document.createElement("article");
+  el.className = "clip";
+  el.dataset.i = i;
+  let cells = "";
+  for (let c = 0; c < CELLS; c++)
+    cells += `<div class="c-cell cine" style="background:${LOOKS[cl.seq[c % cl.seq.length]]}"></div>`;
+  const chips = cl.tags.map(t => `<span class="chip">${t}<button class="x" title="Remove tag">×</button></span>`).join("");
+  el.innerHTML = `
+    <header class="c-head">
+      <span class="c-id">clip ${i + 1}</span>
+      <span class="c-dur"><b class="c-trim"></b><i>/</i><span class="c-srcd">${cl.src.toFixed(2)}s</span></span>
+      <button class="c-menu" title="Clip options">⋯</button>
+    </header>
+    <h3 class="c-title" title="${cl.n}">${cl.n}</h3>
+    <div class="c-view"><div class="c-frame cine"></div></div>
+    <div class="c-bar">
+      <button class="c-play" title="Play trimmed range">${PLAY_SVG}</button>
+      <span class="c-cut">cut <b>0.00s</b></span>
+      <span class="c-srct">src <b>0.00s</b></span>
+    </div>
+    <div class="c-strip">
+      ${cells}
+      <div class="c-shade l"></div><div class="c-shade r"></div>
+      <div class="c-playline"></div>
+      <div class="c-win"><i class="c-h l"></i><i class="c-h r"></i></div>
+    </div>
+    <div class="c-io">
+      <label>in</label><input class="c-in" spellcheck="false">
+      <span class="arr">→</span>
+      <label>out</label><input class="c-out" spellcheck="false">
+      <span class="c-total"></span>
+    </div>
+    <div class="c-tags">${chips}<button class="c-add" title="Add tag">+</button></div>`;
+  deckTrack.appendChild(el);
+  wireClip(el, cl);
+  return el;
+});
+
+/* deck motion: drag to swipe with fling, tap a side card to activate */
+
+function layoutDeck(){
+  const w = cardEls[0].offsetWidth || 480;
+  deckSp = w * 0.93 + 18;                              // side cards sit beside the center, 18px gap
+  const near = Math.round(clamp(deckPos, 0, CLIPS.length - 1));
+  if (near !== deckNear && (deckDrag || near === deckTarget)){
+    deckNear = near;                                   // user sweep or arrival → timeline follows;
+    stopAllClips();                                    // switching takes stops the old one
+    select(near);                                      // cards passed mid-glide don't hijack the target
+    if (pendingAutoplay === near){ pendingAutoplay = -1; CLIPS[near]._play(); }
+    syncTransport();
+  }
+  cardEls.forEach((c, i) => {
+    const o = i - deckPos, ao = Math.abs(o), k = Math.min(ao, 1);
+    c.style.transform = `translate(calc(-50% + ${o * deckSp}px), -50%) scale(${1 - k * .14})`;
+    c.style.opacity = ao > 2 ? 0 : (1 - k * .16) * clamp(2 - ao, 0, 1);
+    c.style.filter = `brightness(${1 - k * .22}) saturate(${1 - k * .08})`;
+    c.style.zIndex = 30 - Math.round(ao * 6);
+    c.style.pointerEvents = ao > 1.6 ? "none" : "";
+    c.classList.toggle("active", i === near);
+  });
+}
+function animDeck(){
+  cancelAnimationFrame(deckRaf);
+  const step = () => {
+    const d = deckTarget - deckPos;
+    if (Math.abs(d) < .002){ deckPos = deckTarget; layoutDeck(); return; }
+    deckPos += d * (REDUCED ? 1 : .16);
+    layoutDeck();
+    deckRaf = requestAnimationFrame(step);
+  };
+  deckRaf = requestAnimationFrame(step);
+}
+function goDeck(i){ deckTarget = clamp(Math.round(i), 0, CLIPS.length - 1); if (!deckDrag) animDeck(); }
+
+/* scroll the timeline so a shot is comfortably in view */
+function revealShot(i){
+  const sh = SHOTS[i];
+  const x0 = sh.s * PXS, x1 = sh.e * PXS;
+  const vw = viewport.clientWidth, sl = viewport.scrollLeft;
+  if (x0 < sl + 30 || x1 > sl + vw - 30){
+    cancelMomentum();
+    viewport.scrollTo({ left: clamp((x0 + x1) / 2 - vw / 2, 0, content.offsetWidth - vw), behavior: REDUCED ? "auto" : "smooth" });
+  }
+}
+
+deck.addEventListener("pointerdown", e => {
+  if (e.target.closest("input, button, .c-win, .c-tags")) return;
+  const card = e.target.closest(".clip");
+  cancelAnimationFrame(deckRaf);
+  deckDrag = { x0:e.clientX, pos0:deckPos, lastX:e.clientX, lastT:performance.now(),
+               v:0, moved:false, card: card ? +card.dataset.i : null };
+  deck.setPointerCapture(e.pointerId);
+  deck.classList.add("dragging");
+});
+deck.addEventListener("pointermove", e => {
+  if (!deckDrag) return;
+  const now = performance.now(), dt = now - deckDrag.lastT;
+  if (dt > 0) deckDrag.v = deckDrag.v * .7 + ((e.clientX - deckDrag.lastX) / dt) * .3;
+  deckDrag.lastX = e.clientX; deckDrag.lastT = now;
+  const dx = e.clientX - deckDrag.x0;
+  if (Math.abs(dx) > 5) deckDrag.moved = true;
+  deckPos = clamp(deckDrag.pos0 - dx / deckSp, -0.35, CLIPS.length - 1 + 0.35);
+  layoutDeck();
+});
+function deckUp(){
+  if (!deckDrag) return;
+  deck.classList.remove("dragging");
+  const d = deckDrag; deckDrag = null;
+  if (d.moved) deckJustDragged = performance.now();
+  if (!d.moved){
+    if (d.card !== null && d.card !== Math.round(clamp(deckPos, 0, CLIPS.length - 1))) goDeck(d.card);
+    return;
+  }
+  if (performance.now() - d.lastT > 80) d.v = 0;
+  goDeck(deckPos + (-d.v) * 160 / deckSp);        // 160 ms fling projection
+}
+deck.addEventListener("pointerup", deckUp);
+deck.addEventListener("pointercancel", deckUp);
+
+/* trackpad horizontal swipe */
+let wAcc = 0, wT = 0;
+deck.addEventListener("wheel", e => {
+  if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
+  e.preventDefault();
+  const now = performance.now();
+  if (now - wT > 260) wAcc = 0;
+  wT = now; wAcc += e.deltaX;
+  if (Math.abs(wAcc) > 130){ goDeck(deckTarget + Math.sign(wAcc)); wAcc = 0; }
+}, { passive:false });
+
+new ResizeObserver(layoutDeck).observe(deck);
+layoutDeck();
+
+/* ---------- player transport: start / prev / play / next / end ---------- */
+function stopAllClips(){ CLIPS.forEach(c => c._stop && c._stop()); }
+function syncTransport(){
+  const on = playing || CLIPS.some(c => c.playing);
+  tPlay.innerHTML = on ? PAUSE_SVG : PLAY_SVG;
+  tPlay.classList.toggle("playing", on);
+  tPlay.title = on ? "Pause" : "Play sequence";
+  tPrev.disabled = deckTarget <= 0;
+  tNext.disabled = deckTarget >= CLIPS.length - 1;
+}
+function stepDeck(dir){
+  const nt = clamp(deckTarget + dir, 0, CLIPS.length - 1);
+  if (nt === deckTarget) return;
+  if (CLIPS.some(c => c.playing)) pendingAutoplay = nt;   // auditioning: keep rolling on the next take
+  goDeck(nt);
+  syncTransport();
+}
+tPrev.addEventListener("click", () => stepDeck(-1));
+tNext.addEventListener("click", () => stepDeck(1));
+tPlay.addEventListener("click", () => {
+  const takeCl = CLIPS.find(c => c.playing);
+  if (takeCl) takeCl._stop();
+  else togglePlay();
+  syncTransport();
+});
+tStart.addEventListener("click", () => { cancelMomentum(); stopAllClips(); setT(0); viewport.scrollLeft = 0; });
+tEnd.addEventListener("click", () => {
+  cancelMomentum(); stopAllClips();
+  if (playing) togglePlay(false);
+  setT(DUR); viewport.scrollLeft = content.offsetWidth;
+});
+syncTransport();
+
+/* seekable progress bar with section notches */
+SECTIONS.slice(1).forEach(s => {
+  const n = document.createElement("i");
+  n.className = "p-notch";
+  n.style.left = (s.s / DUR * 100) + "%";
+  pBar.appendChild(n);
+});
+let pSeek = false;
+function seekBar(e){
+  const r = pBar.getBoundingClientRect();
+  setT(clamp((e.clientX - r.left) / r.width, 0, 1) * DUR);
+  follow();
+}
+pBar.addEventListener("pointerdown", e => {
+  pSeek = true; pBar.setPointerCapture(e.pointerId);
+  cancelMomentum(); stopAllClips();
+  seekBar(e);
+});
+pBar.addEventListener("pointermove", e => { if (pSeek) seekBar(e); });
+pBar.addEventListener("pointerup",     () => pSeek = false);
+pBar.addEventListener("pointercancel", () => pSeek = false);
+
+/* ---------- preview is dismissible; the content area lives below it ---------- */
+const pSlot = $("pSlot"), pToggle = $("pToggle"), pClose = $("pClose");
+let playerOpen = true, pAnimT = 0;
+function setPlayerOpen(open){
+  if (open === playerOpen) return;
+  playerOpen = open;
+  pToggle.classList.toggle("on", open);
+  pToggle.title = open ? "Hide preview" : "Show preview";
+  clearTimeout(pAnimT);
+  if (REDUCED){
+    pSlot.style.display = open ? "" : "none";
+    if (open) playerRender();
+    return;
+  }
+  if (open){
+    pSlot.style.display = "";
+    playerRender();                                    // frame is current the moment it reappears
+    window.scrollTo({ top: 0, behavior: "smooth" });   // preview + playbar share the viewport
+    const h = pSlot.scrollHeight;
+    pSlot.classList.add("anim");
+    pSlot.style.height = "0px"; pSlot.style.opacity = "0";
+    requestAnimationFrame(() => { pSlot.style.height = h + "px"; pSlot.style.opacity = "1"; });
+    pAnimT = setTimeout(() => { pSlot.classList.remove("anim"); pSlot.style.height = ""; pSlot.style.opacity = ""; }, 340);
+  } else {
+    pSlot.classList.add("anim");
+    pSlot.style.height = pSlot.scrollHeight + "px"; pSlot.style.opacity = "1";
+    requestAnimationFrame(() => { pSlot.style.height = "0px"; pSlot.style.opacity = "0"; });
+    pAnimT = setTimeout(() => { pSlot.classList.remove("anim"); pSlot.style.display = "none"; pSlot.style.height = ""; pSlot.style.opacity = ""; }, 340);
+  }
+}
+pToggle.addEventListener("click", () => setPlayerOpen(!playerOpen));
+pClose.addEventListener("click", () => setPlayerOpen(false));
+
+/* ============================================================
+   Boot — mirror the reference screenshot: shot 07 selected, ~34.6s
+   ============================================================ */
+select(6);
+setT(34.6);
+viewport.scrollLeft = 18 * PXS - 24;
+syncWindow();
+$("metaR").textContent = FPS + " fps · " + SECTIONS.length + " sections · " + SHOTS.length + " shots · " + tc(DUR);
+$("areaCount").textContent = CLIPS.length + " takes · " + pad(Math.floor(DUR / 60)) + ":" + pad(DUR % 60);
+if (document.fonts) document.fonts.ready.then(updateLabels);
+</script>
+</body>
+</html>


### PR DESCRIPTION
The projects list is server-rendered (LCP roughly halves), and the CLS regression that blocked the branch is fixed at its real cause.

## The CLS

The two instruments never disagreed — one of them was never running. CDP's `initScript` is consumed by the navigation that installs it, so it does not re-run on a reload, and every traced measurement reloads. The observer was absent from the load being measured. An observer injected server-side (a proxy in front of `next start`) took this from intermittent to 13 of 13.

**The shift:** `main` moves `x:0 w:1385` → `x:260 w:1125`. One shift, 0.1837, the whole CLS of the page. 260px is `RAIL_OPEN_WIDTH_PX` exactly.

**The cause:** the rail is server-rendered but inside `<Suspense fallback={null}>`. The shell flushes with the boundary pending and the rail arrives at 46% of the same response inside `<div hidden id="S:0">`. A `null` fallback reserves no width, so `main` — its `flex-1` sibling — lays out across the whole row and is shoved when the boundary resolves.

`origin/main` carries that `null` fallback verbatim. **This branch did not introduce the shift; it made the page paint early enough to show it.** The shift only scores when a paint lands between the shell and the boundary resolving, and a 1,671ms LCP left no such window.

The fix reserves the rail's width from the variable the server already publishes on `<html>` from the cookie — correct for both rail states before anything paints. Same reasoning as #471.

## Measured — 4x CPU / Slow 4G, signed in

| | before | after |
| --- | ---: | ---: |
| loads shifting (injected observer) | 13 of 13 | 0 of 12 |
| worst CLS | 0.1837 | **0.0002** |
| `main` shoves | 13 | **0** |
| CLS (DevTools trace, raw server) | 0.18 | **0.00, 2 of 2** |
| LCP (raw server, warm) | 710 / 756 / 761 / 789 ms | 664 / 672 / 676 ms |

LCP is not paid for it, and the first reading said it was: two post-fix traces came back 1,159 and 1,085ms on a cold `next start` (render delay 546ms against ~100ms warm). Three warm samples land at 664-676ms.

## Guard

`app/root-layout-rail-reservation.test.ts` reads the layout as source and fails if the fallback is `null`, does not reserve `RAIL_WIDTH_VAR`, or is not `shrink-0`. All three assertions fail against `origin/main` and pass here — it catches the defect rather than restating the fix, which matters because a future `fallback={null}` reads as tidier and nothing about the defect is visible until the page is fast.

## Also

Files **PL15-028** — Cloudinary delivery usage jumped 21-23 Aug. Storage moved only +13.5% with no step, so it is delivery, not uploads. Two spikes with different shapes: video bandwidth (192MB on 20 Aug with *zero* delivered seconds — originals rather than a derived rendition) and image impressions (66-133/day → 13,907). Attribution to our own e2e and PL15-020 runs is correlation, not proof, and the item says so.

Files **PL15-029** — the item details modal should replace the content area rather than portal a scrim over the board. Filed rather than built: `aria-modal` currently IS true and `useDialogFocus` has to split (no Tab trap, but keep the focus restore), Escape loses the scrim it shares a path with, the panel geometry is viewport-relative (`h-[68vh]`) and must come from the container, and the board underneath has to be unmounted or hidden — neither obviously right.

Tests: 1457 passed. Lint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
