### PR TITLE
Cover mode — the view stops masking its own background

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -195,9 +195,6 @@ const STRIP_FLOOR_HEIGHT_PX = 104;
 const DETAILS_GAP_PX = 24;
 const DETAILS_GAP_FLOOR_PX = 12;
 
-const DECK_EDGE_FADE =
-  "linear-gradient(90deg, transparent 0, #000 5%, #000 95%, transparent 100%)";
-
 // The trim MODAL (PL10-008, an experiment replacing the docked map).
 //
 // The board had too much on it: a strip, a tree, a preview, a ruler, a rail,
@@ -1771,8 +1768,20 @@ function DetailsFilmstripModal({
       // is meant to be softening.
       style={{
         containerType: "inline-size",
-        maskImage: DECK_EDGE_FADE,
-        WebkitMaskImage: DECK_EDGE_FADE,
+        // THE EDGE FADE IS NOT HERE ANY MORE, and it never should have been.
+        //
+        // A mask applies to everything the element paints — its BACKGROUND
+        // included — so the same gradient that softened the outer cards also
+        // faded this view's own opaque ground to transparent at both edges. In
+        // cover mode that is a hole: the live preview underneath reads straight
+        // through the outer 5% either side, which is what "the sides let the
+        // preview poke through" is.
+        //
+        // NOTHING IS LOST BY REMOVING IT. `.pb .deck` carries the identical
+        // mask — `linear-gradient(90deg, transparent 0, #000 5%, #000 95%,
+        // transparent 100%)` — and the deck is the element that actually holds
+        // the cards, which is where the reference put it. The fade was being
+        // applied TWICE; this was the copy in the wrong place.
         // SCROLLS ONLY WHEN IT IS BOUNDED — AND IT IS ALWAYS BOUNDED NOW.
         //
         // `auto` makes this a scroll container, and a scroll container inside

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -5648,6 +5648,30 @@ test.describe("graph view E2E", () => {
       : 1;
     expect(ground).not.toBe("transparent");
     expect(alpha).toBe(1);
+
+    // AND OPAQUE AT THE EDGES TOO. The view used to carry the deck's own edge
+    // fade as a mask, and a mask applies to the BACKGROUND as well — so the
+    // outer few percent either side faded to transparent and the live pane read
+    // straight through them. Sampled just inside both edges, at the vertical
+    // middle, which is where that hole was.
+    const edges = await page.evaluate(() => {
+      const el = document.querySelector("[data-item-details]");
+      if (el === null) return ["no-view"];
+      const rect = el.getBoundingClientRect();
+      const y = Math.round(rect.top + rect.height / 2);
+      return [Math.round(rect.left + 4), Math.round(rect.right - 4)].map((x) => {
+        const hit = document.elementFromPoint(x, y);
+        if (hit === null) return "nothing";
+        return hit.closest("[data-item-details]") !== null ? "details" : "pane";
+      });
+    });
+    expect(edges).toEqual(["details", "details"]);
+    // Nothing is masking the view itself; the deck keeps its own fade.
+    const masked = await view.evaluate((el) => {
+      const style = getComputedStyle(el);
+      return `${style.maskImage}|${(style as unknown as { webkitMaskImage?: string }).webkitMaskImage ?? "none"}`;
+    });
+    expect(masked).not.toContain("gradient");
   });
 
   test("the default mode still stands the pane down", async ({ page }) => {


### PR DESCRIPTION
The sides of the three-item area let the preview through. The edge fade was the reason — but not the deck's copy of it.

## What was happening

**A mask applies to everything an element paints, background included.**

The view carried this on its own `<section>`:

    linear-gradient(90deg, transparent 0, #000 5%, #000 95%, transparent 100%)

So the same gradient that softens the outer cards also faded the opaque ground added for cover mode down to nothing at both edges. Over a live pane that is a hole, exactly 5% wide either side — which is what you were seeing.

## Why removing it costs nothing

`.pb .deck` **already carries the identical mask**, and the deck is the element that actually holds the cards, which is where the reference put it. The fade was being applied twice; this was the copy in the wrong place — on the one element that also had a background to lose.

So the outer cards still leave the row softly. They now do it against an opaque ground instead of against the preview.

I stopped short of removing every gradient, because the deck's own fade is doing the job it was written for and no longer leaks anything. If you want the cards to clip square at the edge instead, that is the one line in `playbar-styles.ts` — say so and it goes.

## Test

Both edges sampled with `elementFromPoint`, four pixels inside each side at the vertical middle: both must land in the view rather than the pane. Plus the view must carry no gradient mask of its own, so the two cannot be reintroduced together.

## Suites

    app        1473 passing
    unit        812 passing
    storybook   308 passing
    e2e         177 passing, 10 skipped
    tsc clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
