### PR TITLE
PL15-037 — the gesture takes its own reading, so the clamp cannot eat it

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-context.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-context.tsx
@@ -11,7 +11,12 @@ import {
   type ReactNode,
 } from "react";
 import { withViewTransition } from "@/lib/view-transition";
-import { HERO as SHARED_HERO, HERO_ATTRIBUTE, heroElement } from "./graph-item-details-shared";
+import {
+  HERO as SHARED_HERO,
+  HERO_ATTRIBUTE,
+  captureBoardScrollAtOpen,
+  heroElement,
+} from "./graph-item-details-shared";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { useCollectionsStore } from "@storyboard/ui/dnd-collections";
@@ -156,6 +161,12 @@ export function ItemDetailsProvider({ children }: Readonly<{ children: ReactNode
       // the board returning rather than a picture travelling — the view owns
       // that one, where it still has itself on screen to fly from.
       const fromBoard = next !== null && !switching && typeof document !== "undefined";
+
+      // WHERE THE BOARD IS, READ NOW — before a render, and therefore before
+      // anything can have hidden it and made the browser clamp the page to 0.
+      // The board's own listener parks the same number continuously and races
+      // that clamp; this reading cannot. See `captureBoardScrollAtOpen`.
+      if (fromBoard) captureBoardScrollAtOpen(window.scrollY);
 
       // THE PICTURE INSIDE THE CARD, not the card. Card-to-card was a 65%
       // vertical stretch cross-fading two unrelated layouts; picture-to-picture

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -71,7 +71,14 @@ import {
 import { swipeIntent, swipeOffset } from "./graph-strip-swipe";
 import { DetailsPanel } from "./graph-item-details-panel";
 import { ItemDetailsHeader } from "./graph-item-details-header";
-import { HERO, HERO_ATTRIBUTE, PANEL_GAP, heroElement } from "./graph-item-details-shared";
+import {
+  HERO,
+  HERO_ATTRIBUTE,
+  PANEL_GAP,
+  heroElement,
+  parkBoardScroll,
+  restoreBoardScroll,
+} from "./graph-item-details-shared";
 import { useScopedHistory } from "./graph-item-details-history";
 import { TrimNumbers } from "./graph-item-details-trim-fields";
 import {
@@ -1815,7 +1822,7 @@ export function GraphItemDetailsModal() {
       // from the render the context triggered, so the page can hold the offset;
       // the old capture has already been taken, so moving the page now cannot
       // reach back and displace what the morph is flying FROM.
-      restoreParkedBoardScroll();
+      restoreBoardScroll();
       holder.card = heroElement(mountedId);
       // AN ATTRIBUTE, for the same reason the opening flight uses one: React
       // is rendering this card now, and it rewrites the `style` attribute it
@@ -1927,39 +1934,6 @@ export function GraphItemDetailsModal() {
  * the subtree non-focusable and non-interactive for free, so no `inert` is
  * needed alongside it.
  */
-/**
- * WHERE THE BOARD WAS SCROLLED TO, and WHO PUTS IT BACK (PL15-035).
- *
- * The value is parked by `GraphBoardContent` below, which is the only thing
- * that knows when the board is showing. It is SPENT by the details view's
- * closing transition, which is the only thing that knows when moving the page
- * is invisible — and that is the whole reason this sits at module scope instead
- * of in the ref it used to live in.
- *
- * The restore used to run in a layout effect on the render `openId` went null.
- * That render still has the details view in normal flow, so scrolling the page
- * down scrolled the view UP and out of the viewport, and the browser captured
- * it there as the morph's old state. Doing it inside the transition's callback
- * puts it after the old capture and before the new one.
- *
- * ZERO MEANS NOTHING TO DO, which is also what an unvisited board reads as —
- * the two are the same instruction here.
- */
-let parkedBoardScroll = 0;
-
-function restoreParkedBoardScroll(): void {
-  const to = parkedBoardScroll;
-  if (to === 0) return;
-  // TWICE, AND THE SECOND ONE IS THE ONE THAT LANDS. Closing by Back is a
-  // popstate, and the browser restores that entry's own scroll offset after
-  // this runs — an offset it recorded while the page was still short, so it is
-  // 0 and it overwrites the restore. A frame later nothing else is going to
-  // move it. Kept from the layout effect this moved out of; it was learned
-  // there and the popstate has not changed.
-  window.scrollTo(0, to);
-  requestAnimationFrame(() => window.scrollTo(0, to));
-}
-
 export function GraphBoardContent({ children }: Readonly<{ children: ReactNode }>) {
   const { openId } = useItemDetails();
   const open = openId !== null;
@@ -1984,7 +1958,7 @@ export function GraphBoardContent({ children }: Readonly<{ children: ReactNode }
   useEffect(() => {
     if (open) return;
     const onScroll = () => {
-      parkedBoardScroll = window.scrollY;
+      parkBoardScroll(window.scrollY);
     };
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
@@ -2012,7 +1986,7 @@ export function GraphBoardContent({ children }: Readonly<{ children: ReactNode }
     if (!wasOpen.current) return;
     wasOpen.current = false;
     if (document.querySelector("[data-item-details]") !== null) return;
-    restoreParkedBoardScroll();
+    restoreBoardScroll();
   }, [open]);
 
   return (

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-shared.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-shared.ts
@@ -66,3 +66,60 @@ export function heroElement(id: string): HTMLElement | null {
   const card = cardElement(id);
   return card?.querySelector<HTMLElement>("[data-clip-artwork]") ?? card;
 }
+
+/**
+ * WHERE THE BOARD WAS SCROLLED TO — two sources, and the gesture wins
+ * (PL15-033, finally closed).
+ *
+ * The board scrolls the DOCUMENT, and hiding it collapses the page, so the
+ * browser clamps the window offset to 0. Carrying it across is
+ * `GraphBoardContent`'s job and it does so by parking every scroll while the
+ * board is showing.
+ *
+ * THAT ALONE IS A RACE, and it was seen in the wild once before it could be
+ * named. Hiding the board is the same commit that makes the browser clamp, and
+ * a clamp emits a scroll event; React's passive cleanup runs after paint. If
+ * the event beats the teardown the listener parks the clamped 0, the restore
+ * declines, and the grid comes back at the top. Nothing orders those two.
+ *
+ * So the OPEN GESTURE takes its own reading, synchronously, before React has
+ * rendered anything and therefore before anything can have clamped. That value
+ * cannot be wrong. The listener's is kept as the fallback for the ways in that
+ * are not a gesture — a deep link, Back/Forward — where there was no board on
+ * screen to read and 0 is the right answer anyway.
+ *
+ * Two slots rather than a lock, deliberately: a lock has to be released, and
+ * the release would be another ordering question between two components'
+ * effects. A value that simply outranks the other has none.
+ */
+let parkedBoardScroll = 0;
+let boardScrollAtOpen: number | null = null;
+
+/** From `GraphBoardContent`'s listener, while the board is showing. */
+export function parkBoardScroll(y: number): void {
+  parkedBoardScroll = y;
+}
+
+/** From the open gesture, before the board can be hidden out from under it. */
+export function captureBoardScrollAtOpen(y: number): void {
+  boardScrollAtOpen = y;
+}
+
+/**
+ * Puts the board back, and is called INSIDE the closing transition's callback
+ * (PL15-035): after the browser has captured the frame the details view is
+ * still in, so moving the page cannot displace what the morph flies from, and
+ * before it captures the frame the board is in, so the card is already where it
+ * belongs.
+ */
+export function restoreBoardScroll(): void {
+  const to = boardScrollAtOpen ?? parkedBoardScroll;
+  boardScrollAtOpen = null;
+  if (to === 0) return;
+  // TWICE, AND THE SECOND ONE IS THE ONE THAT LANDS. Closing by Back is a
+  // popstate, and the browser restores that entry's own offset after this runs
+  // — recorded while the page was short, so it is 0 and it overwrites this. A
+  // frame later nothing else is going to move it.
+  window.scrollTo(0, to);
+  requestAnimationFrame(() => window.scrollTo(0, to));
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -5394,6 +5394,56 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => page.evaluate(() => Math.round(window.scrollY))).toBe(parked);
   });
 
+  test("a scroll landing as the view opens does not eat the board's offset", async ({
+    page,
+  }) => {
+    // PL15-033's remainder, and the reason that entry was left open rather than
+    // guessed at: the failure was seen ONCE and would not come back.
+    //
+    // `GraphBoardContent` parks `window.scrollY` on every scroll while the
+    // board is showing, and stops listening when it hides. Hiding the board is
+    // also what collapses the document and makes the browser CLAMP the window
+    // scroll to 0 — and a clamp emits a scroll event. Those two are ordered by
+    // nothing: React's passive cleanup runs after paint, the clamp's event
+    // fires off layout, and if the event wins the race the parked value becomes
+    // 0. `restoreParkedBoardScroll` then declines (`to === 0`) and the board
+    // comes back at the top.
+    //
+    // REPRODUCED BY FORCING THE ORDERING rather than by waiting for it. The
+    // scroll below is what the clamp does, delivered in the same task as the
+    // open so it lands before anything can react to it. That is a real
+    // interleaving, not a synthetic one — it is the interleaving that was
+    // observed.
+    await installGraphApi(page);
+    await page.setViewportSize({ width: 640, height: 470 });
+    await page.goto(`${GRAPH_URL}?surface=grid`);
+    await expect(page.locator(`[data-virtual-grid="${PROJECT_ID}"]`)).toHaveCount(1);
+
+    const maxScroll = await page.evaluate(
+      () => document.documentElement.scrollHeight - window.innerHeight,
+    );
+    expect(maxScroll).toBeGreaterThan(40);
+    const parked = Math.min(maxScroll, 200);
+    await page.evaluate((to) => window.scrollTo(0, to), parked);
+    await expect.poll(() => page.evaluate(() => Math.round(window.scrollY))).toBe(parked);
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("graph-view:open-item-details", { detail: "alpha" }),
+      );
+      // The clamp, by hand and in the same task.
+      window.scrollTo(0, 0);
+    });
+    await expect(page.locator("[data-item-details]")).toHaveCount(1);
+    await settleViewTransition(page);
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator("[data-item-details]")).toHaveCount(0);
+
+    // The offset survives the interleaving.
+    await expect.poll(() => page.evaluate(() => Math.round(window.scrollY))).toBe(parked);
+  });
+
   // PARKED: the deck draws its trim strip on a STILL.
   //
   // A still has a duration but no SOURCE to window, so a map of the source is a

--- a/punch-list/PUNCH-LIST-15.md
+++ b/punch-list/PUNCH-LIST-15.md
@@ -2698,3 +2698,111 @@ Acceptance criteria (unchanged, and now owned by #285):
 - The first thumb anyone sees after a close is the settled one.
 - Nothing moves sideways when the details view opens or closes.
 - Neither is bought with a scrollbar that is always on screen.
+
+## PL15-037 — PL15-033's remainder, reproduced and closed
+
+- Status: Complete. The failure was forced, watched to fail 3 of 3, then fixed.
+- Area: `components/graph-view/graph-item-details-shared.ts` (the parking lot
+  moves here and gains a second slot),
+  `components/graph-view/graph-item-details-context.tsx` (the gesture's own
+  reading), `components/graph-view/graph-item-details-modal.tsx`
+- Screenshot: Not captured
+
+PL15-033 was withdrawn but left one real thing behind, seen once and not
+reproducible: `GraphBoardContent` parks `window.scrollY` on every scroll while
+the board is showing, and hiding the board is the SAME COMMIT that collapses the
+document and makes the browser clamp the offset to 0. A clamp emits a scroll
+event. React's passive cleanup runs after paint. Nothing orders those two, so if
+the event beats the teardown the listener parks the clamped 0, the restore
+declines (`to === 0`), and the grid comes back at the top.
+
+**REPRODUCED BY FORCING THE ORDERING**, which is what the entry asked for before
+anything was changed. The open and the clamp go in one task:
+
+```
+window.dispatchEvent(new CustomEvent("graph-view:open-item-details", { detail: "alpha" }));
+window.scrollTo(0, 0);
+```
+
+That is not a synthetic interleaving — it is the one that was observed, delivered
+on purpose instead of waited for. 3 runs of 3 came back with the board at 0
+against a parked 200.
+
+**THE FIX IS A SECOND READING THAT CANNOT BE WRONG.** `setOpenId` takes
+`window.scrollY` synchronously at the gesture, before React has rendered
+anything and therefore before anything can have hidden the board or clamped the
+page. `restoreBoardScroll` prefers it and consumes it; the listener's value stays
+as the fallback for the ways in that are not a gesture — a deep link,
+Back/Forward — where there was no board on screen to read and 0 is the right
+answer anyway.
+
+TWO SLOTS RATHER THAN A LOCK, deliberately. A lock has to be released, and the
+release is another ordering question between two components' effects — the same
+class of bug one layer down. A value that simply outranks the other has no
+release and no ordering.
+
+The parking lot moves from the modal file to `graph-item-details-shared.ts`,
+which is where the two ends of this already meet: the context writes the gesture
+reading, `GraphBoardContent` writes the listener's, and the closing transition
+spends whichever wins.
+
+Acceptance criteria:
+
+- Covered by `a scroll landing as the view opens does not eat the board's
+  offset`, which fails 3 of 3 without the gesture reading.
+- The existing restore behaviour is unchanged for a plain scroll-open-close, and
+  PL15-035's placement of the restore inside the transition callback is
+  untouched.
+
+## PL15-038 — #285 sized: capping the grid's height breaks exactly one thing
+
+- Status: OPEN, SPIKED not shipped. Needs one design decision from the owner
+  before it can be built; see the end.
+- Area: `components/graph-view/graph-board.tsx` (`GRID_UNCAPPED_HEIGHT`),
+  `components/graph-view/graph-seek-rails.tsx`
+- Screenshot: Not captured
+
+PL15-036 handed the wrong-size scrollbar and the 15px sideways shift to issue
+#285, on the reasoning that both exist only because the BOARD scrolls the page.
+This is what it would actually take.
+
+**THE GRID ALREADY SUPPORTS IT.** `VirtualGrid`'s `height` prop is documented as
+"MAXIMUM scroll viewport height: the grid is content-height while its rows fit,
+and scrolls only past this cap". The board passes
+`GRID_UNCAPPED_HEIGHT = 100_000`, so the cap is never reached, the grid is always
+content-height, and the virtualizer's viewport is 100000px — which is also why
+every card mounts, the headline complaint in #285. One prop.
+
+**THE BLAST RADIUS WAS MEASURED, NOT ESTIMATED.** With `height={520}` hard-coded
+and nothing else touched, the e2e is 171 passed / 1 failed. The one failure is
+`grid mode with preview: seek rail scrubs (pointer + keyboard); cards keep
+select, drill and hold-drag`, and it is deterministic rather than the flake that
+test is already known for (#453): 3 of 3 with the cap, 3 of 3 clean without it.
+
+**AND THE FAILURE IS THE PREDICTABLE ONE.** `GraphSeekRails` is a SIBLING of the
+grid, `absolute inset-0` over the surface shell, and it measures row positions
+from `rootRect`/`gridRect` under a ResizeObserver. A ResizeObserver does not fire
+on scroll, so the moment the grid scrolls inside itself the rails stop agreeing
+with the rows they are supposed to sit above.
+
+That is a known shape here rather than new ground: the STRIP's rail already
+solves exactly this problem — its own note describes being "a SIBLING of the
+strip, so it queries across for the scroller", viewport-fixed with scroll-synced
+content. The grid's rail needs the same treatment.
+
+**THE DECISION IT NEEDS, and it is a visible one.** Capping the grid means the
+page stops scrolling on the board, so the graph header and toolbar stay put
+while only the cards move. That is a different feel from today, where the whole
+page scrolls and the header leaves. It is arguably the better instrument — the
+controls stay where your hand is — but it is a change to the main surface and
+not one to make on the way past a scrollbar complaint.
+
+If it is wanted, the work is: a measured height for the grid (the same
+`innerHeight - top - gap` arithmetic PL15-032 built for the details view), the
+grid rail re-anchored the way the strip's already is, and a check that the
+board's drag auto-scroll follows the container rather than the window.
+
+What it buys, all of it measured elsewhere in this list: real virtualization
+(#285's own point), no wrong-size thumb, no 15px shift, and the whole
+parking-and-restoring apparatus (PL15-035, PL15-037) becomes unnecessary,
+because a container keeps its own `scrollTop` with nothing to clamp it.


### PR DESCRIPTION
Closes the one real thing PL15-033 left behind, and sizes #285 rather than doing it.

## PL15-037 — the park race, reproduced then fixed

`GraphBoardContent` parks `window.scrollY` on every scroll while the board is
showing. Hiding the board is the SAME COMMIT that collapses the document and
makes the browser clamp the offset to 0 — and a clamp emits a scroll event.
React's passive cleanup runs after paint. Nothing orders the two, so if the event
beats the teardown the listener parks the clamped 0, `restoreBoardScroll`
declines (`to === 0`), and the grid comes back at the top.

**Reproduced before anything was changed**, which is what the entry demanded
after the last round's false start. The open and the clamp go in one task:

    window.dispatchEvent(new CustomEvent("graph-view:open-item-details", { detail: "alpha" }));
    window.scrollTo(0, 0);

That is the interleaving that was observed in the wild, delivered on purpose
instead of waited for. **3 of 3 failed**, board at 0 against a parked 200.

**The fix is a second reading that cannot be wrong.** `setOpenId` takes
`window.scrollY` synchronously at the gesture — before React renders, therefore
before anything can have hidden the board or clamped the page.
`restoreBoardScroll` prefers it and consumes it. The listener's value stays as
the fallback for the ways in that are not a gesture (deep link, Back/Forward),
where there was no board on screen to read and 0 is the right answer anyway.

Two slots rather than a lock, deliberately: a lock has to be released, and the
release is another ordering question between two components' effects — the same
class of bug one layer down. A value that simply outranks the other has neither.

The parking lot moves from the modal to `graph-item-details-shared.ts`, where the
two ends already meet: the context writes the gesture reading,
`GraphBoardContent` writes the listener's, the closing transition spends whichever
wins.

## PL15-038 — #285 sized, not shipped

PL15-036 handed the wrong-size scrollbar and the 15px shift to #285. This is what
it would cost, measured rather than estimated.

**The grid already supports it.** `VirtualGrid`'s `height` is "MAXIMUM scroll
viewport height: the grid is content-height while its rows fit, and scrolls only
past this cap". The board passes `GRID_UNCAPPED_HEIGHT = 100_000`, so the cap is
never reached — which is also why every card mounts, #285's headline.

**Blast radius, spiked.** `height={520}`, nothing else touched: e2e **171 passed
/ 1 failed**. The one failure is `grid mode with preview: seek rail scrubs`, and
it is deterministic rather than the flake that test is known for (#453) — 3 of 3
with the cap, 3 of 3 clean without.

**And it is the predictable failure.** `GraphSeekRails` is an `absolute inset-0`
sibling of the grid that measures row positions under a ResizeObserver, which
does not fire on scroll. The STRIP's rail already solves exactly this — its own
note describes querying across for the scroller and staying scroll-synced — so
this is a known shape, not new ground.

**It needs one decision, and it is visible.** Capping the grid means the page
stops scrolling on the board: the graph header and toolbar stay put and only the
cards move. Arguably the better instrument, but a change to the main surface, and
not one to make on the way past a scrollbar complaint. Left for the owner.

What it would buy: real virtualization, no wrong-size thumb, no 15px shift, and
the whole parking-and-restoring apparatus (PL15-035, PL15-037) becomes
unnecessary — a container keeps its own `scrollTop` with nothing to clamp it.

## Suites

    app        1473 passing
    unit        812 passing
    storybook   306 passing
    e2e         172 passing, 10 skipped
    tsc clean, lint 0 errors

One e2e failed in the full run — `the menu is reachable and operable from the
keyboard alone`, the Radix autofocus flake this repo already knows — and passes
3 of 3 alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
