### PR TITLE
PL16-005 — two ways to relate to the pane, so they can be compared

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/details-preview-mode.ts
+++ b/apps/timeline-gstudio001/components/graph-view/details-preview-mode.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+/**
+ * TWO WAYS THE DETAILS VIEW CAN RELATE TO THE PREVIEW PANE (PL16-005).
+ *
+ * Both are wanted at once so they can be compared side by side on the same
+ * build, which is why this is a runtime switch rather than a decision taken in
+ * code and a commit reverted to see the other one.
+ *
+ * `standdown` (the default, PL16-003) unmounts the pane for the duration. The
+ *   view then IS the content area, with nothing running behind it.
+ *
+ * `cover` leaves the pane mounted and paints the view over it, the way the view
+ *   already covers the board. Costs a second video decoding behind something
+ *   nobody can see; buys a pane that is exactly where it was when you come back
+ *   out, with no re-open.
+ *
+ * WHAT DOES NOT CHANGE WITH THE MODE: the pane never TAKES the scrub frame
+ * while the view is up. `usePublishTrimPreview` reporting that it did is what
+ * tells the deck not to show a preview of its own, and a covered pane showing
+ * the frame behind the view would be showing it to nobody. Keeping that
+ * constant is what makes the two modes comparable — the only difference between
+ * them is what happens to the pane, not what the deck does.
+ */
+export type DetailsPreviewMode = "standdown" | "cover";
+
+/** The query key. `?previewmode=cover` — same shape as `?dev=1` and
+ *  `?surface=grid`, which is how every other switch in this view is reached. */
+export const DETAILS_PREVIEW_MODE_PARAM = "previewmode";
+
+export function useDetailsPreviewMode(): DetailsPreviewMode {
+  // Read from the URL rather than threaded from the page: the graph tree mounts
+  // client-only (`ssr: false` in client-graph-view), so this has no prerender
+  // or Suspense implications — the same note the surface and dev params carry.
+  const value = useSearchParams().get(DETAILS_PREVIEW_MODE_PARAM);
+  return value === "cover" ? "cover" : "standdown";
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -12,6 +12,7 @@ import {
 import { AudioLines, Pause, Play, SkipBack, SkipForward, Redo2, Undo2, X } from "lucide-react";
 
 import { MediaPreviewSurface } from "./media-preview-surface";
+import { useDetailsPreviewMode } from "./details-preview-mode";
 
 import {
   TrimOverviewStrip,
@@ -302,6 +303,66 @@ function DetailsFilmstripModal({
   onClose: () => void;
   onOpenNeighbour: (id: string) => void;
 }>) {
+  /**
+   * COVER MODE: the view paints OVER the pane instead of replacing it
+   * (PL16-005).
+   *
+   * MEASURED, never a constant. The overlay starts exactly where the sticky
+   * header ends, and the header's height is the consumer's business —
+   * `workbench-display-surface` says so itself and measures it for the same
+   * reason. `[data-testid="workbench-header-region"]` is that element; the
+   * split pane's own root gives the column's left edge and width, so the
+   * overlay lands on the content area rather than on the window.
+   *
+   * `fixed` rather than `absolute`: the split pane is a grid of sticky rows,
+   * and an absolutely-positioned child would scroll away with the board
+   * underneath. What is wanted is the view sitting still over everything below
+   * the trail — which is what the header itself already does, one band up.
+   */
+  const coverMode = useDetailsPreviewMode() === "cover";
+  const [coverBox, setCoverBox] = useState<{
+    top: number;
+    left: number;
+    width: number;
+  } | null>(null);
+  useLayoutEffect(() => {
+    // NOTHING TO CLEAR on the way out: the mode is a URL parameter and does not
+    // change within a visit, so `coverBox` is simply never set in the default
+    // mode. Resetting it here would also be a synchronous setState in an
+    // effect, which the lint rejects as a cascading render — correctly.
+    if (!coverMode) return;
+    const header = document.querySelector<HTMLElement>(
+      '[data-testid="workbench-header-region"]',
+    );
+    const pane = document.querySelector<HTMLElement>('[data-testid="workbench-split-pane"]');
+    if (pane === null) return;
+    const measure = () => {
+      const paneRect = pane.getBoundingClientRect();
+      const top = header === null ? paneRect.top : header.getBoundingClientRect().bottom;
+      // Written only when it actually moves: this runs from observers watching
+      // the same elements it measures, and an unconditional setState is a loop.
+      setCoverBox((current) =>
+        current !== null &&
+        Math.round(current.top) === Math.round(top) &&
+        Math.round(current.left) === Math.round(paneRect.left) &&
+        Math.round(current.width) === Math.round(paneRect.width)
+          ? current
+          : { top, left: paneRect.left, width: paneRect.width },
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    if (header !== null) observer.observe(header);
+    observer.observe(pane);
+    window.addEventListener("resize", measure);
+    window.addEventListener("scroll", measure, { passive: true });
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measure);
+      window.removeEventListener("scroll", measure);
+    };
+  }, [coverMode]);
+
   const graph = useCollectionsSelector((state) => state.graph);
   // The one mutation the deck makes — a trim — goes through the same command
   // path the trim fields used, so it is undoable like every other edit here.
@@ -1619,6 +1680,7 @@ function DetailsFilmstripModal({
     <section
       ref={viewRef}
       data-item-details={node.id}
+      data-details-preview-mode={coverMode ? "cover" : "standdown"}
       aria-label={`Details for ${node.name}`}
       // A REGION IN THE CONTENT AREA, NOT A DIALOG OVER IT (PL15-029).
       //
@@ -1700,6 +1762,25 @@ function DetailsFilmstripModal({
         // that appears only when the view genuinely cannot fit is the right
         // failure; silently hiding a card is not.
         overflowY: "auto",
+        // COVER MODE lifts the view out of the column and over the pane. z-45
+        // is above the surface's z-40 and below the header's z-50, which states
+        // the whole requirement as a single number: over the preview, under the
+        // breadcrumb.
+        //
+        // Only once the box has been MEASURED — painting a full-width overlay
+        // for the frame before the header has been read would flash the view
+        // across the trail, which is the one thing this mode must not do.
+        ...(coverMode && coverBox !== null
+          ? {
+              position: "fixed" as const,
+              top: Math.round(coverBox.top) + "px",
+              left: Math.round(coverBox.left) + "px",
+              width: Math.round(coverBox.width) + "px",
+              bottom: 0,
+              height: "auto",
+              zIndex: 45,
+            }
+          : {}),
       }}
       // `overflow-x: clip` still, for the row's scrim — but the Y axis is
       // `auto`: the height above is a CEILING, and on a window too short for

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -110,6 +110,7 @@ import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { compileClientPlaybackManifest } from "@/lib/client-playback-manifest";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
 import { useItemDetails } from "./graph-item-details-context";
+import { useDetailsPreviewMode } from "./details-preview-mode";
 import { sharedWaveformCache, type WaveformCache } from "@/lib/waveform-cache";
 
 import {
@@ -1161,7 +1162,16 @@ export function PreviewShell({
    * child, and knowing where you are is exactly as useful inside a clip.
    */
   const { openId: detailsOpenId } = useItemDetails();
-  const enabled = enabledProp && detailsOpenId === null;
+  const detailsPreviewMode = useDetailsPreviewMode();
+  // `cover` keeps the pane mounted and lets the view paint over it; `standdown`
+  // takes it away for the duration. See `details-preview-mode` for the trade.
+  const enabled =
+    enabledProp && (detailsPreviewMode === "cover" || detailsOpenId === null);
+  // AND IN BOTH MODES THE PANE STOPS TAKING THE SCRUB FRAME while the view is
+  // up. A covered pane would be showing it to nobody, and its saying it had
+  // taken it is what stops the deck showing one. Held constant on purpose: it
+  // is what makes the two modes comparable.
+  const previewOwnsTrimFrame = enabledProp && detailsOpenId === null;
 
   const graph = useCollectionsSelector((snapshot) => snapshot.graph);
   const detailsStore = useGraphDetailsStore();
@@ -1295,7 +1305,7 @@ export function PreviewShell({
         <PreviewCardSpansContext.Provider value={cardSpans}>
           {/* The board renders here, so every trim handle is inside this
               provider and can publish the frame it wants shown. */}
-          <TrimPreviewProvider previewOpen={enabled} store={trimStore}>
+          <TrimPreviewProvider previewOpen={previewOwnsTrimFrame} store={trimStore}>
             {children}
           </TrimPreviewProvider>
         </PreviewCardSpansContext.Provider>

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -5559,6 +5559,73 @@ test.describe("graph view E2E", () => {
     await expect.poll(async () => await pane.count(), { timeout: 10000 }).toBeGreaterThan(0);
   });
 
+  test("cover mode keeps the pane up and paints the view over it", async ({ page }) => {
+    // PL16-005. The default (`standdown`, PL16-003) unmounts the pane while the
+    // view is up. `?previewmode=cover` leaves it mounted and paints over it, so
+    // the two can be compared on one build rather than by reverting a commit.
+    //
+    // ASSERTED ON BOTH HALVES, because either alone would pass for the wrong
+    // reason: the pane must still BE there, and the view must actually be over
+    // it rather than below it in the column.
+    await installGraphApi(page);
+    // Same landing `openGraph` does — strip layout, wait for a real card, reveal
+    // the tree — with the mode param carried alongside it. Written out rather
+    // than calling the helper because the helper owns the URL.
+    await page.goto(`${GRAPH_URL}?surface=strip&previewmode=cover`);
+    await strip(page, PROJECT_ID)
+      .locator('[data-node-id="alpha"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+    await page.getByRole("button", { name: "Show children timelines" }).click();
+    await previewToggle(page).click();
+    const pane = page.locator("[data-preview-settled]");
+    await expect(pane).toHaveCount(1, { timeout: 15000 });
+
+    await openItemDetails(page, "alpha");
+    await settleViewTransition(page);
+
+    const view = page.locator("[data-item-details]");
+    await expect(view).toHaveCount(1);
+    await expect(view).toHaveAttribute("data-details-preview-mode", "cover");
+    // THE PANE IS STILL THERE — this is the whole difference from the default.
+    await expect(pane).toHaveCount(1);
+
+    // And the view is OVER it: fixed, stacked above the surface, and starting
+    // below the header rather than at the top of the window.
+    const box = await view.evaluate((el) => {
+      const style = getComputedStyle(el);
+      const header = document.querySelector('[data-testid="workbench-header-region"]');
+      return {
+        position: style.position,
+        zIndex: Number(style.zIndex),
+        top: Math.round(el.getBoundingClientRect().top),
+        headerBottom: header ? Math.round(header.getBoundingClientRect().bottom) : null,
+      };
+    });
+    expect(box.position).toBe("fixed");
+    expect(box.zIndex).toBeGreaterThan(40);
+    expect(box.headerBottom).not.toBeNull();
+    // Starts at the header's bottom edge, so the trail stays readable.
+    expect(Math.abs(box.top - (box.headerBottom as number))).toBeLessThanOrEqual(2);
+  });
+
+  test("the default mode still stands the pane down", async ({ page }) => {
+    // The other half of PL16-005: the original behaviour is untouched, which is
+    // the point of keeping both — they are meant to be compared.
+    await installGraphApi(page);
+    await openGraph(page);
+    await previewToggle(page).click();
+    const pane = page.locator("[data-preview-settled]");
+    await expect(pane).toHaveCount(1, { timeout: 15000 });
+
+    await openItemDetails(page, "alpha");
+    await settleViewTransition(page);
+    await expect(page.locator("[data-item-details]")).toHaveAttribute(
+      "data-details-preview-mode",
+      "standdown",
+    );
+    await expect(pane).toHaveCount(0);
+  });
+
   // PARKED: the deck draws its trim strip on a STILL.
   //
   // A still has a duration but no SOURCE to window, so a map of the source is a


### PR DESCRIPTION
Keeps what PL16-003 does and adds the other version beside it, because these need comparing rather than choosing between on paper.

## The switch

    ?previewmode=cover        the pane stays up, the view paints over it
    (default)                 the pane unmounts for the duration

Same shape as `?dev=1` and `?surface=grid` — how every other switch in this view is reached. Both live on the same build, so comparing them is a URL edit rather than a revert.

**The trade runs both ways.** Cover leaves a second video decoding behind something nobody can see. It also leaves the pane exactly where it was when you come back out, with no re-open — which is the thing that prompted this.

## How the overlay is placed

**Measured, never a constant.** It starts where the sticky header ends, and the header's height is the consumer's business — `workbench-display-surface` says so itself and measures it for the same reason. Both the header region and the split pane root are watched by a `ResizeObserver`, so the box follows the rail expanding and the window resizing.

`fixed` rather than `absolute`: the split pane is a grid of sticky rows, so an absolutely-positioned child would scroll away with the board underneath.

`z-45` states the whole requirement as one number — above the surface's `z-40`, below the header's `z-50`. Over the preview, under the breadcrumb.

## One thing deliberately held constant

**The pane never takes the scrub frame while the view is up, in either mode.** A covered pane showing the frame behind the view would be showing it to nobody, and its reporting that it *took* the frame is exactly what stops the deck showing one. Holding that still is what makes the two modes differ only in what happens to the pane — otherwise the comparison would be confounded by the deck behaving differently too.

## Tests

Both modes, because either alone would pass for the wrong reason:

- `cover mode keeps the pane up and paints the view over it` — pane still present, view `position: fixed`, `z-index > 40`, and its top within 2px of the header's bottom edge so the trail stays readable.
- `the default mode still stands the pane down` — the original behaviour asserted explicitly, so a future change to cover mode cannot quietly take it with it.

## Suites

    app        1473 passing
    unit        812 passing
    storybook   308 passing
    e2e         177 passing, 10 skipped
    tsc clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
