### PR TITLE
PL16-001 — grab the playhead and the deck becomes the screen

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -726,8 +726,37 @@ function DetailsFilmstripModal({
   }, [skimSrc, skimPosterBase, skimSourceTime]);
   const skimTaken = usePublishTrimPreview(skimFrame);
 
+  /**
+   * THE DECK BECOMES THE PREVIEW WHILE THE PLAYHEAD IS HELD (PL16-001).
+   *
+   * Same source as the strip's skim card and the pane's frame — one scrub, three
+   * possible places to show it — so the precedence has to be stated rather than
+   * left to whoever renders last:
+   *
+   *   the PANE takes it when it is open (`skimTaken`), and nothing else shows;
+   *   otherwise the DECK takes it, becoming the preview screen itself;
+   *   the strip's floating card is what is left when neither did.
+   *
+   * That order is the existing rule extended by one, not a new one: the strip's
+   * `skimPreview` already stood down for the pane, and `skimPreview` below now
+   * stands down for this as well. Precisely one of the three is ever up.
+   */
+  const deckPreviewing = !skimTaken && (skimSeconds !== null || trimSkim !== null);
+  const deckPreviewPoster = useMemo<string | undefined>(() => {
+    if (!deckPreviewing || skimNode === null || skimSourceTime === null) return undefined;
+    // Audio has no picture to show, and a clip with no addressable poster base
+    // can only offer its own source — the deck falls back to the card's frame
+    // for both rather than going black.
+    if (skimNode.mediaKind === "audio" || skimPosterBase === undefined) return undefined;
+    // QUANTISED TO A QUARTER SECOND for the reason the strip's card is: every
+    // distinct time is a distinct Cloudinary fetch, and a pointer sweeping the
+    // bar would ask for hundreds. The pane's copy is not quantised because it
+    // seeks an element it already holds; this one is a URL.
+    return monitorPosterUrl(skimPosterBase, Math.round(skimSourceTime * 4) / 4);
+  }, [deckPreviewing, skimNode, skimSourceTime, skimPosterBase]);
+
   const skimPreview = useMemo<FilmStripSkimPreview | null>(() => {
-    if (skimTaken || skimNode === null || skimSourceTime === null) return null;
+    if (skimTaken || deckPreviewing || skimNode === null || skimSourceTime === null) return null;
     // QUANTISED TO A QUARTER SECOND, because the URL is a Cloudinary frame grab
     // and every distinct time is a distinct fetch — a pointer sweeping the bar
     // would ask for hundreds. Finer than the eye tracks mid-sweep, and coarse
@@ -748,7 +777,7 @@ function DetailsFilmstripModal({
       // chosen rather than something to measure against.
       meta: `${(trimSkim === null ? (skimAt?.clipSeconds ?? 0) : skimSourceTime).toFixed(2)}s / ${total.toFixed(2)}s`,
     };
-  }, [skimTaken, skimNode, skimAt, skimSourceTime, skimPosterBase, trimSkim]);
+  }, [skimTaken, deckPreviewing, skimNode, skimAt, skimSourceTime, skimPosterBase, trimSkim]);
   // ANY clip the bar covers, not just the three it used to. With nine panels
   // the playhead can be inside a clip four along, and the monitor still has to
   // be able to paint it.
