### PR TITLE
Fix #541 — a hidden grid keeps the layout it had

### DIFF
--- a/packages/ui/dnd-collections/VirtualGrid.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualGrid.stories.tsx
@@ -151,6 +151,64 @@ export const FillsFullWidth: Story = {
  * waited to catch the flash would be a race; this one fails the moment someone
  * tidies the class list back to a single overflow rule.
  */
+/**
+ * A GRID THAT IS HIDDEN KEEPS THE LAYOUT IT HAD.
+ *
+ * `display: none` gives every descendant a client width of 0, and a
+ * ResizeObserver reports that as a resize. Fed through the responsive column
+ * arithmetic, 0 floors to ONE COLUMN — so a grid that is merely out of sight
+ * re-lays itself as a single tall stack of every row, and the page it sits in
+ * grows to match until it is shown and measured again.
+ *
+ * The app hides its board exactly this way while the details view is up (it
+ * keeps the board mounted so selection and in-flight drags survive), so this
+ * ran on every close. Measured there with four cards: the spacer went to 944
+ * (4 rows) against a settled 472, the document to 1565 against a settled 615,
+ * and the browser drew a scrollbar thumb for a page two and a half times the
+ * real height before correcting it (#541).
+ *
+ * TWO FRAMES BEFORE ASSERTING, and that is the whole test. ResizeObserver
+ * delivers before paint but not synchronously, so an assertion made in the same
+ * tick as the hide would pass without the observer ever having run — vacuously,
+ * and just as green with the guard removed. Waiting is what makes this a test.
+ */
+export const HiddenGridKeepsItsColumns: Story = {
+  render: () => (
+    <DndCollections initialGraph={gridGraph()}>
+      <div className="w-[601px]" data-testid="hideable">
+        <VirtualGrid collectionId={parseNodeId("grid")} cellWidth={160} gap={8} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "m0"));
+    const container = canvasElement.querySelector<HTMLElement>('[data-testid="hideable"]')!;
+    const grid = container.querySelector<HTMLElement>("[data-virtual-grid]")!;
+    const spacer = grid.querySelector<HTMLElement>(":scope > div")!;
+
+    const columns = grid.dataset.gridColumns;
+    const spacerHeight = Math.round(spacer.getBoundingClientRect().height);
+    // The fixture is 1000 items at 160px in a 601px box, so this is several
+    // columns — a grid that was ALREADY one column could not show the defect.
+    expect(Number(columns)).toBeGreaterThan(1);
+
+    const settle = () =>
+      new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+    container.style.display = "none";
+    await settle();
+    // Still what it was. Without the zero-width guard this is "1".
+    expect(grid.dataset.gridColumns).toBe(columns);
+
+    container.style.display = "";
+    await settle();
+    expect(grid.dataset.gridColumns).toBe(columns);
+    // And the row count it implies never moved either, which is the number the
+    // page height is actually made of.
+    expect(Math.round(spacer.getBoundingClientRect().height)).toBe(spacerHeight);
+  },
+};
+
 export const GridNeverScrollsHorizontally: Story = {
   render: () => (
     <DndCollections initialGraph={gridGraph()}>

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -176,6 +176,27 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       const compute = () => {
         // The spacer's clientWidth already excludes container padding.
         const width = contentRef.current?.clientWidth ?? el.clientWidth;
+        // A HIDDEN BOX MEASURES ZERO, AND ZERO IS NOT A LAYOUT.
+        //
+        // Every descendant of a `display: none` subtree has a client width of
+        // 0, and a ResizeObserver reports that as a resize. Through the
+        // arithmetic below 0 floors to ONE COLUMN, so a grid that is merely out
+        // of sight re-lays itself as a single tall stack of every row.
+        //
+        // Not hypothetical, and not invisible. The app hides the board with
+        // `display: none` while the details view is up — deliberately, so
+        // selection and in-flight drags survive — so every close came back
+        // through the one-column layout. Measured on the way out, with four
+        // cards: the spacer went to 944 (4 rows x 236) against a settled 472,
+        // the document to 1565 against a settled 615, and the browser drew a
+        // scrollbar thumb for a page two and a half times the real height
+        // before correcting it.
+        //
+        // Keeping the last real measurement is right rather than merely
+        // convenient: a box with no layout has no width to report, so there is
+        // nothing here to learn. The next non-zero measurement is the answer
+        // and it arrives in the frame the box comes back.
+        if (width <= 0) return;
         setMeasuredWidth(width);
         if (columns === undefined) {
           setMeasuredColumns(Math.max(1, Math.floor((width + gap) / (cellWidth + gap))));


### PR DESCRIPTION
Closes #541.

## The defect

`display: none` gives every descendant a client width of **0**, and a ResizeObserver reports that as a resize. Through `VirtualGrid`'s responsive column arithmetic:

```js
setMeasuredColumns(Math.max(1, Math.floor((width + gap) / (cellWidth + gap))));
```

0 floors to **one column**. So a grid that is merely out of sight re-lays itself as a single tall stack of every row, and the page it sits in grows to match until it is shown and measured again.

The app hides its board exactly this way while the details view is up — deliberately, so selection and in-flight drags survive — so this ran on every close.

## Measured, on the fixture's four cards

    spacer     944 (4 rows x 236)  ->  472 (2 rows)
    document  1565                 -> 1093
    settled                             615

1565 against a settled 615 is the scrollbar thumb being drawn for a page two and a half times the real height and then corrected — the "wrong size then corrects itself" report.

Captured mid-blip, which is what made it unambiguous:

    gridClientWidth 925   spacerH 944   cards 0   detailsPresent true

The width had already come back to 925 while the column count was still 1 — a stale measurement, not a narrow container.

## What is left, and why

The remaining 1093 is the board and the details view being in flow together for one render. That is PL15-035, and it is deliberately not fixed: holding the board hidden through the close removes the morph's destination (a hidden virtualized board renders no cards), which was tried and reverted with the e2e catching it 3 of 3.

## A correction to my own earlier finding

I previously reported that this exact guard "regresses the column count to 1 permanently". **It does not.** That reading, and one other, were taken in the preview pane, whose document is `visibilityState: hidden` — which stops `requestAnimationFrame` and throttles the observers this behaviour depends on. Everything above is measured in Playwright against a genuinely visible page. #541 has been updated.

## Test

`HiddenGridKeepsItsColumns` hides the container, waits **two frames**, and asserts the column count and spacer height are unchanged.

The wait is the test. ResizeObserver delivers before paint but not synchronously, so an assertion made in the same tick as the hide passes without the observer ever running — vacuously green with the guard removed. With the wait, removing the guard fails it: `expected '1' to be '3'`.

It also asserts the starting column count is > 1, so it cannot pass for the wrong reason if the fixture or cell size changes.

## Also better on first mount

A pre-layout width of 0 used to set `measuredWidth` to 0, which sizes every cell at 1px until the next measurement. The guard skips that too.

## Suites

    app        1473 passing
    unit        812 passing
    storybook   307 passing
    e2e         173 passing, 10 skipped
    tsc clean (packages/ui and the app), lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
