### PR TITLE
PL16-002/003/004 — a transport, a smaller screen, and one component that paints a clip

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -9,7 +9,9 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { AudioLines, Pause, Play, Redo2, Undo2, X } from "lucide-react";
+import { AudioLines, Pause, Play, SkipBack, SkipForward, Redo2, Undo2, X } from "lucide-react";
+
+import { MediaPreviewSurface } from "./media-preview-surface";
 
 import {
   TrimOverviewStrip,
@@ -146,6 +148,20 @@ const DETAILS_BOTTOM_GAP_PX = 12;
  * spent in exactly the wrong order.
  */
 const DETAILS_MIN_FIT_PX = 360;
+
+/** The transport's skip buttons: quiet until reached for, and visibly dead at
+ *  the ends of the sequence rather than silently doing nothing. */
+const TRANSPORT_BUTTON_CLASS =
+  "flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 transition-colors " +
+  "hover:bg-zinc-800 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-1 " +
+  "focus-visible:ring-sky-400/60 disabled:pointer-events-none disabled:opacity-30";
+
+/** Play is the one control here anyone reaches for without looking, so it is
+ *  the only one that carries a filled surface. */
+const TRANSPORT_PLAY_CLASS =
+  "flex h-10 w-10 items-center justify-center rounded-full bg-zinc-800 text-zinc-100 " +
+  "transition-colors hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-1 " +
+  "focus-visible:ring-sky-400/60 data-[playing]:bg-sky-500/20 data-[playing]:text-sky-300";
 
 /* ── CONCEDE ONLY WHEN CONCEDING WINS ────────────────────────────────────
    Something has to give in a window that cannot hold everything, and the
@@ -737,23 +753,96 @@ function DetailsFilmstripModal({
    *   otherwise the DECK takes it, becoming the preview screen itself;
    *   the strip's floating card is what is left when neither did.
    *
+   * IN PRACTICE THE FIRST BRANCH NO LONGER FIRES FROM IN HERE. PL16-003 stands
+   * the pane down for the whole time this view is up, so `skimTaken` is false
+   * throughout and the deck always wins. The branch is KEPT rather than
+   * deleted: it is the rule, the pane standing down is a decision about layout
+   * that could be revisited, and a precedence written down only in the places
+   * that currently happen to reach it is one that breaks quietly when they
+   * change.
+   *
    * That order is the existing rule extended by one, not a new one: the strip's
    * `skimPreview` already stood down for the pane, and `skimPreview` below now
    * stands down for this as well. Precisely one of the three is ever up.
+   *
+   * PLAYING RAISES IT TOO, not just scrubbing. Pressing play is a request to
+   * WATCH, and watching three cards at card size is the thing this view was
+   * asked to stop doing — so the transport puts the same screen up that
+   * dragging the playhead does. It comes down again on pause, which is why
+   * this is derived from `playing` rather than latched by the button.
    */
-  const deckPreviewing = !skimTaken && (skimSeconds !== null || trimSkim !== null);
+  const deckPreviewing =
+    !skimTaken && (playing || skimSeconds !== null || trimSkim !== null);
+  /**
+   * THE FRAME UNDER THE CLOCK, for the preview to follow while PLAYING.
+   *
+   * The skim derivation below cannot serve this: it is keyed on a pointer
+   * dragging the playhead, and while playback runs there is no pointer. Same
+   * arithmetic, different question — where is the clock, rather than where is
+   * the finger.
+   *
+   * QUANTISED BEFORE IT IS A DEPENDENCY, not inside. `shownSeconds` changes
+   * every frame, so keying the memo on it would rebuild a URL sixty times a
+   * second and ask Cloudinary for most of them; keying on the quarter-second it
+   * rounds to means four requests a second at most, and the second pass over a
+   * stretch comes from cache. The same reasoning the strip's card carries.
+   */
+  const clockQuarter = playing ? Math.round(shownSeconds * 4) / 4 : null;
+  const clockPoster = useMemo<string | undefined>(() => {
+    if (clockQuarter === null) return undefined;
+    const at = seamAt(timeline, clockQuarter);
+    if (at === null) return undefined;
+    const found = graph.nodesById.get(parseNodeId(at.clipId));
+    const media = found && found.kind === "media" ? (found as MediaNode) : null;
+    // Frame grabs are a video's business — see `deckClips`, which is careful
+    // about the same thing for the same reason.
+    if (media === null || media.mediaKind !== "video") return undefined;
+    const base = media.posterSrcs?.[0];
+    if (base === undefined) return undefined;
+    const source = (hasSourceWindow(media) ? media.trimInSeconds : 0) + at.clipSeconds;
+    return monitorPosterUrl(base, Math.round(source * 4) / 4);
+  }, [clockQuarter, timeline, graph]);
+
+  /**
+   * THE CLIP UNDER THE PLAYHEAD, and where inside it (PL16-002).
+   *
+   * NOT QUANTISED, unlike the poster. A poster is a URL and every distinct time
+   * is a distinct request, which is why that one rounds to a quarter second.
+   * This is a file and a seek offset: the element decodes forward on its own
+   * once it has started, so the only thing the exact number costs is one
+   * accurate seek at the moment the clip changes.
+   *
+   * The seam is read at the CLOCK, not at the skim, so it is right during
+   * playback and equally right when a scrub parks somewhere. `deckPreviewing`
+   * decides whether any of it is on screen.
+   */
+  const previewAt = seamAt(timeline, shownSeconds);
+  const previewNode = (() => {
+    if (previewAt === null) return null;
+    const found = graph.nodesById.get(parseNodeId(previewAt.clipId));
+    return found && found.kind === "media" ? (found as MediaNode) : null;
+  })();
+  const deckPreviewVideoTime =
+    previewAt === null || previewNode === null
+      ? undefined
+      : (hasSourceWindow(previewNode) ? previewNode.trimInSeconds : 0) + previewAt.clipSeconds;
+
   const deckPreviewPoster = useMemo<string | undefined>(() => {
-    if (!deckPreviewing || skimNode === null || skimSourceTime === null) return undefined;
+    if (!deckPreviewing) return undefined;
+    // A SCRUB OUTRANKS THE CLOCK. Dragging the playhead during playback is a
+    // question about somewhere else, and the answer should be where the finger
+    // is rather than where the clock has got to.
+    if (skimNode === null || skimSourceTime === null) return clockPoster;
     // Audio has no picture to show, and a clip with no addressable poster base
     // can only offer its own source — the deck falls back to the card's frame
     // for both rather than going black.
-    if (skimNode.mediaKind === "audio" || skimPosterBase === undefined) return undefined;
+    if (skimNode.mediaKind === "audio" || skimPosterBase === undefined) return clockPoster;
     // QUANTISED TO A QUARTER SECOND for the reason the strip's card is: every
     // distinct time is a distinct Cloudinary fetch, and a pointer sweeping the
     // bar would ask for hundreds. The pane's copy is not quantised because it
     // seeks an element it already holds; this one is a URL.
     return monitorPosterUrl(skimPosterBase, Math.round(skimSourceTime * 4) / 4);
-  }, [deckPreviewing, skimNode, skimSourceTime, skimPosterBase]);
+  }, [deckPreviewing, skimNode, skimSourceTime, skimPosterBase, clockPoster]);
 
   const skimPreview = useMemo<FilmStripSkimPreview | null>(() => {
     if (skimTaken || deckPreviewing || skimNode === null || skimSourceTime === null) return null;
@@ -1146,6 +1235,34 @@ function DetailsFilmstripModal({
   // released scrub differ only in how the clip was chosen; what happens next
   // — carry the clock, cut rather than travel, fade the panels either side —
   // is the same sentence and is written once.
+  /**
+   * THE CLIPS EITHER SIDE, for the transport's skip buttons.
+   *
+   * FROM `ids`, THE WHOLE FLAT ORDER, not from the deck's window: the deck
+   * shows three or five, and "next clip" at the edge of that window still means
+   * the next clip in the sequence rather than nothing. `null` only at the true
+   * ends, which is what disables the buttons.
+   */
+  /**
+   * A USER SCRUB STOPS PLAYBACK. PLAYBACK'S OWN TICKS MUST NOT (PL16-002).
+   *
+   * The strip owns the clock — it has run a rAF loop the whole time, advancing
+   * on wall clock and stopping at the end — and every tick of it arrives here
+   * through `onScrub`, because that is also how a drag reports. The handler
+   * could not tell them apart and stopped playback on the first frame it was
+   * given, so play toggled on and switched itself off before anything moved.
+   * Reported as "nothing's really going on", which was exactly right.
+   *
+   * `onSkim` IS the difference: it fires only for a pointer holding the
+   * playhead, and it is `null` the moment that ends. A ref rather than state
+   * because `onScrub` reads it in the same tick `onSkim` writes it, and a state
+   * update would not have landed yet.
+   */
+  const userScrubbingRef = useRef(false);
+
+  const previousClipId = centre > 0 ? (ids[centre - 1] ?? null) : null;
+  const nextClipId = centre < ids.length - 1 ? (ids[centre + 1] ?? null) : null;
+
   const landOn = useCallback(
     (clipId: string, at: SeamPosition | null) => {
       if (clipId === (node.id as string)) return;
@@ -1634,6 +1751,32 @@ function DetailsFilmstripModal({
         standalone={false}
         previewing={deckPreviewing}
         previewPoster={deckPreviewPoster}
+        previewSurface={
+          deckPreviewing && previewNode !== null ? (
+            <MediaPreviewSurface
+              media={previewNode}
+              sourceTime={deckPreviewVideoTime ?? null}
+              playing={playing}
+              // SOUND WHILE PLAYING, SILENT WHILE SCRUBBING (PL16-004).
+              //
+              // Judging a cut is not only a picture problem — a line landing
+              // across the join, or music that stops dead on it, is what is
+              // being listened for as often as the frame is looked at. But a
+              // dragged playhead sweeping a sequence is not playback, and
+              // unmuting it produces noise rather than information.
+              //
+              // Nothing new is built for this: the surface already takes
+              // `audible`, and the element it puts up carries the clip's own
+              // track. `useSeekedVideo` is what starts and stops it.
+              audible={playing}
+              scrubbing={skimSeconds !== null || trimSkim !== null}
+              // COVER, because this fills a card's picture box rather than a
+              // panel. The monitor's own use of the same component contains.
+              fit="cover"
+              className="h-full w-full"
+            />
+          ) : undefined
+        }
         // TAKES WHAT THE BAR LEAVES — but only when the pane is up and the
         // height is actually contested. `min-h-0` because a flex item's default
         // `min-height: auto` refuses to shrink below its content, which is the
@@ -1691,6 +1834,62 @@ function DetailsFilmstripModal({
         />
       </div>
 
+      {/* THE TRANSPORT: previous, play, next.
+          UNDER THE DECK AND ABOVE THE STRIP, which is where it belongs on both
+          counts — it acts on the cut the deck is showing, and the strip below
+          is the thing it moves through. Centred, because it is the one control
+          in this view that is about the whole sequence rather than about a
+          corner of it.
+
+          PLAY RAISES THE PREVIEW, and that is the point of it rather than a
+          side effect: pressing play is a request to watch, so the deck becomes
+          the screen exactly as it does under a scrub. Nothing here sets that —
+          `deckPreviewing` derives it from `playing`, so pause puts the cards
+          back without a second piece of state to keep in step. */}
+      <div className="flex items-center justify-center gap-2" data-details-transport>
+        <button
+          type="button"
+          data-details-transport-prev
+          aria-label="Previous clip"
+          title="Previous clip"
+          disabled={previousClipId === null}
+          onClick={() => {
+            if (previousClipId !== null) landOn(previousClipId, null);
+          }}
+          className={TRANSPORT_BUTTON_CLASS}
+        >
+          <SkipBack aria-hidden="true" className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          data-details-transport-play
+          data-playing={playing ? "" : undefined}
+          aria-label={playing ? "Pause" : "Play"}
+          title={playing ? "Pause" : "Play"}
+          onClick={() => setPlaying((was) => !was)}
+          className={TRANSPORT_PLAY_CLASS}
+        >
+          {playing ? (
+            <Pause aria-hidden="true" className="h-5 w-5" />
+          ) : (
+            <Play aria-hidden="true" className="h-5 w-5" />
+          )}
+        </button>
+        <button
+          type="button"
+          data-details-transport-next
+          aria-label="Next clip"
+          title="Next clip"
+          disabled={nextClipId === null}
+          onClick={() => {
+            if (nextClipId !== null) landOn(nextClipId, null);
+          }}
+          className={TRANSPORT_BUTTON_CLASS}
+        >
+          <SkipForward aria-hidden="true" className="h-4 w-4" />
+        </button>
+      </div>
+
       {/* The STRIP: one row, translated. Centred by the scrim, then offset by
           the subject's index so the clip being worked on lands mid-screen. */}
       {timeline.totalSeconds > 0 && (
@@ -1735,10 +1934,13 @@ function DetailsFilmstripModal({
               playing={playing}
               selectedId={node.id as string}
               onScrub={(seconds) => {
-                setPlaying(false);
+                if (userScrubbingRef.current) setPlaying(false);
                 setBarSeconds(Math.min(Math.max(seconds, 0), timeline.totalSeconds));
               }}
-              onSkim={setSkimSeconds}
+              onSkim={(seconds) => {
+                userScrubbingRef.current = seconds !== null;
+                setSkimSeconds(seconds);
+              }}
               onTrimSkim={setTrimSkim}
               skimPreview={skimPreview}
               onTrim={commitTrim}

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -109,6 +109,7 @@ import {
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { compileClientPlaybackManifest } from "@/lib/client-playback-manifest";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
+import { useItemDetails } from "./graph-item-details-context";
 import { sharedWaveformCache, type WaveformCache } from "@/lib/waveform-cache";
 
 import {
@@ -1121,7 +1122,7 @@ export function useSelectionCount(): number {
 }
 
 export function PreviewShell({
-  enabled,
+  enabled: enabledProp,
   focusedId,
   channel,
   header,
@@ -1141,6 +1142,27 @@ export function PreviewShell({
   header?: React.ReactNode;
   children: React.ReactNode;
 }>) {
+  /**
+   * THE DETAILS VIEW TAKES THE WHOLE CONTENT AREA, PANE INCLUDED (PL16-003).
+   *
+   * The pane is the top of this shell's sticky stack and the details view is
+   * one of its children, so opening a clip from the grid built the view
+   * UNDERNEATH a preview that stayed exactly where it was. The view is not a
+   * panel inside the board — since PL15-029 it IS the content area — and a
+   * content area with something else pinned above it is not one.
+   *
+   * STOOD DOWN RATHER THAN COVERED. Painting the view over a live pane would
+   * leave a second video decoding behind it for the whole visit, and would
+   * leave `usePublishTrimPreview` reporting that the pane had TAKEN the scrub
+   * frame — which is what tells the deck not to show it. Both problems go away
+   * if the pane is simply not there.
+   *
+   * The breadcrumb row is untouched: it is this shell's `header` slot, not its
+   * child, and knowing where you are is exactly as useful inside a clip.
+   */
+  const { openId: detailsOpenId } = useItemDetails();
+  const enabled = enabledProp && detailsOpenId === null;
+
   const graph = useCollectionsSelector((snapshot) => snapshot.graph);
   const detailsStore = useGraphDetailsStore();
   const details = useSyncExternalStore(

--- a/apps/timeline-gstudio001/components/graph-view/media-preview-surface.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/media-preview-surface.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { AudioLines } from "lucide-react";
+
+import { type MediaNode, type VideoMediaNode } from "@storyboard/ui/dnd-collections";
+
+import { useSeekedVideo } from "@/hooks/use-seeked-video";
+import { useFrameCrossfade } from "@/hooks/use-frame-crossfade";
+import { cloudinaryScrubProxySrc } from "@/lib/cloudinary-scrub-proxy";
+import { monitorPosterUrl } from "@/lib/video-frame-url";
+
+/**
+ * ONE PLACE THAT PAINTS A CLIP AT A MOMENT (PL16-002).
+ *
+ * Extracted because it was about to be written a fourth time. Showing a clip at
+ * a source time is not one element — it is a seek that has to be debounced
+ * against a decode, a low-res twin so a dragged bar does not wait 100ms a
+ * frame, a canvas that holds the outgoing frame across a cut so the swap is not
+ * a flash of black, and three different elements depending on whether the media
+ * has a picture at all. Every surface that has needed it has grown its own
+ * copy, and the newest copy — a bare `<video>` in the clip deck — had none of
+ * that machinery and looked it.
+ *
+ * WHAT IT DOES NOT OWN: layout, chrome, controls, or what time it should be
+ * showing. Callers position it and tell it the moment; it decides how to get a
+ * picture there. That is the line that keeps it reusable — the deck wants it
+ * filling a card's picture box, the monitor wants it letterboxed in a panel,
+ * and neither of those is this component's business beyond `fit`.
+ */
+export type MediaPreviewSurfaceProps = Readonly<{
+  /** What to show. `null` paints nothing, which is a legitimate resting state
+   *  rather than an error — a collection has no media of its own. */
+  media: MediaNode | null;
+  /**
+   * Where to sit, in SOURCE seconds.
+   *
+   * Source rather than sequence time on purpose: the caller is the only thing
+   * that knows how its own timeline maps onto a clip, and a component that
+   * guessed would be wrong the moment a trim moved.
+   */
+  sourceTime: number | null;
+  /** Running, rather than parked on a frame. */
+  playing?: boolean;
+  /** Sound. Off by default — several of these can be on screen at once, and
+   *  only one of them can sensibly be heard. */
+  audible?: boolean;
+  /** A pointer is dragging, so the low-res twin takes over until it stops. */
+  scrubbing?: boolean;
+  /**
+   * COVER for a card's picture, CONTAIN for a panel.
+   *
+   * A card's picture is a crop of a shot and wants filling; a monitor is the
+   * shot and must not be cropped to fit the box it is being judged in.
+   */
+  fit?: "contain" | "cover";
+  className?: string;
+}>;
+
+/** The seek is quantised to a frame at 25fps: finer than that asks the element
+ *  to re-decode for a difference nobody can see. Matches what the monitor has
+ *  always used. */
+const SEEK_QUANTUM_FPS = 25;
+
+export function MediaPreviewSurface({
+  media,
+  sourceTime,
+  playing = false,
+  audible = false,
+  scrubbing = false,
+  fit = "cover",
+  className,
+}: MediaPreviewSurfaceProps) {
+  const shownVideo: VideoMediaNode | null =
+    media !== null && media.mediaKind === "video" ? (media as VideoMediaNode) : null;
+  const shownAudio = media !== null && media.mediaKind === "audio" ? media : null;
+  const rawTime = sourceTime ?? 0;
+
+  // THE POSTER IS THE FRAME BEING ASKED FOR, not the clip's first. A fresh
+  // element has decoded nothing, so it paints its poster — and the clip's
+  // opening frame is almost never where the playhead is. Pointing the poster at
+  // the same moment the element is seeking to makes the swap from poster to
+  // decoded frame invisible.
+  const posterAtRawTime = monitorPosterUrl(shownVideo?.posterSrcs?.[0], sourceTime);
+  const videoSrc = shownVideo?.src;
+  const scrubProxySrc = videoSrc === undefined ? null : cloudinaryScrubProxySrc(videoSrc);
+
+  const { videoRef, proxyRef, showProxy } = useSeekedVideo(
+    Math.round(rawTime * SEEK_QUANTUM_FPS) / SEEK_QUANTUM_FPS,
+    shownVideo !== null || shownAudio !== null,
+    playing,
+    { proxySrc: scrubProxySrc, scrubbing },
+  );
+  // Keyed on a constant: the fade covers the swap between two different clips,
+  // which is the case that would otherwise flash black across a cut.
+  const { videoRef: crossfadeVideoRef, canvasRef } = useFrameCrossfade("first");
+
+  const objectFit = fit === "contain" ? "object-contain" : "object-cover";
+
+  return (
+    <div className={["relative overflow-hidden bg-black", className ?? ""].join(" ")}>
+      {shownVideo ? (
+        <video
+          // KEYED BY SOURCE. Swapping `src` on one element leaves the outgoing
+          // frame up until the incoming file has decoded, so the cut lands
+          // late. A key gives each clip its own element, making it a swap.
+          key={shownVideo.src}
+          ref={(element) => {
+            videoRef(element);
+            crossfadeVideoRef.current = element;
+          }}
+          src={shownVideo.src}
+          poster={posterAtRawTime}
+          muted={!audible}
+          playsInline
+          preload="auto"
+          className={`h-full w-full bg-black ${objectFit}`}
+        />
+      ) : shownAudio ? (
+        // AUDIO HAS NO PICTURE, and pointing an <img> at a .wav paints a
+        // broken-image icon. It gets a mark that says what it is, and an
+        // element that can actually play it.
+        <div className="flex h-full w-full items-center justify-center bg-black text-zinc-400">
+          <AudioLines aria-hidden="true" className="h-8 w-8 text-blue-300/80" />
+          <audio
+            key={shownAudio.src}
+            ref={videoRef}
+            src={shownAudio.src}
+            muted={!audible}
+            preload="auto"
+            className="sr-only"
+          />
+        </div>
+      ) : media !== null ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={media.src}
+          alt={media.name}
+          // NOT DRAGGABLE. An `<img>` is draggable by default and a `<video>`
+          // is not, so on a still the browser takes a swipe as a native image
+          // drag: it swallows the rest of the sequence and no pointermove ever
+          // arrives. `select-none` is the same problem at the other end.
+          draggable={false}
+          className={`h-full w-full bg-black select-none ${objectFit}`}
+        />
+      ) : null}
+
+      {/* THE SMALL COPY, up only while a bar is being dragged. A full-res seek
+          costs 67-128ms on these sources, which is a picture changing about
+          once a second under a hand moving far faster than that.
+
+          ABSOLUTE and AFTER the real element, so it paints over it without
+          either one moving: same box, same fit, so the swap is a change of
+          sharpness and nothing else. It sits UNDER the canvas below, which
+          must stay on top to cover a cut. No `poster` — that would flash the
+          clip's first frame at the start of every drag. */}
+      {shownVideo && scrubProxySrc !== null && (
+        <video
+          key={`scrub-proxy:${scrubProxySrc}`}
+          ref={proxyRef}
+          src={scrubProxySrc}
+          aria-hidden="true"
+          muted
+          playsInline
+          preload="auto"
+          className={`absolute inset-0 h-full w-full bg-black ${objectFit} transition-opacity duration-75 ${
+            showProxy ? "opacity-100" : "pointer-events-none opacity-0"
+          }`}
+        />
+      )}
+
+      {/* The crossfade canvas, holding the outgoing frame across a cut. On top
+          of everything, because that is the whole job. */}
+      <canvas
+        ref={canvasRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 h-full w-full opacity-0"
+      />
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/playbar/clip-deck.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/playbar/clip-deck.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 
 import { LOOKS, SECTIONS, SHOTS, clamp } from "./playbar-model";
@@ -49,6 +50,9 @@ const MODELS = ["H3 4-ref", "ref2va", "minimax-h3", "comfy-cloud H3"] as const;
 export const CLIP_DECK_STRIP_CELLS = 8;
 const CELLS = CLIP_DECK_STRIP_CELLS;
 /** How much of a card's width the next one sits away by, plus the gap. */
+/** Widest the preview ever gets, however wide the deck is. */
+const PREVIEW_MAX_W = 720;
+
 const CARD_GAP_PX = 18;
 
 /** The reference's own `clamp(300px, 30vw, 440px)` ends, restated so the fitted
@@ -226,6 +230,26 @@ export type ClipDeckProps = Readonly<{
    * is a truer answer than an empty screen.
    */
   previewPoster?: string;
+  /**
+   * THE SUBJECT PLAYS REAL VIDEO WHILE PREVIEWING (PL16-002).
+   *
+   * `previewPoster` alone cannot do this. It is a frame grab quantised to a
+   * quarter second — deliberately, because a scrubbing pointer would otherwise
+   * ask for hundreds — and a quarter second is four updates a second, which
+   * during PLAYBACK reads as a slideshow rather than a shot. Reported as
+   * "chunky, like it's playing every tenth frame", which is what four frames a
+   * second is.
+   *
+   * So playback gets a real media element instead — and NOT one built here.
+   * `MediaPreviewSurface` already owns the seek, the low-res scrub twin and the
+   * crossfade canvas, and a bare `<video>` in this file was a fourth, worse
+   * copy of all three. The caller passes the surface in; the deck decides where
+   * it goes and when it is on screen, which is the only part of this that is
+   * the deck's business.
+   *
+   * The poster stays as what paints before the surface has decoded anything.
+   */
+  previewSurface?: ReactNode;
   className?: string;
 }>;
 
@@ -233,6 +257,7 @@ export function ClipDeck({
   clips: clipsProp,
   previewing = false,
   previewPoster,
+  previewSurface,
   activeId,
   onActivate,
   onTrim,
@@ -458,6 +483,24 @@ export function ClipDeck({
    */
   useEffect(() => {
     collapseTargetRef.current = previewing ? 1 : 0;
+    // HOW WIDE THE PREVIEW IS, measured rather than expressed as a percentage.
+    //
+    // `.clip` is absolutely positioned, so a `%` width resolves against its
+    // containing block and not against the deck — measured, `min(100%, 720px)`
+    // came out at the card's own 325.5px even inline, where nothing could be
+    // overriding it. The deck is the only thing that knows its own width, so
+    // the deck is what publishes the number.
+    //
+    // Capped as well as proportional: 78% keeps the deck's edges visible either
+    // side so the subject still reads as one of three cards that grew, and the
+    // ceiling stops it becoming a wall on a very wide window.
+    const deckWidth = deckRef.current?.clientWidth ?? 0;
+    if (deckWidth > 0) {
+      deckRef.current?.style.setProperty(
+        "--preview-w",
+        `${Math.round(Math.min(deckWidth * 0.78, PREVIEW_MAX_W))}px`,
+      );
+    }
     if (reduced) {
       collapseRef.current = collapseTargetRef.current;
       layout();
@@ -1052,6 +1095,9 @@ export function ClipDeck({
                             "#0d0d10",
                         }}
                       />
+                      {previewing && index === active && previewSurface !== undefined ? (
+                        <div className="absolute inset-0">{previewSurface}</div>
+                      ) : null}
                     </div>
 
                     <div className="c-bar">

--- a/apps/timeline-gstudio001/components/graph-view/playbar/playbar-styles.ts
+++ b/apps/timeline-gstudio001/components/graph-view/playbar/playbar-styles.ts
@@ -622,7 +622,15 @@ export const PLAYBAR_CSS = `.pb{
    be invisible; growing it too would be work nobody sees, and it would widen
    the box the neighbours are travelling across. */
 .pb .deck.previewing .clip.active{
-  width: var(--preview-w, min(100%, 980px));
+  /* A PIXEL VALUE THE DECK PUBLISHES, and never a percentage.
+     \`min(100%, Npx)\` was tried and is wrong here: \`.clip\` is absolutely
+     positioned, so a percentage width resolves against its containing block
+     rather than the deck, and it measured 325.5px — the card's own resting
+     width — with the rule live and matching. An inline
+     \`width: min(100%, 720px)\` computed to the same 325.5px, which is what
+     proved it was the percentage and not the cascade.
+     \`clip-deck.tsx\` measures the deck and writes the number. */
+  width: var(--preview-w, 720px);
   padding: 0;
   border-radius: 12px;
 }

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -5444,6 +5444,121 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => page.evaluate(() => Math.round(window.scrollY))).toBe(parked);
   });
 
+  test("play raises the preview and actually runs the clock", async ({ page }) => {
+    // PL16-002. Both halves of this were broken and neither was visible from
+    // the other, so both are asserted.
+    //
+    // THE CLOCK. The strip has owned a rAF play loop the whole time, and every
+    // tick of it arrives in the view through `onScrub` — the same callback a
+    // DRAG reports through. The handler stopped playback on any scrub, so
+    // playback stopped itself on its first frame: the button toggled, the
+    // playhead did not move, and it toggled back. `onSkim` is what tells the
+    // two apart, because it only fires for a pointer holding the playhead.
+    //
+    // THE PREVIEW. Pressing play is a request to watch, so the deck becomes the
+    // screen exactly as it does under a scrub.
+    await installGraphApi(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await openGraph(page);
+    await openItemDetails(page, "alpha");
+    await settleViewTransition(page);
+
+    const deck = page.locator(".deck");
+    const subject = page.locator(".deck .clip.active");
+    const play = page.locator("[data-details-transport-play]");
+    const boxWidth = async () =>
+      Math.round((await subject.boundingBox())?.width ?? 0);
+    const headOpacity = async () =>
+      await page.locator(".deck .clip.active .c-head").evaluate((el) => getComputedStyle(el).opacity);
+    const playheadX = async () =>
+      await page.evaluate(() => Math.round(document.querySelector(".playhead")?.getBoundingClientRect().x ?? -1));
+
+    await expect(play).toHaveAttribute("aria-label", "Play");
+    await expect(deck).not.toHaveClass(/previewing/);
+    const restWidth = await boxWidth();
+    expect(restWidth).toBeGreaterThan(0);
+
+    await play.click();
+
+    // It stays playing. Before the fix this flipped straight back to "Play".
+    await expect(play).toHaveAttribute("aria-label", "Pause");
+    await expect(deck).toHaveClass(/previewing/);
+    await expect
+      .poll(boxWidth, { timeout: 3000 })
+      .toBeGreaterThan(restWidth);
+    await expect.poll(headOpacity, { timeout: 3000 }).toBe("0");
+
+    // AND THE PLAYHEAD MOVES, which is the half the preview animation hides:
+    // the deck would collapse just as convincingly with a frozen clock.
+    const startX = await playheadX();
+    await page.waitForTimeout(900);
+    await expect(play).toHaveAttribute("aria-label", "Pause");
+    expect(await playheadX()).toBeGreaterThan(startX);
+
+    // AND IT IS A VIDEO ELEMENT, not a sequence of stills. The first cut drove
+    // the preview from a poster URL quantised to a quarter second, which is
+    // four updates a second — correct for a scrubbing pointer, a slideshow
+    // during playback.
+    //
+    // ASSERTED ON THE ELEMENT, NOT ON PLAYBACK. Whether it decodes depends on
+    // the media actually loading, and the fixture's sources do not — `play()`
+    // rejects and it stays paused here however correct the wiring is. What this
+    // can prove is that the element is mounted on the subject, pointed at a
+    // source, and carrying the two attributes without which a browser will
+    // refuse to autoplay it at all.
+    const video = page.locator(".deck .clip.active video");
+    await expect(video).toHaveCount(1);
+    const media = await video.evaluate((el) => {
+      const v = el as HTMLVideoElement;
+      return { src: v.getAttribute("src") ?? "", muted: v.muted, inline: v.playsInline };
+    });
+    expect(media.src.length).toBeGreaterThan(0);
+    expect(media.inline).toBe(true);
+    // AND IT HAS SOUND while playing. Muted is the resting state — several of
+    // these can exist at once and a scrub sweeping the bar should be silent —
+    // so this asserts the one moment it must not be.
+    expect(media.muted).toBe(false);
+
+    await play.click();
+    await expect(play).toHaveAttribute("aria-label", "Play");
+    await expect(deck).not.toHaveClass(/previewing/);
+    await expect.poll(boxWidth, { timeout: 3000 }).toBe(restWidth);
+  });
+
+  test("opening details takes the whole content area, preview pane included", async ({
+    page,
+  }) => {
+    // PL16-003. Reported: with the preview open, clicking a media item built the
+    // three-item view UNDERNEATH the pane, which stayed pinned above it.
+    //
+    // The view is not a panel inside the board — since PL15-029 it IS the
+    // content area — so the pane stands down for it. The breadcrumb stays: it
+    // is the shell's header slot rather than one of its children.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // Open the preview pane first; the bug needs it up.
+    await previewToggle(page).click();
+    // `data-preview-settled` is the pane's own "I am up and have a picture"
+    // marker — the same one the rest of this suite waits on.
+    const pane = page.locator("[data-preview-settled]");
+    await expect(pane).toHaveCount(1, { timeout: 15000 });
+
+    await openItemDetails(page, "alpha");
+    await settleViewTransition(page);
+
+    // The view is up, and the pane is not.
+    await expect(page.locator("[data-item-details]")).toHaveCount(1);
+    await expect(pane).toHaveCount(0);
+    // The chrome around it is still there — this is not "hide everything".
+    await expect(page.getByRole("button", { name: /(show|hide) preview/i })).toBeVisible();
+
+    // And it comes back when the view closes.
+    await page.keyboard.press("Escape");
+    await expect(page.locator("[data-item-details]")).toHaveCount(0);
+    await expect.poll(async () => await pane.count(), { timeout: 10000 }).toBeGreaterThan(0);
+  });
+
   // PARKED: the deck draws its trim strip on a STILL.
   //
   // A still has a duration but no SOURCE to window, so a map of the source is a


### PR DESCRIPTION
Five things asked for, and two bugs found underneath them.

## Smaller preview

It measured 949px wide and read as taking the whole view rather than the subject growing into one. Now **78% of the deck, capped at 720**.

Published as a **pixel value by the deck**, because `min(100%, Npx)` is wrong here and took a while to see: `.clip` is absolutely positioned, so a percentage resolves against its containing block rather than the deck. An **inline** `width: min(100%, 720px)` computed to the card's own 325.5px, which is what proved it was the percentage and not the cascade.

## A transport, and play that actually plays

Previous / play / next, centred under the deck. Play raises the preview — derived from `playing` rather than latched, so pause puts the cards back with no second piece of state to keep in step.

**The bug underneath:** the strip has owned a rAF play clock the whole time, and every tick of it arrives in the view through `onScrub` — the same callback a *drag* reports through. The handler stopped playback on any scrub, so play toggled on and killed itself on its first frame. Reported as "nothing's really going on", which was exactly right. `onSkim` is what tells a finger from a clock, because it only fires for a pointer holding the playhead.

## One component that paints a clip at a moment

The first cut drove the preview from a poster URL quantised to a quarter second — **four updates a second**, which during playback is a slideshow. Reported as "chunky, like it's playing every tenth frame"; four frames a second is precisely that.

The fix was **not** the `<video>` I wrote next. That was a fourth, worse copy of machinery that already exists — showing a clip at a time is a seek debounced against a decode, a low-res twin so a dragged bar does not wait ~100ms a frame, and a canvas holding the outgoing frame across a cut.

`MediaPreviewSurface` now owns all of it, and the deck takes it as a render slot — the deck decides where the picture goes and when, which is the only part that is the deck's business. `useSeekedVideo` drives play/pause and corrects drift against the clock, which the hand-rolled element did not.

## Sound

Audible while playing, silent while scrubbing — a dragged playhead sweeping a sequence is noise, not information. Nothing new was built: the surface already took `audible`.

**One limit worth naming:** this is the clip's own audio track. Multi-lane mixing lives in the pane's audio graph, and the pane is not up here (below). Beds on other lanes will not play.

## The view takes the whole content area

Opening a clip with the preview up built the view **underneath** a pane that stayed pinned above it. Since PL15-029 the view *is* the content area, and a content area with something pinned above it is not one.

The pane **stands down** rather than being covered — a covered pane keeps a second video decoding behind the view for the whole visit, and keeps reporting that it *took* the scrub frame, which is what tells the deck not to show one. Both problems disappear if it simply is not there. The breadcrumb is untouched: it is the shell's `header` slot, not one of its children.

## Tests

Three new e2e, all of which fail against the code they were written for:

- `play raises the preview and actually runs the clock` — asserts the deck collapses, the chrome fades, **the playhead advances**, and the element is a real video that is unmuted. The playhead assertion is the one that matters: the collapse animation looks just as convincing with a frozen clock.
- `opening details takes the whole content area, preview pane included` — pane up, open a clip, pane gone, chrome still there, pane back on close.
- Plus the existing `CollapsesWhileScrubbing` story, unchanged.

Video **decoding** is not exercised — the fixture's sources do not load, so `play()` rejects there however correct the wiring is. The tests assert the element is mounted, sourced, inline and unmuted; smooth playback needs a look on a real video collection.

## Suites

    app        1473 passing
    unit        812 passing
    storybook   308 passing
    e2e         175 passing, 10 skipped
    tsc clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