@@ -1603,6 +1632,8 @@ function DetailsFilmstripModal({
           which dispatches the same `update-media` the trim fields did. */}
       <ClipDeck
         standalone={false}
+        previewing={deckPreviewing}
+        previewPoster={deckPreviewPoster}
         // TAKES WHAT THE BAR LEAVES — but only when the pane is up and the
         // height is actually contested. `min-h-0` because a flex item's default
         // `min-height: auto` refuses to shrink below its content, which is the

--- a/apps/timeline-gstudio001/components/graph-view/playbar/clip-deck-preview.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/playbar/clip-deck-preview.stories.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { ClipDeck } from "./clip-deck";
+
+/**
+ * THE DECK BECOMES THE PREVIEW WHILE SOMEONE SCRUBS (PL16-001).
+ *
+ * ITS OWN FILE, and not added to `playbar.stories.tsx`, which states as a rule
+ * that it carries NO play functions: its two stories are driven by hand, and
+ * the e2e suite needs stories that do not run a `play` on load — Storybook's
+ * synthetic pointerup kills a concurrently running real-mouse drag. Putting an
+ * asserted story in there would either break that rule or quietly weaken it.
+ *
+ * DRIVEN BY A BUTTON RATHER THAN BY THE FILM STRIP. What is under test is the
+ * deck's response to `previewing`, and the strip's playhead already has its own
+ * coverage for producing the signal. Wiring the real strip in would test the
+ * two together and tell us less about either when it broke.
+ */
+const PREVIEW_POSTER = "https://example.invalid/frame-at-4.25s.png";
+
+function PreviewHarness() {
+  const [previewing, setPreviewing] = useState(false);
+  return (
+    <div>
+      <button type="button" data-testid="toggle" onClick={() => setPreviewing((on) => !on)}>
+        {previewing ? "release" : "scrub"}
+      </button>
+      <ClipDeck previewing={previewing} previewPoster={PREVIEW_POSTER} />
+    </div>
+  );
+}
+
+const meta: Meta = {
+  title: "graph-view/Playbar/Deck preview",
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+
+/**
+ * Grabbing the playhead collapses the deck into a preview screen, and releasing
+ * it puts the three cards back.
+ *
+ * Asserted on the three things the feature actually promises, because each can
+ * break without the others: the neighbours ARRIVE at the subject (they slide in
+ * and go under it), the subject GROWS and drops its chrome, and the picture is
+ * the frame the playhead is on rather than the card's own.
+ */
+export const CollapsesWhileScrubbing: StoryObj = {
+  name: "Collapses while scrubbing",
+  render: () => <PreviewHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const deck = canvasElement.querySelector<HTMLElement>(".deck")!;
+    const subject = () => canvasElement.querySelector<HTMLElement>(".deck .clip.active")!;
+    const neighbours = () =>
+      [...canvasElement.querySelectorAll<HTMLElement>(".deck .clip")].filter(
+        (card) => !card.classList.contains("active"),
+      );
+    const centreOf = (card: HTMLElement) => {
+      const rect = card.getBoundingClientRect();
+      return Math.round(rect.x + rect.width / 2);
+    };
+    const chrome = () => subject().querySelector<HTMLElement>(".c-head")!;
+
+    // The deck lays out on a rAF, so nothing is measurable until it has.
+    await waitFor(() => expect(subject().getBoundingClientRect().width).toBeGreaterThan(0));
+
+    const restWidth = Math.round(subject().getBoundingClientRect().width);
+    const restCentre = centreOf(subject());
+    // APART TO BEGIN WITH. A deck whose neighbours already sat on the subject
+    // would pass the collapse assertion without collapsing.
+    const spreadAtRest = neighbours()
+      .map((card) => Math.abs(centreOf(card) - restCentre))
+      .filter((distance) => distance > 0);
+    expect(Math.max(...spreadAtRest)).toBeGreaterThan(40);
+
+    await userEvent.click(canvas.getByTestId("toggle"));
+
+    await waitFor(() => expect(deck.className).toContain("previewing"));
+    await waitFor(
+      () => {
+        // EVERY neighbour has arrived at the subject — under it, which the
+        // subject's raised z-index is what makes true, and invisible.
+        for (const card of neighbours()) {
+          expect(Math.abs(centreOf(card) - centreOf(subject()))).toBeLessThan(4);
+        }
+        // The subject is a screen now: wider than it was, and its chrome gone.
+        expect(Math.round(subject().getBoundingClientRect().width)).toBeGreaterThan(restWidth);
+        expect(Number(getComputedStyle(chrome()).opacity)).toBe(0);
+      },
+      { timeout: 3000 },
+    );
+
+    // And it is showing the PLAYHEAD's frame, not the card's own.
+    expect(subject().querySelector<HTMLElement>(".c-frame")!.style.background).toContain(
+      PREVIEW_POSTER,
+    );
+
+    await userEvent.click(canvas.getByTestId("toggle"));
+
+    await waitFor(() => expect(deck.className).not.toContain("previewing"));
+    await waitFor(
+      () => {
+        // Back out from behind the subject, to where they started.
+        const spread = neighbours()
+          .map((card) => Math.abs(centreOf(card) - centreOf(subject())))
+          .filter((distance) => distance > 0);
+        expect(Math.max(...spread)).toBeGreaterThan(40);
+        expect(Math.round(subject().getBoundingClientRect().width)).toBe(restWidth);
+        expect(Number(getComputedStyle(chrome()).opacity)).toBe(1);
+      },
+      { timeout: 3000 },
+    );
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/playbar/clip-deck.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/playbar/clip-deck.tsx
@@ -203,11 +203,36 @@ export type ClipDeckProps = Readonly<{
    * entirely.
    */
   heroName?: string;
+  /**
+   * SOMEONE IS SCRUBBING, so the deck becomes the preview (PL16-001).
+   *
+   * The two neighbours slide inward and vanish UNDER the subject, the subject
+   * grows to a preview screen and drops its chrome, and the picture shows
+   * whatever frame the playhead is sitting on. Released, all of it reverses.
+   *
+   * A BOOLEAN RATHER THAN THE FRAME ITSELF, with `previewPoster` separate: the
+   * collapse is a state that outlives any one frame (it holds for the whole
+   * drag, across hundreds of poster changes), and folding them together would
+   * restart the animation every time the pointer moved a quarter second.
+   */
+  previewing?: boolean;
+  /**
+   * The frame under the playhead, for the subject to show while `previewing`.
+   *
+   * A URL, not a CSS value — the deck wraps it. Undefined is legitimate and
+   * common: audio has no picture, a still has one frame that scrubbing cannot
+   * change, and a poster that cannot be addressed is simply not there. The
+   * subject keeps its own frame in those cases rather than going black, which
+   * is a truer answer than an empty screen.
+   */
+  previewPoster?: string;
   className?: string;
 }>;
 
 export function ClipDeck({
   clips: clipsProp,
+  previewing = false,
+  previewPoster,
   activeId,
   onActivate,
   onTrim,
@@ -220,6 +245,20 @@ export function ClipDeck({
 }: ClipDeckProps) {
   const CLIPS = useMemo(() => clipsProp ?? REFERENCE_CLIPS, [clipsProp]);
   const deckRef = useRef<HTMLDivElement | null>(null);
+  /**
+   * HOW FAR THE DECK HAS COLLAPSED INTO A PREVIEW, 0 to 1 (PL16-001).
+   *
+   * A ref driven by the same rAF loop as the glide, and read by `layout()`,
+   * because `layout()` is the ONE writer of every card's transform. Holding it
+   * in React state and letting CSS transition the neighbours would put a second
+   * writer on the same property — the transform `layout()` rewrites on every
+   * frame — and the two would erase each other. The subject's own morph IS left
+   * to CSS, which is safe because CSS is the only thing touching those
+   * properties (width, padding, aspect-ratio).
+   */
+  const collapseRef = useRef(0);
+  const collapseTargetRef = useRef(0);
+  const collapseRafRef = useRef(0);
   const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
   const posRef = useRef(6); // boots on the shot the reference selects
   const targetRef = useRef(6);
@@ -360,16 +399,34 @@ export function ClipDeck({
       // makes five an ADDITION: the three in the middle are untouched by the
       // setting, and the extra pair joins them at the same size.
       const k = Math.min(distance, 1);
-      card.style.transform = `translate(calc(-50% + ${offset * spacingRef.current}px), -50%) scale(${1 - k * 0.14})`;
+      // ── THE COLLAPSE ────────────────────────────────────────────────────
+      //
+      // At `collapse = 1` every neighbour sits exactly where the subject sits
+      // and is invisible, so they read as having slid inward and gone UNDER it
+      // — under rather than over because the subject's z-index is raised below.
+      // The subject itself is unaffected: its offset is already 0 and its
+      // scale already 1, so multiplying both by `(1 - collapse)` and lerping
+      // the scale toward 1 leaves it exactly where it was. One expression
+      // covers both cases rather than branching on which card this is.
+      const collapse = collapseRef.current;
+      const spread = 1 - collapse;
+      const scale = (1 - k * 0.14) * spread + collapse;
+      card.style.transform = `translate(calc(-50% + ${offset * spacingRef.current * spread}px), -50%) scale(${scale})`;
       // `shown` is how far out a card is still fully drawn; one further out is
       // the fade, and past that nothing. At `neighbours = 1` this is the
       // reference's own `2 - distance`, unchanged.
       const shown = neighbours + 1;
       card.style.opacity = String(
-        distance > shown ? 0 : (1 - k * 0.16) * clamp(shown - distance, 0, 1),
+        // `* spread` on the NEIGHBOURS only: `k` is 0 for the subject, so its
+        // own term is 1 and it keeps full opacity all the way through the
+        // collapse. Everything else fades out as it travels in.
+        (distance > shown ? 0 : (1 - k * 0.16) * clamp(shown - distance, 0, 1)) *
+          (k === 0 ? 1 : spread),
       );
       card.style.filter = `brightness(${1 - k * 0.22}) saturate(${1 - k * 0.08})`;
-      card.style.zIndex = String(30 - Math.round(distance * 6));
+      // The subject rides ABOVE its neighbours by more than one step while the
+      // deck is collapsing, so they pass beneath it rather than through it.
+      card.style.zIndex = String(30 - Math.round(distance * 6) + (k === 0 ? 10 : 0));
       // A card you can see is a card you can hit. The 0.6 is the reference's
       // own margin past the last fully-drawn card.
       card.style.pointerEvents = distance > neighbours + 0.6 ? "none" : "";
@@ -385,6 +442,46 @@ export function ClipDeck({
     setNearIndex(near);
     return near;
   }, [neighbours]);
+
+  /**
+   * DRIVES THE COLLAPSE, and repaints the deck while it runs (PL16-001).
+   *
+   * `layout()` reads `collapseRef` but is only called by the glide's own loop,
+   * which is idle when nobody is dragging a card — so the collapse has to run
+   * its own frames and call `layout()` itself. It stops as soon as it lands,
+   * rather than running while a scrub continues, because the collapse is over
+   * long before the scrub is.
+   *
+   * REDUCED MOTION SNAPS. The whole point of this is motion; someone who has
+   * asked for less of it still needs the preview, so the destination is
+   * honoured immediately and only the travel is dropped.
+   */
+  useEffect(() => {
+    collapseTargetRef.current = previewing ? 1 : 0;
+    if (reduced) {
+      collapseRef.current = collapseTargetRef.current;
+      layout();
+      return;
+    }
+    cancelAnimationFrame(collapseRafRef.current);
+    const step = () => {
+      const target = collapseTargetRef.current;
+      const delta = target - collapseRef.current;
+      if (Math.abs(delta) < 0.001) {
+        collapseRef.current = target;
+        layout();
+        return;
+      }
+      // The same shape the glide uses: a proportional step, which eases out on
+      // its own and needs no clock. 0.18 lands in about 12 frames.
+      collapseRef.current += delta * 0.18;
+      layout();
+      collapseRafRef.current = requestAnimationFrame(step);
+    };
+    collapseRafRef.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(collapseRafRef.current);
+  }, [previewing, reduced, layout]);
+
 
   const animate = useCallback(() => {
     cancelAnimationFrame(rafRef.current);
@@ -773,7 +870,7 @@ export function ClipDeck({
       <style>{PLAYBAR_CSS}</style>
       <PlaybarFrame standalone={standalone}>
           <section
-            className="deck"
+            className={previewing ? "deck previewing" : "deck"}
             ref={deckRef}
             // NO MARGIN OF ITS OWN WHEN EMBEDDED. The reference's deck carries
             // `margin: 20px 0 4px` because it sits under a preview panel on its
@@ -933,7 +1030,26 @@ export function ClipDeck({
                           // the committed one, which is exactly the span of a
                           // drag on THIS card: the out handle never moves the
                           // in point, so it never asks.
-                          background: livePoster ?? clip.poster ?? clip.frames[0] ?? "#0d0d10",
+                          // THE PLAYHEAD'S FRAME WINS WHILE SCRUBBING, and
+                          // only on the subject — a neighbour is sliding out
+                          // of sight and repainting it would be work nobody
+                          // sees. Falls through to the card's own frame when
+                          // the scrub has no poster to offer (audio, or one
+                          // that cannot be addressed), which beats going black.
+                          background:
+                            // WRAPPED HERE, because the prop is a URL and this
+                            // is a `background` shorthand — handing it a bare
+                            // URL is invalid CSS and the browser silently drops
+                            // the whole declaration, which reads as the preview
+                            // simply not working. Same shape as `livePoster`
+                            // just below, so the two cannot drift.
+                            (previewing && index === active && previewPoster !== undefined
+                              ? `center/cover no-repeat url("${previewPoster}")`
+                              : undefined) ??
+                            livePoster ??
+                            clip.poster ??
+                            clip.frames[0] ??
+                            "#0d0d10",
                         }}
                       />
                     </div>

--- a/apps/timeline-gstudio001/components/graph-view/playbar/playbar-styles.ts
+++ b/apps/timeline-gstudio001/components/graph-view/playbar/playbar-styles.ts
@@ -592,6 +592,66 @@ export const PLAYBAR_CSS = `.pb{
    deck and any surface that never sets it are unchanged. ─────────────────── */
 .pb .clip{ width: var(--clip-w, clamp(300px, 30vw, 440px)); }
 
+/* ── THE DECK BECOMES THE PREVIEW WHILE SOMEONE SCRUBS (PL16-001) ─────────
+   The neighbours' half of this is NOT here: their travel is a transform, and
+   \`layout()\` rewrites every card's transform on every frame, so a CSS
+   transition on the same property would be a second writer and the two would
+   erase each other. What is here is the subject's own morph, which touches
+   properties nothing else writes.
+
+   THE ORDER IS THE EFFECT, and it is why the chrome and the picture have
+   different timings. The chrome leaves first and quickly (120ms, no delay) so
+   the card is already bare by the time it has finished growing; the box takes
+   the full 260ms; and the picture's aspect goes with the box so the frame
+   reshapes rather than being letterboxed into the old one. Reversed on the way
+   out by the un-prefixed rules above, which is what makes release read as the
+   card coming back rather than a second, different animation. */
+.pb .deck .clip{
+  transition: width 260ms cubic-bezier(.2,0,0,1), padding 260ms cubic-bezier(.2,0,0,1),
+              border-radius 260ms cubic-bezier(.2,0,0,1);
+}
+.pb .deck .clip .c-view{ transition: aspect-ratio 260ms cubic-bezier(.2,0,0,1); }
+.pb .deck .clip .c-head,.pb .deck .clip .c-title,.pb .deck .clip .c-bar,
+.pb .deck .clip .c-strip,.pb .deck .clip .c-io,.pb .deck .clip .c-tags{
+  transition: opacity 160ms ease-out 100ms, max-height 260ms cubic-bezier(.2,0,0,1),
+              margin 260ms cubic-bezier(.2,0,0,1);
+  max-height: 200px;
+}
+
+/* THE SUBJECT ONLY. A neighbour is on its way under this card and is about to
+   be invisible; growing it too would be work nobody sees, and it would widen
+   the box the neighbours are travelling across. */
+.pb .deck.previewing .clip.active{
+  width: var(--preview-w, min(100%, 980px));
+  padding: 0;
+  border-radius: 12px;
+}
+.pb .deck.previewing .clip.active .c-view{ aspect-ratio: 16/9; border-radius: 12px; }
+/* GONE, NOT JUST INVISIBLE. Opacity alone leaves the rows holding their height,
+   so the card would keep a picture-sized hole above and below the frame and
+   never actually become a preview screen. */
+.pb .deck.previewing .clip.active .c-head,
+.pb .deck.previewing .clip.active .c-title,
+.pb .deck.previewing .clip.active .c-bar,
+.pb .deck.previewing .clip.active .c-strip,
+.pb .deck.previewing .clip.active .c-io,
+.pb .deck.previewing .clip.active .c-tags{
+  opacity: 0; max-height: 0; margin-top: 0; margin-bottom: 0; overflow: hidden;
+  /* Out fast and with no delay: the chrome should be gone before the box has
+     finished growing, so what grows is already a screen. */
+  transition: opacity 110ms ease-out, max-height 200ms cubic-bezier(.2,0,0,1),
+              margin 200ms cubic-bezier(.2,0,0,1);
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce){
+  .pb .deck .clip,.pb .deck .clip .c-view,
+  .pb .deck .clip .c-head,.pb .deck .clip .c-title,.pb .deck .clip .c-bar,
+  .pb .deck .clip .c-strip,.pb .deck .clip .c-io,.pb .deck .clip .c-tags{
+    transition: none;
+  }
+}
+
 /* ── AND THE STRIP GIVES A LITTLE BEFORE THE CARD GIVES A LOT ────────────
    150px of film is generous on a short window, and the bar is the one part
    whose job survives being shorter — a shot box still reads as a shot box at


### PR DESCRIPTION
While the playhead is held: the two side cards slide inward and disappear **under** the middle one, the middle one changes shape into a preview screen and its contents fade away, the frame under the playhead shows for as long as the scrub lasts, and releasing reverses all of it.

## Measured through a real scrub in the app

    neighbours   x = 117 and 760  ->  415 and 417  ->  117 and 760
    subject      326 x 363        ->  949 x 557    ->  326 x 363
    chrome       opacity 1        ->  0            ->  1

417 against 415 is the two neighbours arriving on top of the subject; the subject's raised z-index is what turns that into *underneath* rather than through.

## The load-bearing decision: the two halves are driven differently

The neighbours' travel is a **transform**, and `layout()` rewrites every card's transform on every frame. A CSS transition on the same property would be a second writer and the two would erase each other. So the collapse is a `0..1` ref that `layout()` reads, animated by its own rAF loop — its own, because the glide's loop is idle when nobody is dragging a card.

The subject's morph **is** left to CSS, and that is safe for the mirror-image reason: nothing else writes `width`, `padding` or `aspect-ratio`.

The chrome leaves faster than the box grows (110ms, no delay, against 260ms) so what finishes growing is already a screen rather than a card with a large picture.

## Precedence is stated, not left to render order

One scrub, three places that could show it:

- the **pane** takes it when it is open (`skimTaken`), and nothing else shows
- otherwise the **deck** takes it, becoming the screen
- the strip's floating card is what is left when neither did

That is the existing rule extended by one, not a new one — the strip's `skimPreview` already stood down for the pane, and now stands down for the deck as well. Exactly one of the three is ever up.

## Reduced motion

Snaps to the destination instead of travelling. The preview is the point; the movement is not.

## The story caught a real bug

`previewPoster` is a URL and `background` is a shorthand, so handing it a bare URL is invalid CSS — the browser drops the whole declaration and the preview silently did not work. It is wrapped now, in the same shape `livePoster` uses so the two cannot drift.

`CollapsesWhileScrubbing` asserts the three things the feature actually promises, each of which can break without the others: the neighbours **arrive** at the subject, the subject **grows** and drops its chrome, and the picture is the **playhead's** frame rather than the card's own. It also asserts the neighbours are apart to begin with, so it cannot pass on a deck that was already collapsed.

Its own file: `playbar.stories.tsx` states as a rule that it carries no play functions, because the e2e needs stories that do not run one on load.

## One limit worth naming

The frame-follows-playhead path is exercised in the story, not against real video — the local project has no video clips, only stills, and a still has one frame that scrubbing cannot change. On stills the deck correctly falls back to the card's own picture rather than going black. Worth a look on a video collection before this is called done.

## Suites

    app        1473 passing
    unit        812 passing
    storybook   307 passing
    e2e         173 passing, 10 skipped
    tsc clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
