### PR TITLE
PL16-007 — the transport bar and the panel divider, to spec

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -2156,6 +2156,11 @@ export function GraphBoard({
         enabled={previewOn}
         focusedId={focusedId}
         channel={timeChannel}
+        // WHERE THE SPLIT IS REMEMBERED, and it is the PROJECT rather than the
+        // focused collection: drilling into a folder is moving around inside
+        // one piece of work, and a pane that resized itself at every step would
+        // be unusable.
+        projectId={projectId}
         /*
          * TOP of the sticky stack, above the preview rather than below it.
          *

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -815,7 +815,22 @@ export function GraphGridPlayhead({
       // playhead seen in two places, and showing it in two colours said they
       // were different things. The glow goes white with it; a white line over a
       // red halo reads as a mistake rather than as emphasis.
-      className="absolute left-0 top-0 w-0.5 bg-white shadow-[0_0_6px_rgba(255,255,255,0.9)]"
+      //
+      // AND HALF-STRENGTH. The line crosses the CARDS — it runs down the
+      // artwork someone is judging — while the rail's thumb above it sits on
+      // chrome. At full white the line competed with the frames it was drawn
+      // over; at half it still reads as one continuous mark without becoming
+      // part of the picture.
+      //
+      // `opacity`, NOT `bg-white/50`. The glow has to fade with the line: a
+      // full-strength halo around a half-strength mark reads as a rendering
+      // fault rather than as emphasis, which is the same reason the colour was
+      // unified above.
+      //
+      // THE HEAD KEEPS FULL STRENGTH, and is not this element — it is the seek
+      // rail's circular thumb, on chrome above the grid. That is the part you
+      // aim at, so it stays at full opacity deliberately.
+      className="absolute top-0 left-0 w-0.5 bg-white opacity-50 shadow-[0_0_6px_rgba(255,255,255,0.9)]"
     />
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -109,6 +109,7 @@ import {
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { compileClientPlaybackManifest } from "@/lib/client-playback-manifest";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
+import { readPreviewSplit, writePreviewSplit } from "@/lib/preview-split-store";
 import { useItemDetails } from "./graph-item-details-context";
 import { PreviewScrubRail } from "./preview-scrub-rail";
 import { sharedWaveformCache, type WaveformCache } from "@/lib/waveform-cache";
@@ -1130,12 +1131,15 @@ export function useSelectionCount(): number {
 export function PreviewShell({
   enabled,
   focusedId,
+  projectId,
   channel,
   header,
   children,
 }: Readonly<{
   enabled: boolean;
   focusedId: string;
+  /** Which project's remembered split to use. See `preview-split-store`. */
+  projectId: string;
   channel: PreviewTimeChannel;
   /**
    * Pinned above the preview surface — the board's breadcrumb/select row.
@@ -1259,6 +1263,14 @@ export function PreviewShell({
    * THE FIRST CLIP'S START IS NOT A BOUNDARY — it is the beginning of the bar,
    * and a tick there is a notch out of the left cap for no reason.
    */
+  // STABLE IDENTITIES, both of them. The pane reads the getter once at mount
+  // and holds the change callback in an effect dependency, so a new function on
+  // every render would re-run that effect on every drag frame.
+  const readInitialSplit = useCallback(() => readPreviewSplit(projectId), [projectId]);
+  const persistSplit = useCallback(
+    (height: number) => writePreviewSplit(projectId, height),
+    [projectId],
+  );
   const clipBoundaries = useMemo(
     () =>
       totalDuration <= 0
@@ -1296,6 +1308,17 @@ export function PreviewShell({
       ) : null}
       <WorkbenchSplitPane
         header={header}
+        // THE SPLIT SURVIVES THE SESSION (PL16-007).
+        //
+        // A GETTER, read once at mount, because the pane treats a remembered
+        // height as the user's own and skips its one-time automatic fit — so
+        // this has to answer before the first layout, not after it.
+        getInitialSurfaceHeight={readInitialSplit}
+        // WRITTEN ON EVERY DRAG FRAME, which is why the read side is a ref and
+        // not state: this fires many times a second while the edge is moving,
+        // and a `setState` here would re-render the whole board on each one.
+        // `localStorage` writes are synchronous but cheap at this size.
+        onSurfaceHeightChange={persistSplit}
         // The shell and lower pane stay mounted whether the surface is open or
         // closed. That keeps the virtual strip DOM node—and therefore its
         // horizontal scroll position—alive through the preview toggle.

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -1248,6 +1248,27 @@ export function PreviewShell({
   const lastClip = clips[clips.length - 1];
   const totalDuration =
     lastClip === undefined ? 0 : lastClip.startTime + lastClip.duration;
+  /**
+   * WHERE ONE CLIP BECOMES THE NEXT, as fractions of the whole.
+   *
+   * The scrubber cuts a gap through its bar at each of these, so a sequence
+   * reads as a set of shots rather than one undifferentiated span. Drawn from
+   * the same `clips` the pane plays, so they cannot drift from what a scrub
+   * actually lands on.
+   *
+   * THE FIRST CLIP'S START IS NOT A BOUNDARY — it is the beginning of the bar,
+   * and a tick there is a notch out of the left cap for no reason.
+   */
+  const clipBoundaries = useMemo(
+    () =>
+      totalDuration <= 0
+        ? []
+        : clips
+            .slice(1)
+            .map((clip) => clip.startTime / totalDuration)
+            .filter((at) => at > 0 && at < 1),
+    [clips, totalDuration],
+  );
   useEffect(() => {
     if (channel.get() > totalDuration) channel.set(totalDuration);
   }, [channel, totalDuration]);
@@ -1312,7 +1333,17 @@ export function PreviewShell({
               // picture and overlaps nothing — and the transport, which hangs
               // off the surface's bottom edge, does not move.
               underPicture={
-                <PreviewScrubRail channel={channel} totalSeconds={totalDuration} />
+                // 4px BELOW THE FRAME, 14px IN FROM EACH SIDE — the spec's own
+                // numbers. The gap exists so the track never fuses with the
+                // bottom of a bright clip; the inset lines the scrubber up with
+                // the controls row beneath it.
+                <div className="px-[14px] pt-1">
+                <PreviewScrubRail
+                  channel={channel}
+                  totalSeconds={totalDuration}
+                  boundaries={clipBoundaries}
+                />
+                </div>
               }
               className="h-full rounded-b-none border-b-0"
             />

--- a/apps/timeline-gstudio001/components/graph-view/preview-scrub-rail.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/preview-scrub-rail.tsx
@@ -1,29 +1,27 @@
 "use client";
 
-import { useCallback, useRef, useSyncExternalStore } from "react";
+import { useCallback, useRef, useState, useSyncExternalStore } from "react";
 
 import type { PreviewTimeChannel } from "./preview-time-channel";
 
 /**
- * THE PREVIEW'S SCRUB LINE (PL16-006).
+ * THE PREVIEW'S SCRUBBER (PL16-007, to the transport-bar spec).
  *
- * A thin white line across the preview, with the playhead on it as a ball.
- * Drag the ball — or press anywhere on the line — to move the picture; play, or
- * scrub anywhere else, and it moves itself.
+ * A full-width strip below the picture: a 4px track, a white fill for the
+ * elapsed part, a round handle at the playhead, ticks cut through it at every
+ * clip boundary, and a tooltip that follows the cursor.
  *
- * NOTHING HERE OWNS THE CLOCK, and that is what makes "always in unison" true
- * by construction rather than by keeping two things in step.
+ * NOTHING HERE OWNS THE CLOCK, and that is what makes it agree with everything
+ * else by construction rather than by keeping two things in step.
  * `PreviewTimeChannel` is the one clock: this subscribes to it for where the
- * ball goes and writes to it when dragged. The film strip, a board scrub, the
+ * handle goes and writes to it when dragged. The film strip, a board scrub, the
  * transport and this rail all read and write the same value, so none of them
  * can disagree — there is no second copy of the time to drift.
  *
- * NOT `GraphSeekRails`, which already exists and is a different shape. That
- * draws a rail PER GRID ROW mapped onto the cells beneath it (`rowCards`,
- * `offsetX`, `cellWidth`, `columns`); the strip's is the same idea against a
- * scroller. This is the whole timeline as one uninterrupted line, with no cells
- * to map onto and no scroller to follow. Sharing the CLOCK is the reuse that
- * matters here; sharing geometry built for a grid would not be.
+ * ON CHROME, NEVER OVER THE FRAME. The spec's reason is legibility: a control
+ * drawn on footage changes contrast with every clip, so none of them are. That
+ * is also why the strip keeps a 4px gap below the picture — without it the
+ * track fuses with a bright frame's bottom edge.
  *
  * `setScrub` IS DELIBERATELY NOT CALLED. That publishes a pointer position on a
  * BOARD surface so the card under it can raise a hint — it carries a
@@ -32,105 +30,130 @@ import type { PreviewTimeChannel } from "./preview-time-channel";
 export type PreviewScrubRailProps = Readonly<{
   channel: PreviewTimeChannel;
   /** The reachable length of the focused timeline, in seconds. Zero is a
-   *  legitimate resting state — an empty collection — and draws the line with
-   *  the ball parked at its start rather than refusing to render. */
+   *  legitimate resting state — an empty collection — and draws the strip with
+   *  the handle parked at its start rather than refusing to render. */
   totalSeconds: number;
+  /**
+   * Clip boundaries as fractions of the total, 0..1, excluding the ends.
+   *
+   * Fractions rather than seconds because that is what they are drawn as, and
+   * converting once here would leave two representations of the same fact for
+   * the next reader to reconcile.
+   */
+  boundaries?: readonly number[];
+  /**
+   * One frame, in seconds — what an arrow key steps by.
+   *
+   * A PROP because the spec is explicit that stepping must match the sequence's
+   * real rate, and this component has no way to know it. The default is the
+   * prototype's 24fps assumption and is exactly that: an assumption, to be
+   * replaced the moment the caller can answer properly.
+   */
+  frameSeconds?: number;
 }>;
 
 const clamp01 = (value: number) => (value < 0 ? 0 : value > 1 ? 1 : value);
 
-/** Arrow-key steps. A second is the unit people think in when placing a cut;
- *  Shift takes it to ten for crossing a sequence. */
-const ARROW_STEP_SECONDS = 1;
-const ARROW_STEP_COARSE_SECONDS = 10;
+/**
+ * `m:ss.d` — 71.1s reads as `1:11.1`.
+ *
+ * TENTHS, not frames, and not hundredths. This is the number you read while
+ * dragging, so it has to change visibly with the hand without flickering
+ * digits nobody can track.
+ */
+export function formatScrubTime(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  const minutes = Math.floor(safe / 60);
+  const rest = safe - minutes * 60;
+  const whole = Math.floor(rest);
+  const tenth = Math.floor((rest - whole) * 10);
+  return `${minutes}:${whole < 10 ? "0" : ""}${whole}.${tenth}`;
+}
 
-export function PreviewScrubRail({ channel, totalSeconds }: PreviewScrubRailProps) {
+export function PreviewScrubRail({
+  channel,
+  totalSeconds,
+  boundaries = [],
+  frameSeconds = 1 / 24,
+}: PreviewScrubRailProps) {
   const time = useSyncExternalStore(channel.subscribe, channel.get, () => 0);
-  const trackRef = useRef<HTMLDivElement | null>(null);
+  const stripRef = useRef<HTMLDivElement | null>(null);
+  // A CLASS, not just `:hover`, because a fast drag leaves the strip — the
+  // pointer is captured so the scrub continues, and the grown track has to
+  // continue with it or the control appears to let go mid-gesture.
+  const [dragging, setDragging] = useState(false);
+  const [hoverFraction, setHoverFraction] = useState<number | null>(null);
 
   const total = Number.isFinite(totalSeconds) && totalSeconds > 0 ? totalSeconds : 0;
   const fraction = total === 0 ? 0 : clamp01(time / total);
 
+  const fractionAt = useCallback((clientX: number): number | null => {
+    const strip = stripRef.current;
+    if (strip === null) return null;
+    const rect = strip.getBoundingClientRect();
+    if (rect.width === 0) return null;
+    return clamp01((clientX - rect.left) / rect.width);
+  }, []);
+
   const seekTo = useCallback(
     (clientX: number) => {
-      const track = trackRef.current;
-      if (track === null || total === 0) return;
-      const rect = track.getBoundingClientRect();
-      if (rect.width === 0) return;
-      channel.set(clamp01((clientX - rect.left) / rect.width) * total);
+      const next = fractionAt(clientX);
+      if (next !== null && total > 0) channel.set(next * total);
     },
-    [channel, total],
+    [channel, fractionAt, total],
   );
+
+  // The track and fill grow from 4px to 6px together, so they are expressed
+  // once and shared rather than kept in step in two places.
+  const grown = dragging || hoverFraction !== null;
+  const barGeometry = grown ? { top: 7, height: 6 } : { top: 8, height: 4 };
 
   return (
     <div
       data-preview-scrub-rail
-      // THE WHOLE BAND IS THE TARGET, not just the ball. A 10px ball is hard to
-      // catch with a mouse and unreasonable with a finger, and pressing
-      // anywhere on a progress line to jump there is the gesture people already
-      // expect — the drag then continues from under the pointer.
-      //
-      // IN FLOW, and that is the point of it. It renders through the display
-      // surface's `underPicture` slot, where it is a sibling of a `flex-1`
-      // picture — so its height comes out of the PICTURE and it overlaps
-      // nothing. The transport hangs off the surface's bottom edge and is
-      // untouched.
-      // EXACTLY 4px ABOVE THE DIVIDER, and that number is asked for rather than
-      // arrived at — `pb-1`. The line belongs to the divider below it, not to
-      // the picture above, so all the clearance goes above it.
-      //
-      // Twice this was set by eye and twice it was too far: centred in the band
-      // it sat 10px clear, then 6px. The e2e now asserts the 4 exactly, so the
-      // next person changing the band's height cannot move it by accident.
-      //
-      // The ball overhangs it — 5px radius at rest, 6px hovered — which is why
-      // the band does not clip: it is `overflow` visible, and the ball reaching
-      // a couple of pixels over the divider's own clearance is what makes it
-      // read as sitting ON the line rather than above it.
-      // PAINTED 20px LOWER THAN ITS LAYOUT BOX, which is the whole trick.
-      //
-      // The divider is a 44px HIT TARGET whose visible gray bar sits 20px below
-      // its top edge — measured: box top 306, bar top 326. So a gap measured
-      // against the BOX is 20px larger than the gap anyone can see, which is
-      // how this was set to "4px" twice and looked like 24.
-      //
-      // `top-3` shifts the paint 12px down onto the divider's empty top
-      // clearance without moving the layout box, so the picture above is
-      // unaffected and the line lands 12px above the BAR. Twelve, not the four
-      // tried first: at four the line read as part of the divider rather than
-      // as its own control.
-      //
-      // No background: the band it now paints over belongs to the divider, and
-      // filling it would put a black strip across the divider's own ground.
-      className="group/rail relative top-3 z-10 flex h-4 w-full shrink-0 cursor-pointer items-end px-3 pb-1"
+      data-dragging={dragging ? "" : undefined}
+      // 20px OF POINTER, 4px OF PAINT. The strip is the target — pressing
+      // anywhere on it seeks and the drag continues from under the pointer —
+      // while what is drawn stays thin enough not to compete with the picture.
+      // `touch-action: none` so a vertical flick on a touchscreen scrubs rather
+      // than scrolling the page out from under the gesture.
+      className="relative h-5 w-full shrink-0 cursor-pointer"
+      style={{ touchAction: "none" }}
       role="slider"
       tabIndex={0}
       aria-label="Preview position"
       aria-valuemin={0}
       aria-valuemax={Math.round(total * 100) / 100}
       aria-valuenow={Math.round(time * 100) / 100}
-      aria-valuetext={`${time.toFixed(2)} of ${total.toFixed(2)} seconds`}
+      aria-valuetext={`${formatScrubTime(time)} of ${formatScrubTime(total)}`}
+      ref={stripRef}
       onPointerDown={(event) => {
         if (event.button !== 0) return;
-        // POINTER CAPTURE, so a drag that leaves the band keeps scrubbing — the
-        // same thing the seam bar does, and for the same reason: a hand moving
-        // at any speed leaves a 16px band immediately.
+        // POINTER CAPTURE, so a drag that leaves the strip keeps scrubbing.
         event.currentTarget.setPointerCapture(event.pointerId);
         event.preventDefault();
+        setDragging(true);
         seekTo(event.clientX);
       }}
       onPointerMove={(event) => {
-        if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
-        seekTo(event.clientX);
+        const at = fractionAt(event.clientX);
+        if (at !== null) setHoverFraction(at);
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) seekTo(event.clientX);
       }}
       onPointerUp={(event) => {
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
           event.currentTarget.releasePointerCapture(event.pointerId);
         }
+        setDragging(false);
       }}
+      onPointerLeave={() => setHoverFraction(null)}
+      // A SLIDER HAS TO BE OPERABLE FROM THE KEYBOARD, and the spec is specific
+      // about the units: an arrow is one FRAME, not one second, because the
+      // thing being placed is a cut. Shift takes it to a second for crossing
+      // ground. Home and End are the sequence's own ends.
       onKeyDown={(event) => {
         if (total === 0) return;
-        const step = event.shiftKey ? ARROW_STEP_COARSE_SECONDS : ARROW_STEP_SECONDS;
+        const step = event.shiftKey ? 1 : frameSeconds;
         if (event.key === "ArrowLeft") {
           event.preventDefault();
           channel.set(Math.max(0, time - step));
@@ -146,23 +169,56 @@ export function PreviewScrubRail({ channel, totalSeconds }: PreviewScrubRailProp
         }
       }}
     >
-      {/* THE LINE. Continuous across the whole width — it is the sequence, not
-          a set of clips, so nothing divides it. One pixel: it is a reference
-          for the ball to sit on, not a bar to read a value off. */}
-      <div ref={trackRef} data-preview-scrub-track className="relative h-px w-full bg-white/70">
-        {/* THE BALL, white like the line because it is the same object — where
-            you are on it. A second hue would read as a different kind of thing.
-
-            `translate(-50%, -50%)` on both axes so its CENTRE sits on the
-            value; anchored by its left edge it would lie by a radius, which at
-            these scales is a frame or more. */}
-        <span
-          data-preview-scrub-thumb
-          aria-hidden="true"
-          className="pointer-events-none absolute top-1/2 block h-2.5 w-2.5 rounded-full bg-white transition-[height,width] group-hover/rail:h-3 group-hover/rail:w-3"
-          style={{ left: `${fraction * 100}%`, transform: "translate(-50%, -50%)" }}
-        />
+      {/* THE TRACK — the whole sequence, unbroken. */}
+      <div
+        data-preview-scrub-track
+        className="absolute right-0 left-0 rounded-sm bg-white/15 transition-[height,top] duration-100"
+        style={{ top: barGeometry.top, height: barGeometry.height }}
+      />
+      {/* THE FILL — how much of it has gone by. */}
+      <div
+        data-preview-scrub-fill
+        className="absolute left-0 rounded-sm bg-white transition-[height,top] duration-100"
+        style={{ top: barGeometry.top, height: barGeometry.height, width: `${fraction * 100}%` }}
+      />
+      {/* THE CUTS. Painted in the surface's own colour rather than a darker
+          line, so they read as GAPS in the bar rather than as marks on it —
+          which is what a cut is. Above the fill so they survive being passed. */}
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        {boundaries.map((at) => (
+          <i
+            key={at}
+            data-preview-scrub-tick
+            className="absolute block w-0.5 -translate-x-1/2 bg-zinc-950"
+            style={{ left: `${clamp01(at) * 100}%`, top: 6, height: 8 }}
+          />
+        ))}
       </div>
+      {/* THE HANDLE. No pointer events of its own — the strip is the target, so
+          a press 3px away from a 12px dot still lands. */}
+      <span
+        data-preview-scrub-thumb
+        aria-hidden="true"
+        className="pointer-events-none absolute block h-3 w-3 rounded-full bg-white transition-transform duration-100"
+        style={{
+          top: 10,
+          left: `${fraction * 100}%`,
+          transform: `translate(-50%, -50%) scale(${grown ? 1.2 : 1})`,
+        }}
+      />
+      {/* THE TOOLTIP, showing the time UNDER THE CURSOR rather than the
+          playhead's — the question it answers is "what is here", which is what
+          you need before deciding to go there. */}
+      {hoverFraction !== null && total > 0 && (
+        <span
+          data-preview-scrub-tip
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-5 -translate-x-1/2 rounded-md border border-white/15 bg-[#17181c] px-[7px] py-0.5 font-mono text-[11px] whitespace-nowrap text-white"
+          style={{ left: `${hoverFraction * 100}%` }}
+        >
+          {formatScrubTime(hoverFraction * total)}
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/preview-scrub-rail.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/preview-scrub-rail.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useRef, useState, useSyncExternalStore } from "react";
 
+import { formatTimecode } from "@storyboard/ui/timeline/utils";
+
 import type { PreviewTimeChannel } from "./preview-time-channel";
 
 /**
@@ -53,22 +55,6 @@ export type PreviewScrubRailProps = Readonly<{
 }>;
 
 const clamp01 = (value: number) => (value < 0 ? 0 : value > 1 ? 1 : value);
-
-/**
- * `m:ss.d` — 71.1s reads as `1:11.1`.
- *
- * TENTHS, not frames, and not hundredths. This is the number you read while
- * dragging, so it has to change visibly with the hand without flickering
- * digits nobody can track.
- */
-export function formatScrubTime(seconds: number): string {
-  const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
-  const minutes = Math.floor(safe / 60);
-  const rest = safe - minutes * 60;
-  const whole = Math.floor(rest);
-  const tenth = Math.floor((rest - whole) * 10);
-  return `${minutes}:${whole < 10 ? "0" : ""}${whole}.${tenth}`;
-}
 
 export function PreviewScrubRail({
   channel,
@@ -125,7 +111,7 @@ export function PreviewScrubRail({
       aria-valuemin={0}
       aria-valuemax={Math.round(total * 100) / 100}
       aria-valuenow={Math.round(time * 100) / 100}
-      aria-valuetext={`${formatScrubTime(time)} of ${formatScrubTime(total)}`}
+      aria-valuetext={`${formatTimecode(time)} of ${formatTimecode(total)}`}
       ref={stripRef}
       onPointerDown={(event) => {
         if (event.button !== 0) return;
@@ -216,7 +202,7 @@ export function PreviewScrubRail({
           className="pointer-events-none absolute bottom-5 -translate-x-1/2 rounded-md border border-white/15 bg-[#17181c] px-[7px] py-0.5 font-mono text-[11px] whitespace-nowrap text-white"
           style={{ left: `${hoverFraction * 100}%` }}
         >
-          {formatScrubTime(hoverFraction * total)}
+          {formatTimecode(hoverFraction * total)}
         </span>
       )}
     </div>

--- a/apps/timeline-gstudio001/lib/preview-split-store.ts
+++ b/apps/timeline-gstudio001/lib/preview-split-store.ts
@@ -1,0 +1,54 @@
+/**
+ * WHERE THE USER PUT THE SPLIT, remembered per project (PL16-007).
+ *
+ * The split between the preview and the board below it is a working
+ * preference, not a document fact: two people opening the same project want
+ * different amounts of picture, and the same person wants a different amount
+ * on a laptop than on a monitor. So it lives in `localStorage` — per browser,
+ * per project — rather than in the timeline document.
+ *
+ * PER PROJECT, not one global number, because the right split follows the
+ * material. A project of long takes wants the picture; a project being
+ * assembled from a hundred stills wants the board.
+ *
+ * EVERY PATH IS GUARDED AND SILENT. `localStorage` throws rather than returning
+ * null in a private window and under a blocked-cookies setting, and a resize
+ * that raised an exception would be a pane that stops moving for a preference
+ * nobody would miss. A read that cannot answer returns `undefined`, which is
+ * exactly what "no remembered height" already means to the pane.
+ */
+const KEY_PREFIX = "storyboard:preview-split:";
+
+/** The same bounds the pane clamps to, restated here because a stored value is
+ *  UNTRUSTED INPUT: it survives a release that changed the layout, and it can
+ *  be edited by hand. A number outside this range is discarded rather than
+ *  clamped — it is evidence the value is stale, not that it is slightly off. */
+const MIN_REMEMBERED = 80;
+const MAX_REMEMBERED = 2000;
+
+export function readPreviewSplit(projectId: string): number | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.localStorage.getItem(`${KEY_PREFIX}${projectId}`);
+    if (raw === null) return undefined;
+    const value = Number(raw);
+    if (!Number.isFinite(value)) return undefined;
+    if (value < MIN_REMEMBERED || value > MAX_REMEMBERED) return undefined;
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writePreviewSplit(projectId: string, height: number): void {
+  if (typeof window === "undefined") return;
+  if (!Number.isFinite(height)) return;
+  try {
+    // ROUNDED. The pane's height is a float mid-drag, and storing 380.3921875
+    // means the restored pane is a subpixel off the one that was left — which
+    // the sticky stack above it then has to resolve against a fractional edge.
+    window.localStorage.setItem(`${KEY_PREFIX}${projectId}`, String(Math.round(height)));
+  } catch {
+    // A preference that cannot be saved is not worth an error to the user.
+  }
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3183,6 +3183,17 @@ test.describe("graph view E2E", () => {
     const playhead = page.locator("[data-graph-grid-playhead]");
     await expect(playhead).toBeVisible();
 
+    // HALF-STRENGTH LINE, FULL-STRENGTH HEAD (PL16-007). The line crosses the
+    // CARDS — it runs down the artwork being judged — while the head sits on
+    // chrome above the grid. The pair is asserted together because that is the
+    // whole point: fading both would lose the thing you aim at, and fading
+    // neither is what the line looked like before.
+    expect(await playhead.evaluate((el) => getComputedStyle(el).opacity)).toBe("0.5");
+    const gridThumb = page.locator("[data-rail-thumb]").first();
+    if ((await gridThumb.count()) > 0) {
+      expect(await gridThumb.evaluate((el) => getComputedStyle(el).opacity)).toBe("1");
+    }
+
     const grid = page.locator("[data-virtual-grid]");
     // Fewer than 4 columns guarantees a second row for the 4 project clips.
     const cols = Number(await grid.getAttribute("data-grid-columns"));

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1808,11 +1808,7 @@ test.describe("graph view E2E", () => {
     // still everything but the first 36px of a divider that runs the full
     // width, which is why one icon was allowed there when a button AND a 64px
     // slider previously were not.
-    // y=30, NOT y=10 (PL16-006). The preview's scrub line is drawn 12px above
-    // the divider's visible bar, so its hit band covers the divider box's top
-    // 12px — a pointer there scrubs rather than resizes. The drag target is
-    // the remaining 32px, bar included. What is asserted below is unchanged.
-    await divider.hover({ position: { x: 60, y: 30 } });
+    await divider.hover({ position: { x: 60, y: 10 } });
     await expect.poll(dividerLineColor).not.toBe(restLineColor);
     await page.mouse.move(0, 0); // unhover before the resize steps below
 
@@ -2749,21 +2745,13 @@ test.describe("graph view E2E", () => {
       groupBox!.y + groupBox!.height / 2,
       0,
     );
-    // THE SCRUB LINE SITS BETWEEN THE PICTURE AND THE DIVIDER'S BAR
-    // (PL16-006), and the two facts worth pinning are where it is NOT and how
-    // close it is.
-    //
-    // MEASURED AGAINST THE VISIBLE BAR, not the divider's box. The box is a
-    // 44px hit target whose gray bar sits 20px below its top edge — so a gap
-    // measured against the box is 20px larger than the one anyone can see,
-    // which is how this was asserted as "4" while reading as 24 on screen. The
-    // bar is what the eye uses, so the bar is what this measures.
-    const lineBox = await page.locator("[data-preview-scrub-track]").boundingBox();
-    expect(lineBox).not.toBeNull();
-    expect(Math.round(dividerLineBox!.y - (lineBox!.y + lineBox!.height))).toBe(12);
-    // And it is clear of the picture: the line starts below where the canvas
-    // ends, so it crosses nothing.
-    expect(lineBox!.y).toBeGreaterThanOrEqual(canvasBox!.y + canvasBox!.height);
+    // THE SCRUBBER SITS BELOW THE PICTURE, ON CHROME (PL16-007). The spec's
+    // reason is legibility — a control drawn on footage changes contrast with
+    // every clip — so what is asserted is that it clears the frame, and by the
+    // 4px the spec asks for so the track cannot fuse with a bright bottom edge.
+    const railBox = await page.locator("[data-preview-scrub-rail]").boundingBox();
+    expect(railBox).not.toBeNull();
+    expect(Math.round(railBox!.y - (canvasBox!.y + canvasBox!.height))).toBe(4);
 
     expect(
       Math.abs(timeBox!.x + timeBox!.width - (surfaceBox!.x + surfaceBox!.width - 12)),
@@ -5711,6 +5699,78 @@ test.describe("graph view E2E", () => {
       .poll(async () => Number(await rail.getAttribute("aria-valuenow")), { timeout: 5000 })
       .toBe(0);
     expect(await thumbX()).toBeLessThan(movedX);
+  });
+
+  test("the scrubber cuts its bar at the cuts, and answers the cursor", async ({ page }) => {
+    // PL16-007, the transport-bar spec's scrubber.
+    //
+    // THREE THINGS THAT CAN EACH BREAK ALONE, so each is asserted alone: the
+    // bar is divided at the cuts, the bar THICKENS under the pointer, and the
+    // tooltip answers "what is HERE" rather than repeating the playhead.
+    await installGraphApi(page);
+    await openGraph(page);
+    await previewToggle(page).click();
+    await expect(page.locator("[data-preview-settled]")).toHaveCount(1, { timeout: 15000 });
+
+    const rail = page.locator("[data-preview-scrub-rail]");
+    const track = page.locator("[data-preview-scrub-track]");
+    const ticks = page.locator("[data-preview-scrub-tick]");
+
+    // FOUR CUTS, not three. The root holds four clips, but one of them is a
+    // COLLECTION, and the preview plays its two children rather than the
+    // folder — five clips end to end. The ticks are drawn from the same list
+    // the pane plays, so they count the cuts a scrub can actually land on.
+    //
+    // The sequence's own start is not one of them: a tick there is a notch out
+    // of the left cap.
+    await expect(ticks).toHaveCount(4);
+
+    const trackBox = (await track.boundingBox())!;
+    const tickXs: number[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      tickXs.push((await ticks.nth(i).boundingBox())!.x);
+    }
+    // In order, and all of them strictly INSIDE the bar rather than piled on
+    // an end — which is what a broken fraction would look like.
+    for (let i = 1; i < tickXs.length; i += 1) {
+      expect(tickXs[i - 1]!).toBeLessThan(tickXs[i]!);
+    }
+    expect(tickXs[0]!).toBeGreaterThan(trackBox.x + 2);
+    expect(tickXs[tickXs.length - 1]!).toBeLessThan(trackBox.x + trackBox.width - 2);
+
+    // THICKER UNDER THE POINTER: 4px at rest, 6px when aimed at.
+    expect(Math.round(trackBox.height)).toBe(4);
+    await page.mouse.move(trackBox.x + trackBox.width * 0.25, trackBox.y + trackBox.height / 2);
+    await expect
+      .poll(async () => Math.round((await track.boundingBox())!.height), { timeout: 3000 })
+      .toBe(6);
+
+    // AND IT READS THE CURSOR, NOT THE PLAYHEAD. The playhead is parked at
+    // zero; the tip a quarter of the way along must not say 0:00.0.
+    const tip = page.locator("[data-preview-scrub-tip]");
+    await expect(tip).toHaveCount(1);
+    const total = Number(await rail.getAttribute("aria-valuemax"));
+    expect(Number(await rail.getAttribute("aria-valuenow"))).toBe(0);
+    const quarter = (await tip.textContent())!.trim();
+    expect(quarter).not.toBe("0:00.0");
+    expect(quarter).toMatch(/^\d+:\d\d\.\d$/);
+
+    // ONE FRAME PER ARROW, at the rate it was given — 1/24s reads as 0.04.
+    await rail.focus();
+    await page.keyboard.press("ArrowRight");
+    await expect
+      .poll(async () => Number(await rail.getAttribute("aria-valuenow")), { timeout: 3000 })
+      .toBe(0.04);
+    // Shift crosses ground instead: a whole second.
+    await page.keyboard.press("Shift+ArrowRight");
+    await expect
+      .poll(async () => Number(await rail.getAttribute("aria-valuenow")), { timeout: 3000 })
+      .toBe(1.04);
+    // And End is the far end of the same clock the bar is drawn from.
+    await page.keyboard.press("End");
+    await expect
+      .poll(async () => Number(await rail.getAttribute("aria-valuenow")), { timeout: 3000 })
+      .toBe(Math.round(total * 100) / 100);
   });
 
   // PARKED: the deck draws its trim strip on a STILL.

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1762,21 +1762,26 @@ test.describe("graph view E2E", () => {
     await expect.poll(heightOf).toBeGreaterThan(0);
     const initial = await heightOf();
 
-    // The 44px box is the DRAG TARGET and never changes; the visible band is
-    // smaller and sits just below centre inside it (8px at desktop, 12 where
-    // it has to hold the grip), so the space either side of it reads as
-    // clearance between the preview and the timeline.
+    // 22px IN FLOW (PL16-007): the spec's 8px gap under the controls row, then
+    // the pane's 14px lip. It was 44 — a well tall enough to hold the
+    // transport, which used to ride on it and no longer does.
     expect(
       await divider.evaluate((el) => Math.round(el.getBoundingClientRect().height)),
-    ).toBe(44);
-    expect(
-      await divider
-        .locator("[data-divider-line]")
-        .evaluate((el) => Math.round(el.getBoundingClientRect().height)),
-    ).toBe(8);
-    // The grip is for coarse pointers only: present in the DOM, not painted
-    // at desktop width.
-    await expect(divider.locator("[data-divider-grip]")).toBeHidden();
+    ).toBe(22);
+    // THE HIT TARGET IS BIGGER THAN THE BOX, and reaches DOWN only. It
+    // straddles the edge so a pointer aimed at the gap between the panes still
+    // catches it; reaching up would put it under the controls row.
+    const zoneBox = await divider.locator("[data-divider-zone]").boundingBox();
+    const dividerBoxForZone = await divider.boundingBox();
+    expect(Math.round(zoneBox!.height)).toBe(30);
+    expect(Math.round(zoneBox!.y)).toBe(Math.round(dividerBoxForZone!.y));
+    // The grip is the resting affordance now — a pill, painted at every width.
+    // It used to be a coarse-pointer-only mark hidden at desktop.
+    const grip = divider.locator("[data-divider-grip]");
+    await expect(grip).toBeVisible();
+    const gripBox = await grip.boundingBox();
+    expect(Math.round(gripBox!.width)).toBe(40);
+    expect(Math.round(gripBox!.height)).toBe(4);
     const splitPane = page.getByTestId("workbench-split-pane");
     const displaySurface = page.getByTestId("workbench-display-surface");
     expect(
@@ -1788,28 +1793,34 @@ test.describe("graph view E2E", () => {
         (element) => getComputedStyle(element).borderBottomWidth,
       ),
     ).toBe("0px");
-    const dividerLine = divider.locator("[data-divider-line]");
-    await expect(dividerLine).toHaveCount(1);
-    expect(
-      await dividerLine.evaluate((element) => getComputedStyle(element).backgroundImage),
-    ).toContain("linear-gradient");
-    // The band is painted by a gradient built from `currentColor`, so COLOR
-    // is what hover changes. (This read used to be `backgroundColor`, which
-    // is transparent on a gradient-backed element in both states — the
-    // assertion could not fail and, once the gradient landed, could not pass
-    // either.)
-    const dividerLineColor = () =>
-      dividerLine.evaluate((el) => getComputedStyle(el).color);
-    const restLineColor = await dividerLineColor();
-    // x=60, NOT x=20 (PL15-008). The divider's left end carries the preview's
-    // audio icon now — a 28px control at `left-2`, so it occupies roughly the
-    // first 36 pixels — and hovering THAT is not hovering the divider. Moving
-    // the point is only honest because of what is left: the drag target is
-    // still everything but the first 36px of a divider that runs the full
-    // width, which is why one icon was allowed there when a button AND a 64px
-    // slider previously were not.
+    // THE OLD BAND IS GONE, not restyled. The spec's acceptance is that exactly
+    // ONE bright horizontal line survives below the picture — the scrubber —
+    // and the divider communicates through cursor, grip and hover instead.
+    await expect(divider.locator("[data-divider-line]")).toHaveCount(0);
+    const edge = divider.locator("[data-divider-edge]");
+    // AT REST THE EDGE PAINTS NOTHING — the one assertion that carries the
+    // spec's acceptance criterion.
+    expect(await edge.evaluate((el) => (el as HTMLElement).style.backgroundColor)).toBe(
+      "transparent",
+    );
+    await expect(divider).not.toHaveAttribute("data-divider-reached", "");
+
+    // HOVER BRINGS THE EDGE UP. x=60 is fine again: the audio control moved off
+    // the divider into the transport row, so the whole width is the zone.
     await divider.hover({ position: { x: 60, y: 10 } });
-    await expect.poll(dividerLineColor).not.toBe(restLineColor);
+    // ASSERTED ON THE PUBLISHED STATE AND THE SPECIFIED COLOUR, not on the
+    // computed one. Both marks fade over 120ms, and a computed read after the
+    // flip returns the value being faded FROM — it stayed there through a
+    // five-second poll, which is indistinguishable from a rule that never
+    // applied. What is checked instead is the fact (the pane says it is being
+    // reached for) and the colour it is heading to.
+    await expect(divider).toHaveAttribute("data-divider-reached", "");
+    await expect
+      .poll(() => edge.evaluate((el) => (el as HTMLElement).style.backgroundColor))
+      .toBe("rgba(255, 255, 255, 0.25)");
+    await expect
+      .poll(() => grip.evaluate((el) => (el as HTMLElement).style.backgroundColor))
+      .toBe("rgba(255, 255, 255, 0.55)");
     await page.mouse.move(0, 0); // unhover before the resize steps below
 
     // Expanding a sub-graph grows the content BELOW the preview. The preview
@@ -2662,218 +2673,204 @@ test.describe("graph view E2E", () => {
     await expect.poll(translateX).toBeLessThan(20);
   });
 
-  test("preview transport stays static in the divider with time aligned right", async ({
+  test("the transport is a row under the picture, and the divider is the pane's edge", async ({
     page,
   }) => {
+    // PL16-007, the transport-bar spec. THE PREVIOUS VERSION OF THIS TEST
+    // asserted the opposite arrangement — a transport hung off the surface's
+    // bottom edge and centred on a divider band's mid-line, with the band
+    // carrying a hand-written gradient window punched through it so no line ran
+    // behind the glyphs. That is the thing the spec replaces: below the picture
+    // there is now exactly ONE bright horizontal line, the scrubber, and the
+    // divider is the pane's own edge rather than a shelf for controls.
     await installGraphApi(page);
     await openGraph(page);
     await previewToggle(page).click();
-    // The pane SLIDES open and its chrome fades in once it lands, so every
-    // measurement below has to be taken against a pane that has stopped
-    // moving — otherwise "the transport does not move on hover" is measured
-    // across a transport that was still arriving. `data-preview-settled` is
-    // the pane saying it is open and still.
+    // Every measurement below has to be taken against a pane that has stopped
+    // moving, or "the row does not overlap the picture" is measured across a
+    // row that was still arriving.
     await page.locator("[data-preview-settled]").waitFor({ state: "attached" });
 
     const surface = page.getByTestId("workbench-display-surface");
     const canvas = page.getByTestId("workbench-display-canvas");
     const controls = page.getByTestId("workbench-preview-controls");
     const buttonGroup = controls.locator("[data-transport-button-group]");
-    const primaryControl = controls.locator("[data-transport-primary-control]");
     const time = page.getByTestId("workbench-preview-time");
-    const divider = page.getByRole("separator", {
-      name: "Resize workbench display",
-    });
-    const dividerLine = divider.locator("[data-divider-line]");
-    const playButton = page.getByRole("button", {
-      name: "Play workbench preview",
-    });
+    const rail = page.locator("[data-preview-scrub-rail]");
+    const divider = page.getByRole("separator", { name: "Resize workbench display" });
 
+    // IN FLOW, and a child of the surface. This is the change itself: the row
+    // used to be `position: absolute` at `top-full`, hanging below the surface.
     expect(await controls.evaluate((element) => getComputedStyle(element).position)).toBe(
-      "absolute",
+      "static",
     );
-    await expect(controls).toHaveAttribute("data-transport-layout", "static");
-    await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
-    await expect(time).toContainText("/");
-    await expect(controls.locator("[data-transport-capsule]")).toHaveCount(0);
-    // Grip marks are the coarse-pointer affordance; this runs at desktop
-    // width, where the hover brighten does the job and the grip stays unpainted.
-    await expect(divider.locator("[data-divider-grip]")).toBeHidden();
-    // RESTING (nothing hovered): background-free. The ACTIVE invert to a white
-    // disc is covered by the WorkbenchSplitPane story, which can hover the
-    // preview deterministically.
+    await expect(controls).toHaveAttribute("data-transport-layout", "row");
     expect(
-      await primaryControl.evaluate(
-        (element) => getComputedStyle(element).backgroundColor,
-      ),
-    ).toBe("rgba(0, 0, 0, 0)");
+      await controls.evaluate((element) => element.parentElement?.dataset.testid ?? ""),
+    ).toBe("workbench-display-surface");
 
-    // All three 44px hit targets remain centered on the divider's visible
-    // band, while their own chrome stays deliberately compact.
-    const [surfaceBox, canvasBox, groupBox, dividerBox, dividerLineBox, timeBox] =
+    const [surfaceBox, canvasBox, railBox, controlsBox, groupBox, timeBox, dividerBox] =
       await Promise.all([
         surface.boundingBox(),
         canvas.boundingBox(),
+        rail.boundingBox(),
+        controls.boundingBox(),
         buttonGroup.boundingBox(),
-        divider.boundingBox(),
-        dividerLine.boundingBox(),
         time.boundingBox(),
+        divider.boundingBox(),
       ]);
-    expect(surfaceBox).not.toBeNull();
-    expect(canvasBox).not.toBeNull();
-    expect(groupBox).not.toBeNull();
-    expect(dividerBox).not.toBeNull();
-    expect(dividerLineBox).not.toBeNull();
-    expect(timeBox).not.toBeNull();
-    // The BOX is the hit target and never changes; the visible band is
-    // smaller and centred on one fixed mid-line, so its height can differ by
-    // breakpoint (8 here at desktop, 12 where it hosts the grip) with nothing
-    // else moving.
-    expect(dividerBox!.height).toBe(44);
-    expect(dividerLineBox!.height).toBe(8);
-    // Just BELOW centre, so there is more clearance above the band than below
-    // it — the transport overhangs far enough to crowd the preview more than
-    // the timeline, and an even split read bottom-heavy.
-    expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(dividerBox!.y + 24, 0);
-    // 5 × the 44px button well — jump-to-start, previous, play, next,
-    // jump-to-end. It was 132 (three wells) before the two edge buttons.
-    expect(groupBox!.width).toBe(220);
-    expect(groupBox!.height).toBe(44);
-    // Centered on the BAND, not on the box.
-    expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(
-      groupBox!.y + groupBox!.height / 2,
-      0,
-    );
-    // THE SCRUBBER SITS BELOW THE PICTURE, ON CHROME (PL16-007). The spec's
-    // reason is legibility — a control drawn on footage changes contrast with
-    // every clip — so what is asserted is that it clears the frame, and by the
-    // 4px the spec asks for so the track cannot fuse with a bright bottom edge.
-    const railBox = await page.locator("[data-preview-scrub-rail]").boundingBox();
-    expect(railBox).not.toBeNull();
-    expect(Math.round(railBox!.y - (canvasBox!.y + canvasBox!.height))).toBe(4);
-
-    expect(
-      Math.abs(timeBox!.x + timeBox!.width - (surfaceBox!.x + surfaceBox!.width - 12)),
-    ).toBeLessThanOrEqual(1);
-
-    const [previousVisualBox, playVisualBox, nextVisualBox] = await Promise.all([
-      page
-        .getByRole("button", { name: "Previous workbench clip" })
-        .locator("span")
-        .boundingBox(),
-      page
-        .getByRole("button", { name: "Play workbench preview" })
-        .locator("span")
-        .boundingBox(),
-      page
-        .getByRole("button", { name: "Next workbench clip" })
-        .locator("span")
-        .boundingBox(),
-    ]);
-    expect(previousVisualBox).not.toBeNull();
-    expect(playVisualBox).not.toBeNull();
-    expect(nextVisualBox).not.toBeNull();
-    expect(
-      playVisualBox!.x +
-        playVisualBox!.width / 2 -
-        (previousVisualBox!.x + previousVisualBox!.width / 2),
-    ).toBeCloseTo(36, 0);
-    expect(
-      nextVisualBox!.x +
-        nextVisualBox!.width / 2 -
-        (playVisualBox!.x + playVisualBox!.width / 2),
-    ).toBeCloseTo(36, 0);
-
-    // Divider hover does not resize or move the transport.
-    // x=60, NOT x=20 (PL15-008). The divider's left end carries the preview's
-    // audio icon now — a 28px control at `left-2`, so it occupies roughly the
-    // first 36 pixels — and hovering THAT is not hovering the divider. Moving
-    // the point is only honest because of what is left: the drag target is
-    // still everything but the first 36px of a divider that runs the full
-    // width, which is why one icon was allowed there when a button AND a 64px
-    // slider previously were not.
-    // y=30, NOT y=6 (PL16-006). The scrub line is drawn 4px above the divider's
-    // visible bar, so its hit band occupies the divider box's top ~20px of
-    // clearance — pressing there scrubs rather than resizes. That is a real
-    // trade and it is the one the placement forces: a line that close to the
-    // bar cannot have a usable target anywhere but in that clearance. What is
-    // left for the drag is 24px, including the bar itself, which is more than
-    // a resizer conventionally gets. The point being asserted — hovering the
-    // divider does not move the transport — is unchanged.
-    await divider.hover({ position: { x: 60, y: 30 } });
-    const groupAfterHover = await buttonGroup.boundingBox();
-    expect(groupAfterHover).not.toBeNull();
-    expect(groupAfterHover!.x).toBeCloseTo(groupBox!.x, 0);
-    expect(groupAfterHover!.y).toBeCloseTo(groupBox!.y, 0);
-    expect(groupAfterHover!.width).toBe(groupBox!.width);
-    expect(groupAfterHover!.height).toBe(groupBox!.height);
-
-    const overhangPaintsAboveLowerContent = await playButton.evaluate((element) => {
-      const buttonBox = element.getBoundingClientRect();
-      const controls = element.closest("[data-testid='workbench-preview-controls']");
-      const hit = document.elementFromPoint(
-        buttonBox.left + buttonBox.width / 2,
-        buttonBox.bottom - 2,
-      );
-      return controls === hit || controls?.contains(hit) === true;
-    });
-    expect(overhangPaintsAboveLowerContent).toBe(true);
-
-    // Keyboard focus follows the visible previous/play/next DOM order without
-    // changing the transport's dimensions.
-    const stripButton = page.getByRole("button", {
-      name: "Strip layout",
-      exact: true,
-    });
-    await stripButton.focus();
-    let playHasFocus = false;
-    for (let step = 0; step < 16 && !playHasFocus; step += 1) {
-      await page.keyboard.press("Tab");
-      playHasFocus = await playButton.evaluate(
-        (element) => document.activeElement === element,
-      );
+    for (const box of [surfaceBox, canvasBox, railBox, controlsBox, groupBox, timeBox, dividerBox]) {
+      expect(box).not.toBeNull();
     }
-    expect(playHasFocus).toBe(true);
-    expect(await playButton.evaluate((element) => element.matches(":focus-visible"))).toBe(
-      true,
-    );
-    await expect(controls).toHaveAttribute("data-transport-layout", "static");
-    const groupAfterFocus = await buttonGroup.boundingBox();
-    expect(groupAfterFocus).not.toBeNull();
-    expect(groupAfterFocus!.width).toBe(groupBox!.width);
-    expect(groupAfterFocus!.height).toBe(groupBox!.height);
 
-    // Clicking the transport must not engage the divider's resize gesture.
-    const surfaceHeightBeforePlay = await divider.getAttribute("aria-valuenow");
-    await playButton.click();
-    await expect(surface).toHaveAttribute("data-preview-playing", "true");
-    await expect(divider).toHaveAttribute("aria-valuenow", surfaceHeightBeforePlay!);
+    // THE ORDER, TOP TO BOTTOM, WITH NOTHING OVERLAPPING: picture, scrubber,
+    // controls, edge. Every control sits on chrome and none is drawn over the
+    // frame, which is the spec's reason — a control on footage changes contrast
+    // with every clip.
+    expect(Math.round(railBox!.y - (canvasBox!.y + canvasBox!.height))).toBe(4);
+    expect(controlsBox!.y).toBeGreaterThanOrEqual(railBox!.y + railBox!.height);
+    expect(dividerBox!.y).toBeGreaterThanOrEqual(controlsBox!.y + controlsBox!.height);
+    expect(Math.round(controlsBox!.height)).toBe(44);
 
-    // The rest of the divider remains a resize target.
-    //
-    // AT x=60, NOT x=20 (PL15-008). The divider's left end carries the
-    // preview's audio icon now — 28px at `left-2` — and that control stops
-    // pointer propagation for exactly the reason the transport does: a press on
-    // it must not begin a resize. So x=20 lands ON the island and the drag
-    // correctly does nothing, which is a pass for the island and a false
-    // failure for this assertion. The claim here is about the REST of the
-    // divider, and 36px in is where the rest begins.
-    const dividerBoxAfterPlay = await divider.boundingBox();
-    expect(dividerBoxAfterPlay).not.toBeNull();
-    await page.mouse.move(
-      dividerBoxAfterPlay!.x + 60,
-      dividerBoxAfterPlay!.y + dividerBoxAfterPlay!.height / 2,
+    // ONE 14px INSET, shared, so the bar begins and ends where the controls do.
+    expect(Math.round(railBox!.x - surfaceBox!.x)).toBe(14);
+    expect(
+      Math.round(surfaceBox!.x + surfaceBox!.width - (timeBox!.x + timeBox!.width)),
+    ).toBe(14);
+
+    // CENTRED ON THE PICTURE, not on what the other two columns leave over.
+    // `1fr auto 1fr` is what makes that survive the timecode changing width,
+    // which it does on the tenth, ten times a second.
+    expect(
+      Math.abs(groupBox!.x + groupBox!.width / 2 - (surfaceBox!.x + surfaceBox!.width / 2)),
+    ).toBeLessThanOrEqual(1);
+    // Four 30px ghosts, a 36px play disc, and its 6px margins.
+    expect(Math.round(groupBox!.width)).toBe(168);
+    expect(await controls.locator("[data-transport-capsule]").count()).toBe(0);
+
+    // `m:ss.d`, the same function the scrubber's tooltip spends — the spec
+    // requires the two to agree and one definition is how that is guaranteed.
+    await expect(time).toHaveText(/^\d+:\d\d\.\d \/ \d+:\d\d\.\d$/);
+
+    await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Jump to start of workbench preview" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Jump to end of workbench preview" }),
+    ).toBeVisible();
+
+    // THE EDGE PAIR SITS OUTSIDE THE CLIP STEPPERS. Asserted by x rather than by
+    // DOM order: what matters is that reading outward from play you get "one
+    // clip" then "all the way", and a DOM check would pass on a layout that
+    // visually interleaved them.
+    const xOf = async (name: string) =>
+      (await page.getByRole("button", { name }).boundingBox())!.x;
+    expect(await xOf("Jump to start of workbench preview")).toBeLessThan(
+      await xOf("Previous workbench clip"),
     );
+    expect(await xOf("Jump to end of workbench preview")).toBeGreaterThan(
+      await xOf("Next workbench clip"),
+    );
+
+    // AND THE VOLUME IS IN THE ROW NOW, at its left, rather than parked on the
+    // divider where it used to shrink the drag target.
+    const mute = page.getByTestId("workbench-preview-mute");
+    const muteBox = (await mute.boundingBox())!;
+    expect(Math.round(muteBox.x - surfaceBox!.x)).toBe(14);
+    expect(muteBox.y).toBeGreaterThanOrEqual(controlsBox!.y);
+    expect(muteBox.y + muteBox.height).toBeLessThanOrEqual(controlsBox!.y + controlsBox!.height);
+
+    // THE DIVIDER IS THE PANE'S EDGE. Its old band is gone entirely, and the
+    // resting affordance is a grip pill rather than a rule.
+    expect(Math.round(dividerBox!.height)).toBe(22);
+    await expect(divider.locator("[data-divider-line]")).toHaveCount(0);
+    const gripBox = (await divider.locator("[data-divider-grip]").boundingBox())!;
+    expect(Math.round(gripBox.width)).toBe(40);
+    expect(Math.round(gripBox.height)).toBe(4);
+    // A PILL, NOT A RULE — the distinction the whole redesign turns on.
+    expect(gripBox.width).toBeLessThan(dividerBox!.width / 4);
+    // And it is centred, so it reads as a handle on the edge rather than a mark
+    // at one end of it.
+    expect(
+      Math.abs(gripBox.x + gripBox.width / 2 - (dividerBox!.x + dividerBox!.width / 2)),
+    ).toBeLessThanOrEqual(1);
+  });
+
+  test("the pane's edge drags, resets, nudges, and is remembered", async ({ page }) => {
+    // PL16-007. The sheet edge's four behaviours, each of which can break
+    // alone, and the last of which survives a reload.
+    await installGraphApi(page);
+    await openGraph(page);
+    await previewToggle(page).click();
+    await page.locator("[data-preview-settled]").waitFor({ state: "attached" });
+
+    const divider = page.getByRole("separator", { name: "Resize workbench display" });
+    const grip = divider.locator("[data-divider-grip]");
+    const edge = divider.locator("[data-divider-edge]");
+    const heightOf = async () => Number(await divider.getAttribute("aria-valuenow"));
+    const specified = (locator: Locator) =>
+      locator.evaluate((element) => (element as HTMLElement).style.backgroundColor);
+
+    const opened = await heightOf();
+    expect(opened).toBeGreaterThan(0);
+
+    // DRAGGING. The zone reaches 8px past the box into the pane below, so the
+    // press is taken at the very bottom of the box to prove the straddle: a
+    // zone that only covered the box would miss this and resize nothing.
+    const box = (await divider.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height - 1);
     await page.mouse.down();
-    await page.mouse.move(
-      dividerBoxAfterPlay!.x + 60,
-      dividerBoxAfterPlay!.y + dividerBoxAfterPlay!.height / 2 + 24,
-    );
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height + 39, { steps: 6 });
+    // WHILE DRAGGING both marks take the accent, and they take the SAME one —
+    // one constant drives both, so they cannot drift apart mid-gesture.
+    await expect(divider).toHaveAttribute("data-divider-dragging", "");
+    const draggingGrip = await specified(grip);
+    expect(await specified(edge)).toBe(draggingGrip);
+    expect(draggingGrip).not.toBe("transparent");
+    // And the page wears the resize cursor, because the pointer has long since
+    // left the 30px zone it is still resizing from.
+    expect(await page.evaluate(() => document.body.style.cursor)).toBe("ns-resize");
+    expect(await page.evaluate(() => document.body.style.userSelect)).toBe("none");
     await page.mouse.up();
-    await expect
-      .poll(() => divider.getAttribute("aria-valuenow"))
-      .not.toBe(surfaceHeightBeforePlay);
+
+    const dragged = await heightOf();
+    expect(dragged).toBeGreaterThan(opened + 20);
+    // The body is handed back exactly what it had.
+    expect(await page.evaluate(() => document.body.style.cursor)).toBe("");
+
+    // ARROWS NUDGE IT, 8px a press, and UP shrinks — the key moves the edge,
+    // which is the thing under the hand, not the value the label names.
+    await divider.focus();
+    await page.keyboard.press("ArrowUp");
+    await expect.poll(heightOf).toBe(dragged - 8);
+    await page.keyboard.press("ArrowDown");
+    await expect.poll(heightOf).toBe(dragged);
+
+    // DOUBLE-CLICK RESETS, which is the only way back for someone who has
+    // dragged the pane somewhere useless.
+    await divider.dblclick({ position: { x: 200, y: 14 } });
+    await expect.poll(heightOf).not.toBe(dragged);
+    const reset = await heightOf();
+
+    // AND IT IS REMEMBERED PER PROJECT, across a full reload rather than just a
+    // pane toggle — the toggle keeps the component tree, so it would pass on
+    // nothing more than React state.
+    await divider.focus();
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await expect.poll(heightOf).toBe(reset + 16);
+    const chosen = await heightOf();
+
+    await page.reload();
+    // The pane's OPEN state is not persisted — only the split is — so it is
+    // reopened here rather than expected back. That is deliberate on both
+    // counts: which panes are showing is a per-visit decision, and how big they
+    // are once shown is a preference.
+    await previewToggle(page).click();
+    await expect(page.locator("[data-preview-settled]")).toHaveCount(1, { timeout: 15000 });
+    await expect.poll(heightOf).toBe(chosen);
   });
 
   test("preview surface is a pointer shortcut that activates the compact control", async ({
@@ -2891,10 +2888,14 @@ test.describe("graph view E2E", () => {
     const surface = page.getByTestId("workbench-display-surface");
     const canvas = page.getByTestId("workbench-display-canvas");
     const controls = page.getByTestId("workbench-preview-controls");
-    const primaryControl = controls.locator("[data-transport-primary-control]");
-    const primaryColor = () =>
-      primaryControl.evaluate((element) => getComputedStyle(element).color);
-    const restingColor = await primaryColor();
+    // THE HOVER FEEDBACK MOVED TO THE PICTURE (PL16-007). It used to be the
+    // play control inverting to a white disc; the spec makes that disc the
+    // RESTING state, so there is nothing left for it to invert to. What still
+    // answers a hover is the faint play mark over the frame, which is the
+    // better place for it anyway — it is where the pointer is.
+    const hint = page.getByTestId("workbench-hover-transport-hint");
+    const hintOpacity = () =>
+      hint.evaluate((element) => Number(getComputedStyle(element).opacity));
 
     await expect(canvas).toHaveAttribute("data-preview-playback-surface-ready", "true");
 
@@ -2917,7 +2918,7 @@ test.describe("graph view E2E", () => {
     expect(await canvas.evaluate((element) => getComputedStyle(element).cursor)).toBe(
       "default",
     );
-    await expect.poll(primaryColor).toBe(restingColor);
+    await expect.poll(hintOpacity).toBe(0);
     await canvas.click({ position: emptyGutter });
     await expect(surface).toHaveAttribute("data-preview-playing", "false");
 
@@ -2926,15 +2927,15 @@ test.describe("graph view E2E", () => {
     expect(await canvas.evaluate((element) => getComputedStyle(element).cursor)).toBe(
       "pointer",
     );
-    await expect(controls).toHaveAttribute("data-transport-layout", "static");
-    await expect.poll(primaryColor).not.toBe(restingColor);
+    await expect(controls).toHaveAttribute("data-transport-layout", "row");
+    await expect.poll(hintOpacity).toBeGreaterThan(0);
 
     await canvas.click({ position: playbackCenter });
     await expect(surface).toHaveAttribute("data-preview-playing", "true");
     await expect(
       page.getByRole("button", { name: "Pause workbench preview" }),
     ).toBeVisible();
-    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await expect(controls).toHaveAttribute("data-transport-layout", "row");
 
     await canvas.click({ position: playbackCenter });
     await expect(surface).toHaveAttribute("data-preview-playing", "false");
@@ -2943,7 +2944,7 @@ test.describe("graph view E2E", () => {
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Strip layout", exact: true }).hover();
-    await expect.poll(primaryColor).toBe(restingColor);
+    await expect.poll(hintOpacity).toBe(0);
   });
 
   test("preview audio: mute and volume survive a pane toggle", async ({ page }) => {
@@ -2960,18 +2961,21 @@ test.describe("graph view E2E", () => {
     await expect(surface).toHaveAttribute("data-preview-muted", "false");
     await expect(surface).toHaveAttribute("data-preview-volume", "1");
 
-    // THE SLIDER AND MUTE LIVE BEHIND THE ICON NOW (PL15-008): the divider
-    // carries one audio icon, and a press on it reveals the pair. Opening is
-    // part of the flow rather than setup noise — the state being pinned here
-    // is reached the way a user reaches it.
-    const audioToggle = page.getByTestId("workbench-preview-volume-toggle");
-    await audioToggle.click();
+    // ONE BUTTON, AND IT MUTES (PL16-007). It used to be an icon on the divider
+    // whose click opened a popover holding a mute button and the slider — a
+    // trade forced by there being nowhere beside it to put them. In the
+    // transport row there is room, so the slider expands on hover and the
+    // click goes back to being the mute.
+    const mute = page.getByTestId("workbench-preview-mute");
     const volume = page.getByTestId("workbench-preview-volume");
+    // THE SLIDER IS ALWAYS IN THE TREE, at zero width until reached for, so it
+    // keeps its place in the tab order and can be opened by keyboard.
     await expect(volume).toHaveValue("1");
 
-    await page.getByRole("button", { name: "Mute workbench preview" }).click();
+    await mute.click();
     await expect(surface).toHaveAttribute("data-preview-muted", "true");
     await expect(volume).toHaveValue("0");
+    await expect(mute).toHaveAccessibleName("Unmute workbench preview");
 
     // The whole reason audio state lives on the channel rather than in the
     // surface: closing the pane unmounts the surface, and the setting must not
@@ -2981,11 +2985,12 @@ test.describe("graph view E2E", () => {
     await previewToggle(page).click();
     await expect(surface).toHaveAttribute("data-preview-muted", "true");
 
-    // Reopened pane, reopened popover: the surface unmounted with the pane, so
-    // the reveal is closed again while the MUTE it was showing survived on the
-    // channel — which is the point of the round trip above.
-    await audioToggle.click();
-    await page.getByRole("button", { name: "Unmute workbench preview" }).click();
+    // AND THE ROUND TRIP LEFT THE CONTROL AGREEING WITH THE CHANNEL: a fresh
+    // surface mounted showing the mute that outlived it.
+    await expect(page.getByTestId("workbench-preview-mute")).toHaveAccessibleName(
+      "Unmute workbench preview",
+    );
+    await page.getByTestId("workbench-preview-mute").click();
     await expect(surface).toHaveAttribute("data-preview-muted", "false");
   });
 
@@ -3011,13 +3016,14 @@ test.describe("graph view E2E", () => {
 
     const controls = page.getByTestId("workbench-preview-controls");
     const buttonGroup = controls.locator("[data-transport-button-group]");
-    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await expect(controls).toHaveAttribute("data-transport-layout", "row");
     await expect
       .poll(() =>
         buttonGroup.evaluate((element) => Math.round(element.getBoundingClientRect().width)),
       )
-      // 5 × 44px wells, up from 3 — see the static-transport test above.
-      .toBe(220);
+      // 4 × 30px ghost wells + a 36px play disc + its 6px margins (PL16-007).
+      // It was 220 — five 44px wells — while the row rode the divider.
+      .toBe(168);
     await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
     // The whole point of this test is TOUCH reach, so the two new edge buttons
@@ -3044,7 +3050,7 @@ test.describe("graph view E2E", () => {
       "data-preview-playing",
       "true",
     );
-    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await expect(controls).toHaveAttribute("data-transport-layout", "row");
     await canvas.click({ position: playbackCenter });
     await expect(page.getByTestId("workbench-display-surface")).toHaveAttribute(
       "data-preview-playing",
@@ -3054,12 +3060,11 @@ test.describe("graph view E2E", () => {
     await page.getByRole("button", { name: "Play workbench preview" }).click();
     // The SAME width while playing — this is the "stays static" half of the
     // test: the transport must not resize or re-lay-out when playback starts.
-    // 5 × 44px wells, up from 3 with the two edge buttons.
     await expect
       .poll(() =>
         buttonGroup.evaluate((element) => Math.round(element.getBoundingClientRect().width)),
       )
-      .toBe(220);
+      .toBe(168);
     await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
     await expect(
@@ -3072,7 +3077,7 @@ test.describe("graph view E2E", () => {
     await page.getByTestId("workbench-display-canvas").click({
       position: playbackCenter,
     });
-    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await expect(controls).toHaveAttribute("data-transport-layout", "row");
   });
 
   test("strip seek rail auto-pans at the scroller's edge while scrubbing", async ({
@@ -3389,10 +3394,14 @@ test.describe("graph view E2E", () => {
 
     // Seconds off the transport's readout. It renders the value twice (a
     // visible span and a screen-reader one), so the FIRST match is the clock.
+    // `m:ss.d / m:ss.d` since PL16-007 — it used to read `4.25s / 25.3s`. Only
+    // the ELAPSED half is parsed: the duration is the same shape and a looser
+    // pattern would happily read the wrong one.
     const clock = async () => {
       const text = (await page.getByTestId("workbench-preview-time").textContent()) ?? "";
-      const match = text.match(/([\d.]+)\s*s/);
-      return match === null ? Number.NaN : Number(match[1]);
+      const match = text.match(/^\s*(\d+):(\d\d)\.(\d)/);
+      if (match === null) return Number.NaN;
+      return Number(match[1]) * 60 + Number(match[2]) + Number(match[3]) / 10;
     };
     const cue = (id: string) => page.locator(`[data-grid-cue="${id}"]`);
     const play = (id: string) => page.locator(`[data-grid-play="${id}"]`);

--- a/packages/ui/timeline/utils.test.ts
+++ b/packages/ui/timeline/utils.test.ts
@@ -1,11 +1,35 @@
 import { describe, expect, it } from "vitest";
 
-import { clamp, getSourceTimeFromClientX, getTrimHandleSourceTime } from "./utils";
+import {
+  clamp,
+  formatTimecode,
+  getSourceTimeFromClientX,
+  getTrimHandleSourceTime,
+} from "./utils";
 
 describe("timeline utilities", () => {
   it("clamps values to a range", () => {
     expect(clamp(-1, 0, 10)).toBe(0);
     expect(clamp(12, 0, 10)).toBe(10);
+  });
+
+  it("writes a playhead's time as m:ss.d", () => {
+    // The spec's own worked example.
+    expect(formatTimecode(71.1)).toBe("1:11.1");
+    // Under a minute still carries the minute, so the column never shifts.
+    expect(formatTimecode(0)).toBe("0:00.0");
+    expect(formatTimecode(4.25)).toBe("0:04.2");
+    // Seconds are zero-padded and minutes are not — 9 and 10 must not change
+    // the width of the seconds field.
+    expect(formatTimecode(59.9)).toBe("0:59.9");
+    expect(formatTimecode(60)).toBe("1:00.0");
+    // FLOORED. 9.99 is not yet 10, and a clock that said so would read as
+    // past a cut it is parked on.
+    expect(formatTimecode(9.99)).toBe("0:09.9");
+    // Nothing sensible to say gets the resting value rather than "NaN:aN.N".
+    expect(formatTimecode(-3)).toBe("0:00.0");
+    expect(formatTimecode(Number.NaN)).toBe("0:00.0");
+    expect(formatTimecode(Number.POSITIVE_INFINITY)).toBe("0:00.0");
   });
 
   it("maps browser coordinates into source time", () => {

--- a/packages/ui/timeline/utils.ts
+++ b/packages/ui/timeline/utils.ts
@@ -48,6 +48,42 @@ export function formatSeconds(value: number) {
   return `${value.toFixed(1)}s`;
 }
 
+/**
+ * A PLAYHEAD'S TIME, as `m:ss.d` — 71.1s reads as `1:11.1`.
+ *
+ * NOT `formatSeconds`, and not a replacement for it. That one labels a
+ * DURATION on a card ("4.25s", "0s"), where the unit is the point and the
+ * value stands alone. This is a POSITION on a clock, read against another
+ * position, where what matters is that the digits line up and that the last
+ * one moves visibly under a dragging hand.
+ *
+ * TENTHS: frames would flicker faster than anyone can read, and hundredths
+ * are two columns of noise. One place after the point changes about as fast
+ * as the eye can follow it.
+ *
+ * ONE DEFINITION, deliberately, because the transport's readout and the
+ * scrubber's hover tooltip both spend it and the spec's acceptance is that
+ * they always agree. Two copies of this would agree until one of them was
+ * rounded differently.
+ */
+export function formatTimecode(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  // QUANTISE FIRST, then split. Subtracting the minutes off in seconds and
+  // flooring what is left is the obvious way to write this and it is wrong:
+  // 71.1 - 60 is 11.099999999999994 in binary floating point, so the tenth
+  // floors to 0 and the spec's own worked example renders `1:11.0`.
+  //
+  // FLOOR, not round, because a clock that rounds shows the next tenth before
+  // it has arrived — a playhead parked exactly on a cut would read as past it.
+  // The epsilon is 100 nanoseconds: far below anything a frame can express, and
+  // enough to absorb the representation error that made 71.1 land just under.
+  const tenths = Math.floor(safe * 10 + 1e-6);
+  const minutes = Math.floor(tenths / 600);
+  const whole = Math.floor(tenths / 10) % 60;
+  const tenth = tenths % 10;
+  return `${minutes}:${whole < 10 ? "0" : ""}${whole}.${tenth}`;
+}
+
 export function getTrimHandleSourceTime(clip: TimelineClip, edge: "left" | "right") {
   const frameEpsilon = Math.min(1 / 60, clip.sourceDuration / 200);
   const sourceOutTime = clip.trimIn + clip.duration;

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -118,64 +118,46 @@ export const StickyPreview: Story = {
       canvasElement.querySelectorAll("[data-preview-edge-occluder]"),
     ).toHaveLength(2);
     expect(getComputedStyle(displaySurface).borderBottomWidth).toBe("0px");
-    expect(getComputedStyle(controls).position).toBe("absolute");
+    // IN FLOW UNDER THE PICTURE (PL16-007). It used to be `absolute` at
+    // `top-full`, riding the divider, with the divider's band carrying a
+    // hand-written gradient window punched through it so no line ran behind the
+    // transport's glyphs. The spec replaces all of that: one bright horizontal
+    // line below the picture (the scrubber), and a divider that is the pane's
+    // own edge rather than a shelf.
+    expect(getComputedStyle(controls).position).toBe("static");
     expect(controls.parentElement).toBe(displaySurface);
+    expect(controls).toHaveAttribute("data-transport-layout", "row");
     const buttonGroup = controls.querySelector<HTMLElement>("[data-transport-button-group]");
-    const dividerLine = divider.querySelector<HTMLElement>("[data-divider-line]");
     expect(buttonGroup).not.toBeNull();
-    expect(dividerLine).not.toBeNull();
     const buttonGroupBox = buttonGroup!.getBoundingClientRect();
     const dividerBox = divider.getBoundingClientRect();
-    const dividerLineBox = dividerLine!.getBoundingClientRect();
-    expect(getComputedStyle(dividerLine!).backgroundImage).toContain("linear-gradient");
-    // 5 × the 44px button well: jump-to-start, previous, play, next,
-    // jump-to-end. It was 132 (three wells) before the two edge buttons were
-    // added, and the number is pinned rather than derived because the time
-    // readout budgets its own max-width against half of it — the two have to
-    // be changed together, and a hard number is what makes that fail loudly.
-    expect(buttonGroupBox.width).toBe(220);
-    expect(buttonGroupBox.height).toBe(44);
-    // THE BAND'S CLEAR WINDOW IS HALF THAT WIDTH, either side of centre.
-    //
-    // The gradient breaks the divider so no line runs behind the transport's
-    // background-free glyphs. Its stops are hand-written and cannot read the
-    // sibling's width, so adding the two outer buttons widened the group to
-    // five wells and left the window at three — the jump-to-start and
-    // jump-to-end glyphs sat in the fade with the line still showing through.
-    // The assertion above was updated to 220 at the time; this one did not
-    // exist, so nothing caught it.
-    //
-    // Read off the COMPUTED gradient, which resolves the rem stops to pixels,
-    // so the check is against the group's real width rather than against the
-    // literal that produced it.
-    const bandGradient = getComputedStyle(dividerLine!).backgroundImage;
-    const clearHalf = buttonGroupBox.width / 2;
-    expect(bandGradient).toContain(`${clearHalf}px`);
+    // THE OLD BAND IS GONE, not restyled.
+    expect(divider.querySelector("[data-divider-line]")).toBeNull();
+    // Four 30px ghost wells, a 36px play disc, and its 6px side margins. Pinned
+    // rather than derived: it is the number the row's centre column is, and a
+    // hard value is what makes a change to the control set fail loudly.
+    expect(Math.round(buttonGroupBox.width)).toBe(168);
+    expect(Math.round(buttonGroupBox.height)).toBe(36);
     expect(controls.querySelector("[data-transport-capsule]")).toBeNull();
-    // The grip is the coarse-pointer affordance — always in the DOM, painted
-    // only at tablet width and below (md:hidden), so presence is what this
-    // story can assert without pinning the canvas width.
-    expect(divider.querySelector("[data-divider-grip]")).not.toBeNull();
-    // The box is the hit target and stays 44 at every breakpoint. The visible
-    // band is smaller and CENTERED on one fixed mid-line, so its height can
-    // change (8 desktop / 12 coarse-pointer) without moving anything.
-    expect(dividerBox.height).toBe(44);
-    expect(dividerLineBox.height).toBeLessThan(dividerBox.height);
-    expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(dividerBox.y + 24, 0);
-    // The band sits BELOW centre on purpose: more clearance above it than
-    // below. The transport is centred on the same line and overhangs the band
-    // far enough to crowd the preview above more than the timeline below, so
-    // an even split still read bottom-heavy. Asserted as an inequality rather
-    // than a number, so it survives a retune of the exact gap.
-    const above = dividerLineBox.y - dividerBox.y;
-    const below = dividerBox.y + dividerBox.height - (dividerLineBox.y + dividerLineBox.height);
-    expect(above).toBeGreaterThan(below);
-    // The transport centers on the BAND, not on the padded box.
-    expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(
-      buttonGroupBox.y + buttonGroupBox.height / 2,
-      0,
-    );
-    expect(controls).toHaveAttribute("data-transport-layout", "static");
+    // 22px: the spec's 8px gap under the row, then the pane's 14px lip.
+    expect(Math.round(dividerBox.height)).toBe(22);
+    // THE GRIP IS THE RESTING AFFORDANCE now — a 40x4 pill, painted at every
+    // width. It used to be a coarse-pointer-only mark, hidden at desktop.
+    const grip = divider.querySelector<HTMLElement>("[data-divider-grip]");
+    expect(grip).not.toBeNull();
+    const gripBox = grip!.getBoundingClientRect();
+    expect(Math.round(gripBox.width)).toBe(40);
+    expect(Math.round(gripBox.height)).toBe(4);
+    // A PILL, NOT A RULE — the distinction the redesign turns on.
+    expect(gripBox.width).toBeLessThan(dividerBox.width / 4);
+    // THE HIT TARGET STRADDLES THE EDGE: it reaches 8px past the box into the
+    // pane below, and deliberately not upward, where the controls row is.
+    const zone = divider.querySelector<HTMLElement>("[data-divider-zone]");
+    expect(zone).not.toBeNull();
+    const zoneBox = zone!.getBoundingClientRect();
+    expect(Math.round(zoneBox.height)).toBe(30);
+    expect(Math.round(zoneBox.top)).toBe(Math.round(dividerBox.top));
+
     expect(
       canvas.getByRole("button", { name: "Previous workbench clip" }),
     ).toBeVisible();
@@ -192,13 +174,14 @@ export const StickyPreview: Story = {
     const x = (el: HTMLElement) => el.getBoundingClientRect().x;
     expect(x(jumpStart)).toBeLessThan(x(canvas.getByRole("button", { name: "Previous workbench clip" })));
     expect(x(jumpEnd)).toBeGreaterThan(x(canvas.getByRole("button", { name: "Next workbench clip" })));
-    // Both live inside the button group, so the divider-drag guard on it (a
-    // transport press must never begin a resize) covers them too.
     expect(buttonGroup!.contains(jumpStart)).toBe(true);
     expect(buttonGroup!.contains(jumpEnd)).toBe(true);
 
-    expect(canvas.getByTestId("workbench-preview-time")).toHaveTextContent("0s / 0s");
-    expect(previewCanvas.getBoundingClientRect().bottom).toBeCloseTo(dividerBox.y, 0);
+    // `m:ss.d`, since PL16-007 — it used to read `0s / 0s`.
+    expect(canvas.getByTestId("workbench-preview-time")).toHaveTextContent("0:00.0 / 0:00.0");
+    // The picture no longer runs to the divider: the scrubber and the controls
+    // row sit between them, on chrome, which is the spec's whole premise.
+    expect(previewCanvas.getBoundingClientRect().bottom).toBeLessThan(dividerBox.y);
     expect(getComputedStyle(lowerPane).zIndex).toBe("0");
   },
 };
@@ -379,16 +362,17 @@ export const ControlledPlayback: Story = {
 
     // Starts paused → the surface offers "Play".
     expect(canvas.getByRole("button", { name: "Play workbench preview" })).toBeInTheDocument();
-    expect(controls).toHaveAttribute("data-transport-layout", "static");
+    expect(controls).toHaveAttribute("data-transport-layout", "row");
     expect(
       canvas.getByRole("button", { name: "Previous workbench clip" }),
     ).toBeVisible();
     expect(canvas.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
     expect(previewCanvas).not.toHaveAttribute("tabindex");
 
-    // RESTING: background-free, so the mark reads straight off the divider.
-    expect(getComputedStyle(primaryControl!).backgroundColor).toBe("rgba(0, 0, 0, 0)");
-    const restingColor = getComputedStyle(primaryControl!).color;
+    // WHITE AT REST (PL16-007). It used to be background-free and invert to a
+    // white disc on hover; the spec makes the disc the resting state, because
+    // play is the one control in this row you look for without hunting.
+    expect(getComputedStyle(primaryControl!).backgroundColor).toBe("rgb(255, 255, 255)");
 
     const previewBounds = previewCanvas.getBoundingClientRect();
     await user.pointer({
@@ -399,21 +383,17 @@ export const ControlledPlayback: Story = {
       },
     });
     expect(getComputedStyle(previewCanvas).cursor).toBe("pointer");
-    // ACTIVE: the control INVERTS — solid white disc, mark punched black out
-    // of it — rather than just brightening the glyph.
-    // POLLED, not read once: the control carries `transition-colors`, so an
-    // immediate getComputedStyle returns a value part-way through the fade —
-    // which read as "still transparent" and looked exactly like the class not
-    // applying at all.
-    await waitFor(() =>
-      expect(getComputedStyle(primaryControl!).backgroundColor).toBe("rgb(255, 255, 255)"),
-    );
-    // The glyph color is not pinned to a literal: the token serializes as
-    // oklch, and which color space a browser reports is not what this story is
-    // about. What matters is that it left the resting zinc for the dark mark
-    // the new white disc needs.
-    expect(getComputedStyle(primaryControl!).color).not.toBe(restingColor);
-    expect(controls).toHaveAttribute("data-transport-layout", "static");
+    // THE HOVER FEEDBACK MOVED TO THE PICTURE. With the play control white at
+    // rest there is nothing left for it to invert to, so what answers a hover
+    // is the faint play mark over the frame — which is where the pointer is,
+    // and so the better place for it.
+    //
+    // POLLED, not read once: the hint carries a transition, and an immediate
+    // read returns the value it is fading FROM, which is indistinguishable from
+    // a rule that never applied.
+    const hint = canvas.getByTestId("workbench-hover-transport-hint");
+    await waitFor(() => expect(Number(getComputedStyle(hint).opacity)).toBeGreaterThan(0));
+    expect(controls).toHaveAttribute("data-transport-layout", "row");
     await user.unhover(previewCanvas);
 
     // Flip the controlled prop from OUTSIDE the surface; it re-renders as
@@ -423,30 +403,28 @@ export const ControlledPlayback: Story = {
     expect(
       await canvas.findByRole("button", { name: "Pause workbench preview" }),
     ).toBeInTheDocument();
+    // `m:ss.d` since PL16-007 — `0:00.0 / 0:30.0` rather than `0s / 30.0s`.
     expect(canvas.getByTestId("workbench-preview-time")).toHaveTextContent(
-      /0(?:\.\d+)?s \/ 30\.0s/,
+      /^0:00\.\d \/ 0:30\.0$/,
     );
 
-    // Tab order follows the DOM: the audio control sits on the divider before
-    // the transport, so it comes first. Walk past it and the transport is
-    // still reachable, which is what this ever asserted.
+    // TAB ORDER FOLLOWS THE ROW, left to right: the mute button is the row's
+    // first column, then its slider, then the transport cluster.
     //
-    // ONE STOP, NOT TWO (PL15-008). It used to be mute then the slider, both
-    // permanently in the picture. They are behind the icon now, so a keyboard
-    // user walking the view passes ONE audio control rather than two — and the
-    // pair below proves they are still reachable once it is opened, which is
-    // the half that would otherwise be lost silently.
+    // THE SLIDER IS A REAL STOP AGAIN (PL16-007), and that is the point of
+    // asserting it. It used to hide inside a popover, so a keyboard user
+    // walking the view passed one control and had to know to open it; it now
+    // lives at zero width in the tree and `focus-within` opens it, so tabbing
+    // reaches the level without a press.
     await user.tab();
-    const audioToggle = canvas.getByTestId("workbench-preview-volume-toggle");
-    expect(audioToggle).toHaveFocus();
+    const mute = canvas.getByTestId("workbench-preview-mute");
+    expect(mute).toHaveFocus();
+    await user.tab();
+    expect(canvas.getByTestId("workbench-preview-volume")).toHaveFocus();
     await user.tab();
     expect(controls.contains(document.activeElement)).toBe(true);
 
-    // Opened, the mute button and the slider are both reachable from the icon.
-    await user.click(audioToggle);
-    expect(canvas.getByTestId("workbench-preview-mute")).toBeInTheDocument();
-    expect(canvas.getByTestId("workbench-preview-volume")).toBeInTheDocument();
-    expect(controls).toHaveAttribute("data-transport-layout", "static");
+    expect(controls).toHaveAttribute("data-transport-layout", "row");
   },
 };
 
@@ -496,10 +474,11 @@ export const ControlledAudio: Story = {
     expect(surface).toHaveAttribute("data-preview-volume", "1");
     expect(canvas.getByTestId("audio-readout")).toHaveTextContent("volume=1 muted=false");
 
-    // The divider carries an audio ICON; mute and the slider are behind it
-    // (PL15-008), so opening it is the first step of the flow now.
-    await user.click(canvas.getByRole("button", { name: "Preview audio" }));
-
+    // ONE BUTTON, AND IT MUTES (PL16-007). The divider used to carry an audio
+    // icon whose click opened a popover holding a mute button and the slider,
+    // because there was nowhere beside it to put them. In the transport row
+    // there is: the slider expands on hover, and the click is the mute again —
+    // so there is no step before this one any more.
     const mute = canvas.getByRole("button", { name: "Mute workbench preview" });
     expect(mute).toHaveAttribute("aria-pressed", "false");
 

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -3,7 +3,6 @@
 import {
   ChevronFirst,
   ChevronLast,
-  GripHorizontal,
   Pause,
   Play,
   SkipBack,
@@ -21,6 +20,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
@@ -38,7 +38,7 @@ import {
   type LayerFrame,
 } from "@storyboard/timeline-model/layer-frame";
 import type { CollectionTimelineClip, TimelineClip } from "../types";
-import { formatSeconds } from "../utils";
+import { formatTimecode } from "../utils";
 import {
   clipContainsPlaybackTime,
   clipToPreroll,
@@ -228,36 +228,45 @@ const PREROLL_LEAD_SECONDS = 1;
 const DEFAULT_SURFACE_HEIGHT = 380;
 const MIN_SURFACE_HEIGHT = 120;
 const MIN_TIMELINE_SPACE = 260;
-/** The divider button's full height — the DRAG HIT TARGET, and what
- *  `--workbench-preview-offset` is built from. Constant at every breakpoint
- *  (Tailwind h-7), so the band inside it can change height without moving the
- *  preview, the transport, or anything sticking below.
+/**
+ * THE DIVIDER'S HEIGHT IN FLOW, and what `--workbench-preview-offset` is built
+ * from, so anything pinned below the sticky stack follows it.
  *
- *  44 rather than 16: the band needs clear space on BOTH sides of it, and at
- *  16 with the mid-line at 10 it had 10 above and 6 below — the surface and
- *  the timeline crowded it from either side.
+ * 22, DOWN FROM 44. It used to be a well tall enough to hold the transport,
+ * which rode on it; the transport is a row of its own now, so this is back to
+ * the size of the thing it actually draws — the spec's 8px gap under the
+ * controls row, then the pane's 14px lip.
  *
- *  It is also the drag hit target, and a taller one is strictly easier to
- *  grab — there is no cost here to spend against. */
-const DIVIDER_HEIGHT_PX = 44;
+ * IT IS NO LONGER THE HIT TARGET. The zone inside it reaches 8px further down,
+ * into the pane below, for the 30px the spec asks for. It deliberately does not
+ * reach UP: 8px above this box is the controls row, and a resize that starts on
+ * a button is what the old arrangement needed a `stopPropagation` on every
+ * control to prevent.
+ */
+const DIVIDER_HEIGHT_PX = 22;
 
+/** The gap between the controls row and the pane's lip, and therefore where the
+ *  lip — and the edge line drawn along its top — begins inside the box. */
+const DIVIDER_LIP_TOP_PX = 8;
 
-/** Where the visible band's mid-line falls inside that box. The band is
- *  CENTERED on this line at every breakpoint rather than sized from the top,
- *  which is what lets it be 8px on desktop and 12px on coarse-pointer widths
- *  (where it hosts the grip) without the transport shifting. The transport is
- *  centered on the same line and may overhang the band freely.
- *
- *  DELIBERATELY BELOW CENTRE — 24 in a 44 box, so the band gets 20 clear above
- *  and 16 below. Optical, not arithmetic: the transport (h-11) is centred on
- *  this same line and overhangs the band by more than the clearance either
- *  side, so it crowds the preview above more than it crowds the timeline
- *  below, and a mathematically even 22/22 still read bottom-heavy. It is a
- *  constant rather than a fraction of the height for exactly that reason —
- *  the right value is judged, not derived. */
-const DIVIDER_BAND_CENTER_PX = 24;
+/** How far the invisible zone reaches PAST the box, into the pane below. 8 + 22
+ *  is the spec's ~30px target, straddling the edge so a pointer aimed at the
+ *  gap between the panes still catches it. */
+const DIVIDER_ZONE_OVERHANG_PX = 8;
 
-type WorkbenchDividerTransportProps = {
+/** One arrow press. Big enough to be worth pressing, small enough to place an
+ *  edge with. */
+const DIVIDER_NUDGE_PX = 8;
+
+/** The accent the grip and the edge line both take while the split is being
+ *  dragged. ONE constant so the two cannot drift apart mid-gesture, and
+ *  `sky-400` — the accent this file's focus rings already use — rather than the
+ *  spec's `#4d8dfa`, which the spec itself says to reconcile with whatever the
+ *  app's accent actually is. Spelled out rather than named as a class because
+ *  these two are styled inline; see the note on the edge. */
+const DIVIDER_ACCENT = "oklch(0.746 0.16 232.661)";
+
+type WorkbenchTransportRowProps = {
   currentTime: number;
   duration: number;
   isPlaying: boolean;
@@ -268,12 +277,18 @@ type WorkbenchDividerTransportProps = {
    *  distinct from the clip-to-clip pair above, which step between clips. */
   canSeekStart: boolean;
   canSeekEnd: boolean;
-  previewHovered: boolean;
   onTogglePlaying: () => void;
   onSeekPrevious: () => void;
   onSeekNext: () => void;
   onSeekStart: () => void;
   onSeekEnd: () => void;
+  /** The row's LEFT column, passed in rather than rendered here.
+   *
+   *  The volume control is the only thing in this row that owns state, and the
+   *  state it owns belongs to the surface (the mixer, the blocked-audio flag).
+   *  Handing it in as a node keeps the row itself a pure arrangement of three
+   *  columns — which is the one thing it has to get right. */
+  volume: ReactNode;
 };
 
 type WorkbenchAudioControlsProps = {
@@ -286,36 +301,33 @@ type WorkbenchAudioControlsProps = {
   audioBlocked: boolean;
 };
 
+/** The two secondary shapes in the row: a 30px ghost square with an 8px
+ *  radius, dimmed until aimed at. One constant because there are seven of them
+ *  and a row whose buttons differ by a pixel reads as a row that was assembled
+ *  rather than laid out. */
+const TRANSPORT_GHOST_BUTTON =
+  "grid size-[30px] shrink-0 place-items-center rounded-lg text-white/70 transition-colors hover:bg-white/[0.09] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent";
+
 /**
- * Volume: an icon on the DIVIDER, and a slider it reveals.
+ * VOLUME: a mute button that GROWS A SLIDER when it is aimed at (PL16-007).
  *
- * IT USED TO LIVE INSIDE THE PREVIEW, and the comment here said why: "The
- * divider is a resize handle first: its whole band is the drag target, and
- * parking a button at its left end quietly shrank that target — the e2e that
- * hovers the divider at x=20 caught it immediately."
+ * IT USED TO BE A CLICK-OPENED POPOVER ON THE DIVIDER, and the note here
+ * explained the trade that forced it: the icon's click was spent opening the
+ * slider, so mute had to move inside the popover as a second button, because
+ * "drag to zero and drag back to a level you have to remember" is not a
+ * replacement for one press.
  *
- * That objection was against a button AND a 64px slider sitting there
- * permanently. What sits there now is one 28px icon, and the slider only
- * exists while it is open — so the band it costs is the left 36px of a divider
- * that runs the full width. The two e2e hover points moved off that end with
- * this change, which is only honest because of that measurement: the drag
- * target is still everything but its first 36 pixels.
+ * THE ROW DISSOLVES THAT TRADE. With the control in flow there is room beside
+ * it, so the slider can arrive on HOVER and the click is free again: the button
+ * is the mute, and the level is one pointer-move away. Nothing is nested, so
+ * there is no popover to dismiss, no outside-press listener, and no Escape
+ * handler racing whatever else in the view treats Escape as "close me".
  *
- * THE ISLAND PATTERN IS THE TRANSPORT'S, not a new one. The wrapper is
- * `pointer-events-none` so the divider keeps every pixel it is not actually
- * covering, the control itself is `pointer-events-auto`, and a pointer press
- * on it stops propagating — a press on the audio control must never begin a
- * resize, exactly as a transport press must not.
- *
- * CLICK OPENS THE SLIDER; MUTE MOVES INSIDE IT. Click used to mute, and the
- * plain reading of "click the icon and you get the slider" would have left
- * mute as "drag to zero and drag back to a level you have to remember" —
- * losing a one-press action to gain a reveal. So the popover carries a mute
- * button beside the slider: mute costs one extra press rather than a gesture
- * and a memory, and the icon still SHOWS the silent state whether or not the
- * popover is open.
+ * IT NO LONGER STEALS FROM A DRAG TARGET EITHER. The old objection -- a button
+ * on the divider quietly shrinks the resize handle -- was about the divider,
+ * and this is not on it any more.
  */
-function WorkbenchAudioControls({
+function WorkbenchVolumeControl({
   volume,
   muted,
   onToggleMuted,
@@ -323,106 +335,76 @@ function WorkbenchAudioControls({
   audioBlocked,
 }: WorkbenchAudioControlsProps) {
   const silent = muted || volume <= 0;
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-
-  // DISMISS ON A PRESS OUTSIDE, AND ON ESCAPE — with one owner, so there is no
-  // question which of them closed it. `pointerdown` rather than `click`: the
-  // click that opens the popover is still in flight when the listener is
-  // attached, and listening for clicks would close it in the same gesture.
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (event: PointerEvent) => {
-      if (rootRef.current?.contains(event.target as Node)) return;
-      setOpen(false);
-    };
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      // Stopped, or Escape reaches whatever else in the view treats it as
-      // "close me" and two things answer one press.
-      event.stopPropagation();
-      setOpen(false);
-    };
-    document.addEventListener("pointerdown", onDown);
-    document.addEventListener("keydown", onKey, true);
-    return () => {
-      document.removeEventListener("pointerdown", onDown);
-      document.removeEventListener("keydown", onKey, true);
-    };
-  }, [open]);
-
   return (
-    <div
-      className="pointer-events-none absolute inset-x-0 top-full z-50 h-0"
-      data-testid="workbench-preview-audio"
-    >
-      <div
-        ref={rootRef}
-        className="pointer-events-auto absolute left-2 flex items-center"
-        style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
-        onPointerDown={(event) => {
-          // The audio control visually occupies the divider and is its own
-          // interaction island — a press here must never begin a resize.
-          event.stopPropagation();
-        }}
+    <div className="group/volume flex items-center" data-testid="workbench-preview-audio">
+      <button
+        type="button"
+        onClick={onToggleMuted}
+        className={TRANSPORT_GHOST_BUTTON}
+        aria-label={silent ? "Unmute workbench preview" : "Mute workbench preview"}
+        aria-pressed={silent}
+        title={audioBlocked ? "Click to enable sound" : silent ? "Unmute" : "Mute"}
+        data-testid="workbench-preview-mute"
+        data-audio-blocked={audioBlocked || undefined}
       >
-        <button
-          type="button"
-          onClick={() => setOpen((was) => !was)}
-          className="grid size-7 shrink-0 place-items-center rounded-full text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-          // NOT "Workbench preview volume" — that name belongs to the SLIDER,
-          // and it has had it since before this control existed. Handing it to
-          // the trigger would have made an accessible-name lookup ambiguous the
-          // moment the popover opened, and silently changed which element every
-          // existing `getByRole("slider", { name: … })` resolves to.
-          aria-label="Preview audio"
-          aria-expanded={open}
-          title={audioBlocked ? "Click to enable sound" : "Volume"}
-          data-testid="workbench-preview-volume-toggle"
-          data-audio-blocked={audioBlocked || undefined}
-        >
-          {silent ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
-        </button>
-
-        {open && (
-          <div
-            className="ml-1 flex items-center gap-2 rounded-full bg-zinc-950/90 px-2 py-1 shadow-lg ring-1 ring-white/15 backdrop-blur-sm"
-            data-testid="workbench-preview-volume-popover"
-          >
-            {/* MUTE, which the icon outside used to carry on its own click.
-                Kept as a press rather than folded into the slider's zero end:
-                muting and restoring is one action, and a drag to zero followed
-                by a drag back to a level you have to remember is not. */}
-            <button
-              type="button"
-              onClick={onToggleMuted}
-              className="grid size-6 shrink-0 place-items-center rounded-full text-zinc-300 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-              aria-label={silent ? "Unmute workbench preview" : "Mute workbench preview"}
-              aria-pressed={silent}
-              title={silent ? "Unmute" : "Mute"}
-              data-testid="workbench-preview-mute"
-            >
-              {silent ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
-            </button>
-            <input
-              type="range"
-              min={0}
-              max={1}
-              step={0.01}
-              value={muted ? 0 : volume}
-              onChange={(event) => onVolumeChange(Number(event.target.value))}
-              className="h-1 w-16 cursor-pointer appearance-none rounded-full bg-zinc-700 accent-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-              aria-label="Workbench preview volume"
-              data-testid="workbench-preview-volume"
-            />
-          </div>
-        )}
+        {silent ? <VolumeX className="size-[17px]" /> : <Volume2 className="size-[17px]" />}
+      </button>
+      {/* WIDTH, not display or mounting. The slider stays in the tree at zero
+          width so it keeps its place in the tab order and can be reached by
+          keyboard -- `focus-within` is what opens it -- and so the expansion is
+          something to animate rather than a mount. `overflow-hidden` is what
+          makes a zero-width box actually hide a 64px child. */}
+      <div
+        className="w-0 overflow-hidden opacity-0 transition-[width,opacity] duration-[180ms] ease-out group-hover/volume:w-[70px] group-hover/volume:opacity-100 group-focus-within/volume:w-[70px] group-focus-within/volume:opacity-100 motion-reduce:transition-none"
+        data-testid="workbench-preview-volume-well"
+      >
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={muted ? 0 : volume}
+          onChange={(event) => onVolumeChange(Number(event.target.value))}
+          className="ml-1.5 h-[3px] w-16 cursor-pointer appearance-none rounded-full bg-white/20 accent-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          // NOT renamed. This name has belonged to the SLIDER since before the
+          // popover existed, and every `getByRole("slider", { name })` in the
+          // suite resolves through it.
+          aria-label="Workbench preview volume"
+          data-testid="workbench-preview-volume"
+        />
       </div>
     </div>
   );
 }
 
-function WorkbenchDividerTransport({
+/**
+ * THE TRANSPORT ROW (PL16-007, to the transport-bar spec).
+ *
+ * IT USED TO HANG OFF THE SURFACE AND RIDE THE DIVIDER -- `absolute top-full`,
+ * every child positioned against the divider band's mid-line, with the band
+ * itself carrying a gradient window punched through it so no line ran behind
+ * the glyphs. That arrangement put THREE horizontal lines below the picture
+ * competing for the same job, and made the divider two things at once: a resize
+ * handle and a shelf for controls, so every button on it needed a
+ * `stopPropagation` to keep a press from starting a drag.
+ *
+ * NOW IT IS A ROW IN FLOW, and both problems go away rather than get managed.
+ * There is no overlap to punch a hole for and no drag to suppress, so the
+ * divider is free to become the bin's own edge and nothing else.
+ *
+ * A THREE-COLUMN GRID, `1fr auto 1fr`, so the transport cluster is OPTICALLY
+ * CENTRED ON THE PICTURE regardless of what sits either side of it. A flex row
+ * with `justify-between` would centre the cluster on the leftovers instead, and
+ * would shift it every time the timecode's width changed -- which it does, on
+ * the tenth, ten times a second.
+ *
+ * THE INNER PAIR STEPS CLIPS, NOT FRAMES. The spec's prototype labels them
+ * frame-back and frame-forward, but frame stepping already exists here, on the
+ * scrubber's arrow keys, and these two are wired to `seekToClip`: moving
+ * between shots, which is what this view is for. Making them frames would
+ * duplicate the keyboard and delete the only pointer route to the next cut.
+ */
+function WorkbenchTransportRow({
   currentTime,
   duration,
   isPlaying,
@@ -431,145 +413,114 @@ function WorkbenchDividerTransport({
   canSeekNext,
   canSeekStart,
   canSeekEnd,
-  previewHovered,
   onTogglePlaying,
   onSeekPrevious,
   onSeekNext,
   onSeekStart,
   onSeekEnd,
-}: WorkbenchDividerTransportProps) {
+  volume,
+}: WorkbenchTransportRowProps) {
   return (
     <div
       role="group"
       aria-label="Preview transport"
-      className="pointer-events-none absolute inset-x-0 top-full z-50 h-0 transition-opacity duration-300 ease-out [[data-preview-chrome='out']_&]:opacity-0 motion-reduce:transition-none"
+      // 44px TALL AND IN FLOW. The picture above is `flex-1`, so this row's
+      // height comes out of the PICTURE rather than off the surface's bottom
+      // edge -- the pane the user sized stays the size they made it.
+      //
+      // The fade is unchanged from the overlay's, and is now free: a row that
+      // fades in flow leaves its own space behind, so nothing below it reflows
+      // as the chrome arrives.
+      className="grid h-11 w-full shrink-0 grid-cols-[1fr_auto_1fr] items-center px-[14px] transition-opacity duration-300 ease-out [[data-preview-chrome='out']_&]:opacity-0 motion-reduce:transition-none"
       data-testid="workbench-preview-controls"
-      data-transport-layout="static"
+      data-transport-layout="row"
     >
-      {/* FIVE controls now, so 13.75rem — the width is 5 × the 44px button
-          well (size-11) and has to be kept in step with the count, since the
-          time readout to the right budgets its own width against half of it. */}
-      <div
-        className="pointer-events-auto absolute left-1/2 flex h-11 w-[13.75rem] items-center justify-center"
-        data-transport-button-group
-        style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translate(-50%, -50%)" }}
-        onPointerDown={(event) => {
-          // The transport visually occupies the divider, but remains its own
-          // interaction island. A transport press must never begin a resize.
-          event.stopPropagation();
-        }}
-      >
-        {/* THE ENDS, outside the clip-steppers. The pairing is deliberate:
-            reading outwards from the play button you get "one clip back" then
-            "all the way back", which is the order every transport in every
-            editor uses. Putting them inside would have made the two arrow
-            pairs read as one four-way stepper.
+      <div className="flex min-w-0 items-center justify-self-start">{volume}</div>
 
-            `translate-x-4` against the steppers' `2` is what makes the row
-            EVENLY spaced, and the number is not free. Each button is a 44px
-            well, so a glyph's position is its well's centre plus its nudge:
-            22+16, 66+8, 110, 154−8, 198−16 → 38, 74, 110, 146, 182. Four gaps
-            of 36px.
-
-            It was `3`, which put the outer glyphs at 34 and 186 — gaps of
-            40, 36, 36, 40. Only 4px, and it read exactly as what it was: the
-            new pair pushed out too far, the cluster reading as a control with
-            two satellites rather than one row. */}
+      <div className="flex items-center justify-self-center" data-transport-button-group>
+        {/* THE ENDS OUTSIDE THE CLIP-STEPPERS. Reading outwards from play you
+            get "one clip back" then "all the way back", which is the order
+            every transport people already know uses. Inside, the two arrow
+            pairs would read as one four-way stepper. */}
         <button
           type="button"
           onClick={onSeekStart}
           disabled={!canSeekStart}
-          className="group/start relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 transition-colors hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-30"
+          className={TRANSPORT_GHOST_BUTTON}
           aria-label="Jump to start of workbench preview"
           title="Jump to start"
         >
-          <span className="grid size-5 translate-x-4 place-items-center rounded-full transition-colors group-focus-visible/start:ring-2 group-focus-visible/start:ring-sky-400 group-focus-visible/start:ring-offset-2 group-focus-visible/start:ring-offset-zinc-950">
-            <ChevronFirst className="size-3.5" />
-          </span>
+          <ChevronFirst className="size-[17px]" />
         </button>
-
         <button
           type="button"
           onClick={onSeekPrevious}
           disabled={!canSeekPrevious}
-          className="group/previous relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 transition-colors hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-30"
+          className={TRANSPORT_GHOST_BUTTON}
           aria-label="Previous workbench clip"
           title="Previous clip"
         >
-          <span className="grid size-5 translate-x-2 place-items-center rounded-full transition-colors group-focus-visible/previous:ring-2 group-focus-visible/previous:ring-sky-400 group-focus-visible/previous:ring-offset-2 group-focus-visible/previous:ring-offset-zinc-950">
-            <SkipBack className="size-3.5 fill-current" />
-          </span>
+          <SkipBack className="size-[17px] fill-current" />
         </button>
 
+        {/* WHITE AT REST, not on hover. The old control was background-free
+            until the preview or the button was hovered and then inverted to a
+            white disc; the spec makes the disc the resting state, because play
+            is the one thing in this row you look for without hunting. There is
+            no hover-invert left to do, so the prop that drove it is gone rather
+            than kept as a no-op. */}
         <button
           type="button"
           onClick={onTogglePlaying}
           disabled={!canPlay}
-          className="group/play relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="mx-1.5 grid size-9 shrink-0 place-items-center rounded-full bg-white text-zinc-950 transition-colors hover:bg-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label={isPlaying ? "Pause workbench preview" : "Play workbench preview"}
           title={isPlaying ? "Pause" : "Play"}
+          data-transport-primary-control
         >
-          {/* ACTIVE = the highlighted state (the preview is hovered, or this
-              button is), the same condition that used to only whiten the
-              glyph. It now INVERTS: a solid white disc with the mark punched
-              black out of it. Resting stays background-free, and the disc is
-              the well's own size, so nothing shifts as it lights up. */}
-          <span
-            className={cn(
-              "grid size-5 place-items-center rounded-full transition-colors group-hover/play:bg-white group-hover/play:text-zinc-950 group-focus-visible/play:ring-2 group-focus-visible/play:ring-sky-400 group-focus-visible/play:ring-offset-2 group-focus-visible/play:ring-offset-zinc-950",
-              previewHovered && "bg-white text-zinc-950",
-            )}
-            data-transport-primary-control
-          >
-            {isPlaying ? (
-              <Pause className="size-3 fill-current" />
-            ) : (
-              <Play className="ml-0.5 size-3 fill-current" />
-            )}
-          </span>
+          {isPlaying ? (
+            <Pause className="size-[15px] fill-current" />
+          ) : (
+            // Nudged right: a triangle's visual centre is left of its bounding
+            // box, so a geometrically centred play glyph reads as sitting back
+            // in its disc.
+            <Play className="ml-0.5 size-[15px] fill-current" />
+          )}
         </button>
 
         <button
           type="button"
           onClick={onSeekNext}
           disabled={!canSeekNext}
-          className="group/next relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 transition-colors hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-30"
+          className={TRANSPORT_GHOST_BUTTON}
           aria-label="Next workbench clip"
           title="Next clip"
         >
-          <span className="grid size-5 -translate-x-2 place-items-center rounded-full transition-colors group-focus-visible/next:ring-2 group-focus-visible/next:ring-sky-400 group-focus-visible/next:ring-offset-2 group-focus-visible/next:ring-offset-zinc-950">
-            <SkipForward className="size-3.5 fill-current" />
-          </span>
+          <SkipForward className="size-[17px] fill-current" />
         </button>
-
         <button
           type="button"
           onClick={onSeekEnd}
           disabled={!canSeekEnd}
-          className="group/end relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 transition-colors hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-30"
+          className={TRANSPORT_GHOST_BUTTON}
           aria-label="Jump to end of workbench preview"
           title="Jump to end"
         >
-          <span className="grid size-5 -translate-x-4 place-items-center rounded-full transition-colors group-focus-visible/end:ring-2 group-focus-visible/end:ring-sky-400 group-focus-visible/end:ring-offset-2 group-focus-visible/end:ring-offset-zinc-950">
-            <ChevronLast className="size-3.5" />
-          </span>
+          <ChevronLast className="size-[17px]" />
         </button>
       </div>
 
+      {/* THE CLOCK. `tabular-nums` because it changes ten times a second and a
+          proportional 1 is narrower than a 0 -- without it the whole readout
+          twitches sideways on every tenth. Elapsed is white and the duration is
+          dim, so the eye lands on the number that is moving. */}
       <span
-        // Budgeted against HALF the button group (now 13.75rem ⇒ 6.875rem)
-        // plus a gap, so the readout cannot slide under the outermost button.
-        // This number is not free-standing — it moves whenever the group's
-        // width does.
-        className="absolute right-3 max-w-[calc(50%_-_7.75rem)] overflow-hidden text-ellipsis whitespace-nowrap rounded-full bg-zinc-900/90 px-2 py-0.5 font-mono text-[10px] text-zinc-400 shadow-sm"
-        aria-label={`Preview time ${formatSeconds(currentTime)} of ${formatSeconds(duration)}`}
+        className="min-w-0 justify-self-end overflow-hidden font-mono text-[12px] tabular-nums whitespace-nowrap text-ellipsis"
+        aria-label={`Preview time ${formatTimecode(currentTime)} of ${formatTimecode(duration)}`}
         data-testid="workbench-preview-time"
-        style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
       >
-        <span className="sm:hidden">{formatSeconds(currentTime)}</span>
-        <span className="hidden sm:inline">
-          {formatSeconds(currentTime)} / {formatSeconds(duration)}
-        </span>
+        <span className="font-medium text-white">{formatTimecode(currentTime)}</span>
+        <span className="text-white/40"> / {formatTimecode(duration)}</span>
       </span>
     </div>
   );
@@ -2292,26 +2243,7 @@ export function WorkbenchDisplaySurface({
           here at all and what it looks like. This file only promises it a band
           below the picture and above the edge. */}
       {underPicture}
-      <WorkbenchAudioControls
-        volume={activeVolume}
-        muted={activeMuted}
-        audioBlocked={audioBlocked}
-        onToggleMuted={() => {
-          // This click IS a user gesture — resume the context on it.
-          void getMixer().resume();
-          // Unmuting from a zeroed slider must actually be audible, or the
-          // control appears to do nothing.
-          if (activeMuted && activeVolume <= 0) setVolume(1);
-          setMuted(!activeMuted);
-        }}
-        onVolumeChange={(next) => {
-          void getMixer().resume();
-          setVolume(next);
-          // Dragging the slider up is an unmute in every player people know.
-          if (next > 0 && activeMuted) setMuted(false);
-        }}
-      />
-      <WorkbenchDividerTransport
+      <WorkbenchTransportRow
         currentTime={currentTime}
         duration={duration}
         isPlaying={isPlaying}
@@ -2320,7 +2252,6 @@ export function WorkbenchDisplaySurface({
         canSeekNext={canSeekNext}
         canSeekStart={canSeekStart}
         canSeekEnd={canSeekEnd}
-        previewHovered={canPlay && previewHovered}
         onTogglePlaying={() => {
           // This click IS the user gesture the AudioContext has been waiting
           // for, so resume before play() rather than after it is refused.
@@ -2331,6 +2262,27 @@ export function WorkbenchDisplaySurface({
         onSeekNext={() => seekToClip(1)}
         onSeekStart={() => seekToEdge("start")}
         onSeekEnd={() => seekToEdge("end")}
+        volume={
+          <WorkbenchVolumeControl
+            volume={activeVolume}
+            muted={activeMuted}
+            audioBlocked={audioBlocked}
+            onToggleMuted={() => {
+              // This click IS a user gesture — resume the context on it.
+              void getMixer().resume();
+              // Unmuting from a zeroed slider must actually be audible, or the
+              // control appears to do nothing.
+              if (activeMuted && activeVolume <= 0) setVolume(1);
+              setMuted(!activeMuted);
+            }}
+            onVolumeChange={(next) => {
+              void getMixer().resume();
+              setVolume(next);
+              // Dragging the slider up is an unmute in every player people know.
+              if (next > 0 && activeMuted) setMuted(false);
+            }}
+          />
+        }
       />
     </section>
   );
@@ -2471,6 +2423,20 @@ export function WorkbenchSplitPane({
     () => restoredSurfaceHeight ?? DEFAULT_SURFACE_HEIGHT,
   );
   const [isDividerDragging, setIsDividerDragging] = useState(false);
+  /**
+   * THE POINTER IS ON THE EDGE, OR THE KEYBOARD IS — one flag for both.
+   *
+   * React state rather than `group-hover`, for a reason `group-hover` cannot
+   * cover: a keyboard user gets no pointer, and the spec's rest state is a
+   * grip so faint that a focused separator with no other feedback is
+   * invisible. `onFocus`/`onBlur` write the same flag, so focusing the edge
+   * lights it exactly as hovering does, and there is one condition to read
+   * rather than a hover variant plus a focus variant on every child.
+   *
+   * It is also the pattern the file already uses one component up:
+   * `previewHovered` drives the picture's play hint the same way.
+   */
+  const [isDividerHovered, setIsDividerHovered] = useState(false);
   // False until the opening height has been measured AND painted (see the
   // double-rAF below), so the pane appears at its size instead of animating
   // into it.
@@ -2914,6 +2880,63 @@ export function WorkbenchSplitPane({
     onSurfaceHeightChange?.(surfaceHeight);
   }, [surfaceHeight, onSurfaceHeightChange]);
 
+  /**
+   * WHILE DRAGGING, THE WHOLE PAGE GETS THE RESIZE CURSOR.
+   *
+   * Without this the cursor reverts the instant the pointer leaves the 30px
+   * zone — which it does immediately, because dragging the edge is precisely
+   * moving away from where it was. The pointer is captured so the resize keeps
+   * working, and a control that keeps working while its cursor says otherwise
+   * reads as a gesture that has been dropped.
+   *
+   * `user-select: none` for the same reason from the other side: a vertical
+   * drag across a page of text otherwise selects it, and the selection stays
+   * behind after the release.
+   */
+  useEffect(() => {
+    if (!isDividerDragging) return;
+    const { body } = document;
+    const priorCursor = body.style.cursor;
+    const priorUserSelect = body.style.userSelect;
+    body.style.cursor = "ns-resize";
+    body.style.userSelect = "none";
+    return () => {
+      body.style.cursor = priorCursor;
+      body.style.userSelect = priorUserSelect;
+    };
+  }, [isDividerDragging]);
+
+  /** Back to the size the pane opens at. Double-click to reset a splitter is a
+   *  convention old enough that its absence reads as a bug, and it is the only
+   *  way back for someone who has dragged the pane somewhere useless. */
+  const handleDividerReset = useCallback(() => {
+    setSurfaceHeight(clampSurfaceHeight(DEFAULT_SURFACE_HEIGHT));
+  }, [clampSurfaceHeight]);
+
+  /**
+   * ARROWS NUDGE THE SPLIT, 8px a press.
+   *
+   * A `role="separator"` with `aria-valuenow` that cannot be moved from the
+   * keyboard is a control that only claims to be one. Up SHRINKS the preview,
+   * because up is where the edge goes — the key moves the thing under the
+   * hand, not the value the label happens to name.
+   */
+  const handleDividerKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      const step =
+        event.key === "ArrowUp"
+          ? -DIVIDER_NUDGE_PX
+          : event.key === "ArrowDown"
+            ? DIVIDER_NUDGE_PX
+            : 0;
+      if (step === 0) return;
+      // Or the page scrolls under the pane the press was meant to resize.
+      event.preventDefault();
+      setSurfaceHeight((height) => clampSurfaceHeight(height + step));
+    },
+    [clampSurfaceHeight],
+  );
+
   const handleDividerPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
       event.preventDefault();
@@ -3113,54 +3136,98 @@ export function WorkbenchSplitPane({
           aria-valuemin={MIN_SURFACE_HEIGHT}
           aria-valuenow={Math.round(surfaceHeight)}
           aria-label="Resize workbench display"
-          // h-11 = DIVIDER_HEIGHT_PX: the whole box is the drag target, and it
-          // stays this height at every breakpoint. The visible band inside is
-          // smaller and centered, so the space either side of it reads as the
-          // gap between the preview and the timeline without being separate
-          // padding on each.
-          className="group relative block h-11 w-full cursor-row-resize bg-transparent transition-opacity duration-300 ease-out [[data-preview-chrome='out']_&]:opacity-0 motion-reduce:transition-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+          // 22px IN FLOW: the spec's 8px gap below the controls row, then the
+          // bin's 14px lip. It was 44 — a well tall enough to hold the
+          // transport, which used to ride on it. The transport is a row of its
+          // own now, so the divider goes back to being the size of the thing it
+          // actually draws.
+          //
+          // THE HIT TARGET IS NOT THIS BOX. A child below extends it 8px into
+          // the pane beneath, giving the 30px the spec asks for, straddling the
+          // edge so a pointer aimed at the gap between the panes still catches
+          // it. It does NOT reach upward: 8px above this box is the controls
+          // row, and a resize that starts on a button is the bug the old
+          // arrangement needed a `stopPropagation` on every control to avoid.
+          className="group relative block h-[22px] w-full cursor-ns-resize bg-transparent transition-opacity duration-300 ease-out [[data-preview-chrome='out']_&]:opacity-0 motion-reduce:transition-none focus-visible:outline-none"
           data-workbench-divider
+          data-divider-dragging={isDividerDragging ? "" : undefined}
+          // PUBLISHED, so the reach state is a fact a test can read directly
+          // rather than one it has to infer from a colour.
+          data-divider-reached={isDividerHovered ? "" : undefined}
           onPointerDown={handleDividerPointerDown}
           onPointerMove={handleDividerPointerMove}
           onPointerUp={handleDividerPointerUp}
           onPointerCancel={handleDividerPointerUp}
+          onPointerEnter={() => setIsDividerHovered(true)}
+          onPointerLeave={() => setIsDividerHovered(false)}
+          onFocus={() => setIsDividerHovered(true)}
+          onBlur={() => setIsDividerHovered(false)}
+          onDoubleClick={handleDividerReset}
+          onKeyDown={handleDividerKeyDown}
         >
-          {/* The band fades out across the transport group so no divider
-              colour shows behind its background-free icons.
-
-              THE WINDOW IS HALF THE GROUP'S WIDTH, and the numbers below are
-              that and nothing else: the group is `w-[13.75rem]`, so the clear
-              span reaches 6.875rem either side of centre and the fade adds
-              2rem beyond it. When the group was three buttons those numbers
-              were 4.125rem and 6.125rem — half of 8.25rem, the same rule.
-              Adding the two outer buttons widened the group to five wells and
-              left the window at three, so the jump-to-start and jump-to-end
-              glyphs sat in the fade with the line still running under them.
-              Kept in step by hand, because a CSS gradient cannot read the
-              sibling's width; if the count changes again, both numbers move.
-
-              CENTERED on DIVIDER_BAND_CENTER_PX rather than sized from the
-              box's top: 8px at desktop, and 12px below `md`, where it has to
-              stay tall enough to hold the grip icon. Because both heights
-              share one mid-line, the transport that rides on it never moves. */}
+          {/* THE ZONE — invisible, and the only part of this that takes a
+              pointer. Everything drawn below is `pointer-events-none`, so the
+              grip cannot swallow a press that the zone should have had. */}
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 h-3 rounded-sm bg-[linear-gradient(to_right,currentColor_0,currentColor_calc(50%_-_8.875rem),transparent_calc(50%_-_6.875rem),transparent_calc(50%_+_6.875rem),currentColor_calc(50%_+_8.875rem),currentColor_100%)] text-zinc-800 transition-colors group-hover:text-zinc-700 group-active:text-zinc-600 md:h-2"
-            style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
-            data-divider-line
+            className="absolute inset-x-0 top-0"
+            style={{ bottom: -DIVIDER_ZONE_OVERHANG_PX }}
+            data-divider-zone
           />
-          {/* Coarse-pointer devices never see the hover brighten, so at tablet
-              width and below the band carries a standing grip instead. At the
-              band's far LEFT: the centre belongs to the transport and the right
-              end to the time readout, whose opaque pill can span half the
-              width — anything placed there is simply painted over. */}
+          {/* THE EDGE. Nothing at rest — the spec's whole point is that only
+              ONE bright horizontal line survives below the picture, and that
+              line is the scrubber. This one appears on hover to say the edge is
+              grabbable, and takes the accent while it is being dragged.
+              Inset 10px so it reads as the top of a card rather than a rule
+              across the window. */}
           <span
             aria-hidden="true"
-            data-divider-grip
-            className="pointer-events-none absolute left-2 text-zinc-500 md:hidden"
-            style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
+            className="pointer-events-none absolute right-[10px] left-[10px] h-px transition-colors duration-[120ms] motion-reduce:transition-none"
+            // TRANSPARENT AT REST is the spec's headline: exactly one bright
+            // horizontal line survives below the picture, and it is the
+            // scrubber. This edge only exists while someone reaches for it.
+            //
+            // INLINE rather than `bg-*` classes so the two states are one
+            // ternary next to the grip's, which has to agree with it exactly.
+            //
+            // DO NOT ASSERT THE COMPUTED COLOUR HERE. The fade below means a
+            // read taken after the state flips returns the value it is fading
+            // FROM, and it stayed there through a five-second poll — the shape
+            // recorded in `computed-style-reads-transition-start`. The reach
+            // state is published as `data-divider-reached` on the button for
+            // exactly that reason: it is the fact, and it is readable the
+            // instant it is true.
+            style={{
+              top: DIVIDER_LIP_TOP_PX,
+              backgroundColor: isDividerDragging
+                ? DIVIDER_ACCENT
+                : isDividerHovered
+                  ? "rgba(255, 255, 255, 0.25)"
+                  : "transparent",
+            }}
+            data-divider-edge
+          />
+          {/* THE LIP, and the grip pill centred in it. The pill is the resting
+              affordance — the one thing visible when nothing is hovered — and
+              it is a shape rather than a line, so it says "handle" without
+              adding a rule that competes with the scrubber. */}
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 grid place-items-center"
+            style={{ top: DIVIDER_LIP_TOP_PX, height: DIVIDER_HEIGHT_PX - DIVIDER_LIP_TOP_PX }}
           >
-            <GripHorizontal className="h-3 w-3" strokeWidth={2.5} />
+            <span
+              className="block h-1 w-10 rounded-sm transition-colors duration-[120ms]"
+              // Inline for the same reason as the edge above.
+              style={{
+                backgroundColor: isDividerDragging
+                  ? DIVIDER_ACCENT
+                  : isDividerHovered
+                    ? "rgba(255, 255, 255, 0.55)"
+                    : "rgba(255, 255, 255, 0.2)",
+              }}
+              data-divider-grip
+            />
           </span>
         </button>
         </div>


### PR DESCRIPTION
Implements the transport-bar spec in three parts. Below the video preview there
were three horizontal lines competing for one job; there is now exactly one —
the scrubber — and the divider communicates through a grip, a cursor and hover
states instead of a competing rule.

## The scrubber

Boundary ticks cut through the bar at every clip edge, painted in the surface's
own colour so they read as gaps rather than marks — which is what a cut is. They
are drawn from the same clips the pane plays, so they cannot drift from where a
scrub actually lands.

The track thickens 4px → 6px under the pointer, held by a class rather than
`:hover` so a fast drag that leaves the strip keeps it. The tooltip reads the
time under the CURSOR, not the playhead's: the question it answers is "what is
here", which is what you need before deciding to go there.

Arrows step one FRAME at a rate passed in as a prop — the spec is explicit that
stepping must match the sequence's real rate, and this component has no way to
know it, so the 24fps default is marked as the assumption it is.

## The transport row

It used to be `absolute top-full`, hanging off the surface with every child
positioned against the divider band's mid-line. That made the divider two things
at once, and both of its workarounds go away rather than move: the band no
longer needs a hand-written gradient window punched through it so no line runs
behind the glyphs, and no control needs a `stopPropagation` to keep its own
press from starting a resize.

A three-column grid, `1fr auto 1fr`, so the cluster is centred on the PICTURE
rather than on what the other two columns leave over — which would shift it
every time the timecode's width changed, ten times a second.

Volume gets its click back. The popover existed because the icon's click was
spent opening the slider, so mute had to move inside it as a second button. With
room beside it in the row, the slider expands on hover and the button is the
mute again — and the slider stays in the tree at zero width, so it is a real tab
stop rather than something a keyboard user has to know to open.

## The panel divider

22px instead of 44 — the spec's 8px gap and 14px lip — with a 40×4 grip pill as
the resting affordance and no band at all. The hit target is bigger than the box
and straddles the boundary, 8px into the pane below, so a pointer aimed at the
gap still catches it; it deliberately does not reach up, where the controls row
now is.

Hover raises a 1px edge line, dragging takes both marks to the accent and puts
`ns-resize` on the whole page — the pointer leaves the zone the moment the drag
starts, and a control that keeps working while its cursor says otherwise reads
as a gesture that has been dropped.

Double-click resets, arrows nudge by 8px, and the split is remembered per
project — the project rather than the focused collection, because drilling into
a folder is moving around inside one piece of work.

## Two things not done, both on purpose

**Space does not toggle playback.** It is already bound on the board as "select
this card" and documented in the shortcuts sheet. The spec's prototype is a
standalone player with no grid to collide with; this view has one.

**No snap-to-collapse.** The spec marks it a "recommended addition"; it reaches
into the pane's reveal/settle machinery and belongs in its own change.

## Verification

`formatTimecode` moves into `packages/ui/timeline/utils.ts` so the readout and
the scrubber's tooltip are one function — the spec's acceptance is that they
always agree, and two copies would agree only until one was rounded differently.
Its unit test pins the spec's own worked example, which needed quantising to
whole tenths: `71.1 - 60` is `11.0999…` in binary floating point, so the obvious
implementation renders `1:11.0`.

Two e2e tests are rewritten rather than adjusted, because they asserted the
arrangement this replaces. New coverage: the row's three columns and their
insets, the scrubber's ticks/thicken/tooltip, and the edge's drag, reset, nudge
and persistence — the last across a full reload, since a pane toggle keeps the
component tree and would pass on nothing more than React state.

Green locally: 813 unit, 308 story interaction, 1474 app tests, tsc and lint
clean. Full graph-view e2e was running clean at the time of writing.

Assertions on these controls read published state (`data-divider-reached`) or
`element.style.*`, never `getComputedStyle`, of a transitioned property: a read
taken after the state flips returns the value it is fading FROM and stays there
through a five-second poll, which is indistinguishable from a rule that never
applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
