### PR TITLE
PL16-005 follow-up — cover mode leaves the isolated context, and brings a ground

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -11,6 +11,8 @@ import {
 } from "react";
 import { AudioLines, Pause, Play, SkipBack, SkipForward, Redo2, Undo2, X } from "lucide-react";
 
+import { createPortal } from "react-dom";
+
 import { MediaPreviewSurface } from "./media-preview-surface";
 import { useDetailsPreviewMode } from "./details-preview-mode";
 
@@ -1676,7 +1678,31 @@ function DetailsFilmstripModal({
   const rowTransform =
     `translateX(calc(-1 * ${offset} * (${panelWidth} + ${PANEL_GAP}) + var(--drag-px, 0px)))`;
 
-  return (
+  /**
+   * COVER MODE PORTALS OUT, and no z-index could have replaced this.
+   *
+   * The board and this view live inside `[data-testid="workbench-lower-pane"]`,
+   * which is `position: relative; z-index: 0; isolation: isolate` — a stacking
+   * context of its own, at level ZERO. Everything inside it therefore paints at
+   * zero relative to the preview region, which is a z-40 SIBLING of that
+   * container. The first attempt asked for `z-index: 45` and got covered by the
+   * pane anyway, which is the tell: a number inside an isolated context is not
+   * competing with anything outside it.
+   *
+   * So the overlay leaves the context rather than trying to out-rank it from
+   * inside. `createPortal` moves the DOM node only — React context still
+   * resolves through the tree it was declared in, so every provider this view
+   * reads (the store, the details context, the trim preview) is untouched.
+   *
+   * At the root it competes with the header's z-50 and the surface's z-40 on
+   * equal terms, which is what makes 45 mean what it says: over the preview,
+   * under the breadcrumb. The box is already in viewport coordinates — `fixed`,
+   * measured off the header — so nothing about the positioning changes.
+   *
+   * The DEFAULT mode stays exactly where it was, in flow. This view is the
+   * content area there (PL15-029) and a portal would undo that.
+   */
+  const view = (
     <section
       ref={viewRef}
       data-item-details={node.id}
@@ -1786,7 +1812,21 @@ function DetailsFilmstripModal({
       // `auto`: the height above is a CEILING, and on a window too short for
       // even the smallest deck the scroll belongs INSIDE this view rather than
       // on the page, where it would carry the header and the bar away with it.
-      className="relative flex min-h-0 flex-1 flex-col gap-3 overflow-x-clip"
+      className={[
+        "relative flex min-h-0 flex-1 flex-col gap-3 overflow-x-clip",
+        // AN OPAQUE GROUND WHILE COVERING, and it is not decoration.
+        //
+        // In the default mode this view REPLACES the board, so it sits on the
+        // page's own background and needs none of its own. Covering, it sits
+        // over a live preview and the divider band — and with a transparent
+        // ground both read straight through the cards, which is what "the
+        // preview and divider are still viewable behind it" is.
+        //
+        // `zinc-950` is what the header region and the preview region are
+        // already painted with, so the covered view matches the surface it is
+        // standing in for rather than introducing a third shade.
+        coverMode ? "bg-zinc-950" : "",
+      ].join(" ")}
     >
       {/* THE BAR, above everything and spanning it: the cut's clock. Outside
           the strip because it must not travel with it — the row slides, and a
@@ -2034,6 +2074,11 @@ function DetailsFilmstripModal({
       )}
     </section>
   );
+
+  // Portalled only while covering, and only once the box has been measured —
+  // an unmeasured overlay at the root would paint full-bleed for a frame,
+  // across the very trail this mode exists to keep visible.
+  return coverMode && coverBox !== null ? createPortal(view, document.body) : view;
 }
 
 export function GraphItemDetailsModal() {

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -5606,6 +5606,48 @@ test.describe("graph view E2E", () => {
     expect(box.headerBottom).not.toBeNull();
     // Starts at the header's bottom edge, so the trail stays readable.
     expect(Math.abs(box.top - (box.headerBottom as number))).toBeLessThanOrEqual(2);
+
+    // WHAT IS ACTUALLY ON TOP, asked of the browser rather than inferred from a
+    // number. The first attempt had `z-index: 45` against a pane at 40 and was
+    // covered by it anyway: the board's container is `isolation: isolate` at
+    // z-index 0, so nothing inside it competes with the pane at all. A z-index
+    // assertion passed while the feature was broken, which is why this one is
+    // a hit test.
+    const onTop = await page.evaluate(() => {
+      const surface = document.querySelector("[data-preview-settled]");
+      if (surface === null) return "no-surface";
+      const rect = surface.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        Math.round(rect.left + rect.width / 2),
+        Math.round(rect.top + rect.height / 2),
+      );
+      if (hit === null) return "nothing";
+      return hit.closest("[data-item-details]") !== null ? "details" : "pane";
+    });
+    expect(onTop).toBe("details");
+
+    // And the breadcrumb is still reachable — over the preview, UNDER the trail.
+    const headerOnTop = await page.evaluate(() => {
+      const header = document.querySelector('[data-testid="workbench-header-region"]');
+      if (header === null) return "no-header";
+      const rect = header.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        Math.round(rect.left + rect.width / 2),
+        Math.round(rect.top + Math.min(8, rect.height / 2)),
+      );
+      return hit !== null && hit.closest("[data-item-details]") === null ? "header" : "details";
+    });
+    expect(headerOnTop).toBe("header");
+
+    // AND IT IS OPAQUE. Being on top is not enough — with a transparent ground
+    // the live preview and the divider band read straight through the cards,
+    // which is what a first pass at this actually did.
+    const ground = await view.evaluate((el) => getComputedStyle(el).backgroundColor);
+    const alpha = ground.startsWith("rgba")
+      ? Number(ground.split(",")[3]?.replace(")", "").trim() ?? "1")
+      : 1;
+    expect(ground).not.toBe("transparent");
+    expect(alpha).toBe(1);
   });
 
   test("the default mode still stands the pane down", async ({ page }) => {


### PR DESCRIPTION
Two fixes on top of the first cover attempt, both reported from the app.

## It was covered by the pane anyway

`z-index: 45` against a pane at `40`, and the pane still won. **No number would have worked.**

The board and this view live inside `[data-testid="workbench-lower-pane"]`, which is `position: relative; z-index: 0; isolation: isolate` — a stacking context of its own **at level zero**. The preview region is a `z-40` *sibling* of that container. Nothing inside an isolated context competes with anything outside it, so 45, 450 or 45000 would all have lost.

So the overlay **leaves** rather than trying to out-rank from inside. `createPortal` moves the DOM node only — React context still resolves through the tree it was declared in, so every provider this view reads (store, details context, trim preview) is untouched. At the root it meets the header's `z-50` and the surface's `z-40` on equal terms, which is what finally makes 45 mean what it says. The box was already in viewport coordinates, so nothing about the positioning changed.

Default mode is untouched and stays in flow — it *is* the content area there (PL15-029), and a portal would undo that.

## Then the preview and divider read through it

Replacing the board, this view sits on the page's own background and needs none of its own. Covering, it sits over a live pane — so with a transparent ground the preview and the divider band showed straight through the cards.

`bg-zinc-950` in cover mode only: what the header region and the preview region are already painted with, so the covered view matches the surface it stands in for rather than introducing a third shade.

## The test is now a hit test, and that is the point

The first version asserted `position: fixed` and `z-index > 40`. **It passed while the feature was visibly broken** — which is exactly the failure mode of asserting a number instead of an outcome.

It now asks the browser what is actually at the pane's own centre point, what is at the breadcrumb's, and whether the ground is opaque:

    Received: "pane"      ← against the un-portalled build

so it fails on the bug it was written for.

## Suites

    app        1473 passing
    unit        812 passing
    storybook   308 passing
    e2e         177 passing, 10 skipped
    tsc clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
