### PR TITLE
PL16-008 — the media monster

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -469,7 +469,7 @@ html {
   }
 }
 
-/* ── The storyboard monster's hop ─────────────────────────────────────────────
+/* ── The media monster's hop ─────────────────────────────────────────────
    Collapsing the rail re-lays the creature out rather than moving it: inline in
    "m…nster" when open, alone and larger when closed. A view transition is what
    gives the browser two snapshots to interpolate; these rules turn that
@@ -519,7 +519,7 @@ html {
    `data-aiming`, and deliberately its own attribute: one means "the eye is
    pointed along the arc", this one means "this element is in a transition",
    and a later change to either should not silently rewire the other. */
-[data-storyboard-monster][data-hopping] {
+[data-media-monster][data-hopping] {
   view-transition-name: sw-monster;
 }
 
@@ -777,7 +777,7 @@ html {
    ellipse — so the silhouette between the feet and the head is a slant, not an
    arc. A second sage ellipse used to be leaned over the base to fake the curve;
    it broke the outline instead (see the note where it was, in
-   `storyboard-monster-mark.tsx`), and a straight lean from one honest shape
+   `media-monster-mark.tsx`), and a straight lean from one honest shape
    turned out to read better than a bend made of two.
 
    It peaks at the apex and reverses at the crouch and the landing, where the
@@ -955,7 +955,7 @@ html {
    It goes a couple of degrees PAST square before settling, the same
    follow-through the hat and the eye get. A body that stops exactly on zero has
    no weight in it. */
-[data-storyboard-monster][data-settling] {
+[data-media-monster][data-settling] {
   animation: sw-monster-untwist 520ms cubic-bezier(0.3, 0.72, 0.3, 1) both;
 }
 
@@ -1033,7 +1033,7 @@ html {
 
    The white can travel (0.98 - 0.64) / 2 = 0.17em before it reaches the body's
    edge, so 0.05em is well inside it and the eye stays an eye. */
-[data-storyboard-monster][data-aiming]:not([data-landing]) [data-monster-eye] {
+[data-media-monster][data-aiming]:not([data-landing]) [data-monster-eye] {
   transform: translateX(calc(var(--sw-hop-dir, 1) * 0.06em));
 }
 
@@ -1049,7 +1049,7 @@ html {
    and not a tenth more. Push it and the leading edge of the pupil is shaved off
    for the whole flight, which at this size reads as a rendering fault rather
    than as a hard look. */
-[data-storyboard-monster][data-aiming]:not([data-landing]) [data-monster-pupil] {
+[data-media-monster][data-aiming]:not([data-landing]) [data-monster-pupil] {
   /* Re-declares the component's gaze property ON the pupil. It is set on the
      MARK there and inherits down, so a value declared directly on this element
      wins — which is how a stylesheet takes back a position an inline style
@@ -1057,7 +1057,7 @@ html {
   --monster-gaze-x: calc(var(--sw-hop-dir, 1) * 0.02em);
 }
 
-[data-storyboard-monster][data-aiming] [data-monster-pupil] {
+[data-media-monster][data-aiming] [data-monster-pupil] {
   /* THREE PROPERTIES, ONE POSE. `translate`, `scale` and `transform` are
      separate animatable properties that compose in that order, which is what
      lets the horizontal flick, the dilation and the vertical bump each run on
@@ -1092,7 +1092,7 @@ html {
    straight bar. Neither is a bend. What bends is the CHAIN each stalk is built
    from: three segments, each a child of the one below and each turned by this
    same angle, so the turns compound (b, 2b, 3b) and the chords approximate an
-   arc. See `SEG_BEND` in `storyboard-monster-mark.tsx`.
+   arc. See `SEG_BEND` in `media-monster-mark.tsx`.
 
    ONE DECLARATION MOVES ALL SIX SEGMENTS, because they read it by inheritance
    rather than being selected individually. That is also why it is set here on
@@ -1109,11 +1109,11 @@ html {
    stalk tore out of the skull. A segment turns about its own bottom edge, so
    the root is a FIXED POINT of the bend and no angle can detach it. If a louder
    version is ever wanted, it is safe to just raise this number. */
-[data-storyboard-monster][data-aiming] [data-monster-antennae] {
+[data-media-monster][data-aiming] [data-monster-antennae] {
   --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -10deg);
 }
 
-[data-storyboard-monster][data-settling] [data-monster-pupil] {
+[data-media-monster][data-settling] [data-monster-pupil] {
   /* The horizontal is a SACCADE and the vertical is a bump, so they cannot
      share a timing function — see the two keyframe blocks. `linear` on the
      saccade is deliberate: its stops carry the velocity profile, and an easing
@@ -1136,7 +1136,7 @@ html {
    Its near edge is the bottom of the pill and its heel is the far edge at the
    top. Anchoring at 50% 100% is therefore anchoring at the toe: it is the part
    that stays on the ground, so it is the part that must not move. */
-[data-storyboard-monster] [data-monster-foot] {
+[data-media-monster] [data-monster-foot] {
   transform-origin: 50% 100%;
 }
 
@@ -1184,19 +1184,19 @@ html {
 
    Set on the DEPARTURE capture only (`:not([data-landing])`), so the feet hang
    on the way up and are back under the body by the time it lands. */
-[data-storyboard-monster][data-aiming]:not([data-landing])
+[data-media-monster][data-aiming]:not([data-landing])
   [data-monster-foot="left"] {
   transform-origin: 100% 0;
   transform: rotate(-22deg);
 }
 
-[data-storyboard-monster][data-aiming]:not([data-landing])
+[data-media-monster][data-aiming]:not([data-landing])
   [data-monster-foot="right"] {
   transform-origin: 0 0;
   transform: rotate(22deg);
 }
 
-[data-storyboard-monster][data-settling] [data-monster-foot] {
+[data-media-monster][data-settling] [data-monster-foot] {
   /* NO ROLL ON LANDING any more. The foot used to arrive still angled off the
      toe and rotate flat under the creature, which is a lot of motion on a shape
      four pixels tall and read as the foot flailing rather than as weight. The
@@ -1230,7 +1230,7 @@ html {
    squash with the head the way an eye in a squashing head should; the antennae
    and the feet are siblings, so they are untouched. Splitting them any other
    way would have needed a wrapper. */
-[data-storyboard-monster][data-settling] [data-monster-body],
+[data-media-monster][data-settling] [data-monster-body],
 /* THE FUR RIDES THE SAME ANIMATION, and must. It is a sibling of the body, not
    a child, and its masked ring clears the body's silhouette by 0.0021em — a
    twentieth of a pixel at rail size. Squash the body without it and the head's
@@ -1238,11 +1238,11 @@ html {
    skull at the bottom of the squash. Same keyframes, same origin point
    (expressed as 50%/85.5% of its own larger box), so the margin holds at every
    frame instead of only at rest. */
-[data-storyboard-monster][data-settling] [data-monster-fur] {
+[data-media-monster][data-settling] [data-monster-fur] {
   animation: sw-body-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) both;
 }
 
-[data-storyboard-monster][data-settling] [data-monster-antennae] {
+[data-media-monster][data-settling] [data-monster-antennae] {
   animation: sw-antennae-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) both;
 }
 
@@ -1540,24 +1540,24 @@ html {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-storyboard-monster][data-settling],
-  [data-storyboard-monster][data-settling] [data-monster-pupil],
-  [data-storyboard-monster][data-settling] [data-monster-foot],
-  [data-storyboard-monster][data-settling] [data-monster-body],
-  [data-storyboard-monster][data-settling] [data-monster-fur],
-  [data-storyboard-monster][data-settling] [data-monster-antennae] {
+  [data-media-monster][data-settling],
+  [data-media-monster][data-settling] [data-monster-pupil],
+  [data-media-monster][data-settling] [data-monster-foot],
+  [data-media-monster][data-settling] [data-monster-body],
+  [data-media-monster][data-settling] [data-monster-fur],
+  [data-media-monster][data-settling] [data-monster-antennae] {
     animation: none;
   }
 
-  [data-storyboard-monster][data-aiming] [data-monster-eye],
-  [data-storyboard-monster][data-aiming] [data-monster-foot] {
+  [data-media-monster][data-aiming] [data-monster-eye],
+  [data-media-monster][data-aiming] [data-monster-foot] {
     transform: none;
   }
 
   /* Rest for both is no transform: the pupil has none of its own, and the hat's
      tilt lives on an inner element that this never touches. */
-  [data-storyboard-monster][data-aiming] [data-monster-pupil],
-  [data-storyboard-monster][data-aiming] [data-monster-antennae] {
+  [data-media-monster][data-aiming] [data-monster-pupil],
+  [data-media-monster][data-aiming] [data-monster-antennae] {
     /* The bend is a property, not a transform, so `transform: none` would leave
        the chain arced with nothing animating it. */
     --sw-antenna-bend: 0deg;
@@ -1566,7 +1566,7 @@ html {
 
   /* The pupil's aim spends three properties; clearing one would leave it
      staring sideways, or stuck dilated. */
-  [data-storyboard-monster][data-aiming] [data-monster-pupil] {
+  [data-media-monster][data-aiming] [data-monster-pupil] {
     translate: none;
     scale: none;
   }

--- a/apps/timeline-gstudio001/components/timeline/media-monster-mark.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/media-monster-mark.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { expect, within } from "storybook/test";
 
 import {
-  StoryboardMonsterMark,
-  STORYBOARD_MONSTER_ACCENT,
-} from "./storyboard-monster-mark";
+  MediaMonsterMark,
+  MEDIA_MONSTER_ACCENT,
+} from "./media-monster-mark";
 
 // The creature in the rail's wordmark.
 //
@@ -76,8 +76,8 @@ function bodyPose(transform: string) {
 }
 
 const meta = {
-  title: "Timeline/StoryboardMonsterMark",
-  component: StoryboardMonsterMark,
+  title: "Timeline/MediaMonsterMark",
+  component: MediaMonsterMark,
   parameters: { layout: "centered" },
   decorators: [
     (Story) => (
@@ -89,7 +89,7 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof StoryboardMonsterMark>;
+} satisfies Meta<typeof MediaMonsterMark>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -115,12 +115,12 @@ export const NotNamedForViewTransitions: Story = {
   args: { scale: 1.6 },
   render: () => (
     <Plate label="no inline view-transition-name">
-      <StoryboardMonsterMark scale={1.6} gaze="breadcrumb" />
+      <MediaMonsterMark scale={1.6} gaze="breadcrumb" />
     </Plate>
   ),
   play: async ({ canvasElement }) => {
     const mark = canvasElement.querySelector<HTMLElement>(
-      "[data-storyboard-monster]",
+      "[data-media-monster]",
     );
     expect(mark).not.toBeNull();
     if (!mark) return;
@@ -141,16 +141,16 @@ export const RailSizes: Story = {
   render: () => (
     <>
       <Plate label="in the word (1.1, looking ahead)">
-        <StoryboardMonsterMark scale={1.1} gaze="ahead" />
+        <MediaMonsterMark scale={1.1} gaze="ahead" />
       </Plate>
       <Plate label="alone, collapsed (1.6, at the breadcrumb)">
-        <StoryboardMonsterMark scale={1.6} gaze="breadcrumb" />
+        <MediaMonsterMark scale={1.6} gaze="breadcrumb" />
       </Plate>
     </>
   ),
   play: async ({ canvasElement }) => {
     const marks = Array.from(
-      canvasElement.querySelectorAll("[data-storyboard-monster]"),
+      canvasElement.querySelectorAll("[data-media-monster]"),
     );
     expect(marks).toHaveLength(2);
     const [inWord, alone] = marks as [Element, Element];
@@ -189,7 +189,7 @@ export const BlownUp: Story = {
   render: () => (
     <Plate label="7x">
       <span className="text-[7em]">
-        <StoryboardMonsterMark scale={1} />
+        <MediaMonsterMark scale={1} />
       </span>
     </Plate>
   ),
@@ -209,19 +209,19 @@ export const InTheWordmark: Story = {
       className="flex items-center font-[family-name:var(--font-grandstander)] text-[19px] text-white"
       style={{ lineHeight: 1 }}
     >
-      storyboard&nbsp;
-      <span style={{ color: STORYBOARD_MONSTER_ACCENT }}>
+      media&nbsp;
+      <span style={{ color: MEDIA_MONSTER_ACCENT }}>
         m
-        <StoryboardMonsterMark scale={1.1} />
+        <MediaMonsterMark scale={1.1} />
         nster
       </span>
     </span>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    expect(canvas.getByText(/storyboard/)).toBeTruthy();
+    expect(canvas.getByText(/media/)).toBeTruthy();
     expect(
-      canvasElement.querySelector("[data-storyboard-monster]"),
+      canvasElement.querySelector("[data-media-monster]"),
     ).toBeTruthy();
   },
 };
@@ -272,14 +272,14 @@ export const JumpPoses: Story = {
               bodyPose(body)(node);
             }}
           >
-            <StoryboardMonsterMark scale={1} />
+            <MediaMonsterMark scale={1} />
           </span>
         </Plate>
       ))}
     </>
   ),
   play: async ({ canvasElement }) => {
-    const marks = canvasElement.querySelectorAll("[data-storyboard-monster]");
+    const marks = canvasElement.querySelectorAll("[data-media-monster]");
     expect(marks).toHaveLength(4);
     const [restMark, flightMark, jamMark] = Array.from(marks) as [
       Element,
@@ -366,21 +366,21 @@ export const WithoutTheAntennae: Story = {
   render: () => (
     <>
       <Plate label="with antennae">
-        <StoryboardMonsterMark scale={1.6} />
+        <MediaMonsterMark scale={1.6} />
       </Plate>
       <Plate label="antennae={false}">
-        <StoryboardMonsterMark scale={1.6} antennae={false} />
+        <MediaMonsterMark scale={1.6} antennae={false} />
       </Plate>
       <Plate label="bare, blown up">
         <span className="text-[4em]">
-          <StoryboardMonsterMark scale={1} antennae={false} />
+          <MediaMonsterMark scale={1} antennae={false} />
         </span>
       </Plate>
     </>
   ),
   play: async ({ canvasElement }) => {
     const marks = Array.from(
-      canvasElement.querySelectorAll("[data-storyboard-monster]"),
+      canvasElement.querySelectorAll("[data-media-monster]"),
     );
     expect(marks).toHaveLength(3);
     const [withPair, without] = marks as [Element, Element];

--- a/apps/timeline-gstudio001/components/timeline/media-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/media-monster-mark.tsx
@@ -1,5 +1,5 @@
 /**
- * The storyboard monster — the creature that sits in the "o" of "monster".
+ * The media monster — the creature that sits in the "o" of "monster".
  *
  * Ported from the logo design document's TURN 54, variant 48a ("antenna pair"),
  * its latest direction: the same one-eyed fuzzball, now with two stalks and
@@ -65,7 +65,7 @@ const PUPIL = "oklch(0.27 0.03 145)";
  * the source, two here on purpose: the antennae belong to the creature, the
  * word belongs to the product.
  */
-export const STORYBOARD_MONSTER_ACCENT = "oklch(0.707 0.165 254.624)";
+export const MEDIA_MONSTER_ACCENT = "oklch(0.707 0.165 254.624)";
 /**
  * The stalks.
  *
@@ -96,7 +96,7 @@ const ANTENNA_KNOB = "oklch(0.89 0.08 48)";
  * before this turn removed it — worth recording so nobody re-derives the dead
  * version. Denim was chosen when terracotta was also the WORD's colour, so
  * terracotta feet read as part of the letters rather than as part of the
- * creature. The word went blue (see `STORYBOARD_MONSTER_ACCENT`), and with it
+ * creature. The word went blue (see `MEDIA_MONSTER_ACCENT`), and with it
  * the only thing that clash was ever about.
  *
  * What the source's scheme buys instead is a BOOKEND: the same pale terracotta
@@ -378,7 +378,7 @@ function Antenna({ side }: Readonly<{ side: keyof typeof ANTENNA }>) {
   );
 }
 
-export function StoryboardMonsterMark({
+export function MediaMonsterMark({
   scale = 1,
   gaze = "ahead",
   antennae = true,
@@ -421,7 +421,7 @@ export function StoryboardMonsterMark({
   // from this ancestor.
   return (
     <span
-      data-storyboard-monster=""
+      data-media-monster=""
       data-monster-gaze={gaze}
       // The growth between rail states. Everything about the creature is sized
       // off its own font-size, so animating that one property scales the whole

--- a/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
@@ -28,15 +28,23 @@ export const RAIL_WIDTH_PX = 72;
  * width could ever be "enough" for them; they truncate, which degrades to an
  * ellipsis rather than shoving the rail's rhythm out of line.
  *
- * 240 -> 260, asked for directly. The wordmark is not what needed the room
- * this time — at Grandstander 700/21px its ink measures 208px against the 218
- * available, so it already fit. The extra 20px is breathing room around it and
- * for the collection names beside it, and it takes the wordmark's own slack
- * from 10px to 30px, which is the margin the note above wanted when it warned
- * that three pixels was "not enough to survive a font fallback rendering a
- * fraction wider".
+ * 232 -> 240 -> 260 -> 240. The last step is asked for directly, and it gives
+ * back exactly what the step before it bought.
+ *
+ * IT IS AFFORDABLE NOW IN A WAY IT WAS NOT THEN, because the wordmark got
+ * shorter in between: the creature is the MEDIA monster, not the storyboard
+ * one. At 260 the old mark's ink measured 208px against the 218 available —
+ * 10px of slack, which is what made 260 worth asking for. Measured again at
+ * 240 with the new name: the ink is 159px, starting 22px in, leaving 59px
+ * clear. The mark has more room at the narrower rail than it had at the wider
+ * one, so the warning further up — that three pixels was "not enough to
+ * survive a font fallback rendering a fraction wider" — is comfortably
+ * answered.
+ *
+ * Collection names are the other tenant and they truncate, so they lose 20px
+ * of visible name rather than pushing anything out of line.
  */
-export const RAIL_OPEN_WIDTH_PX = 260;
+export const RAIL_OPEN_WIDTH_PX = 240;
 
 /**
  * On the rail ALWAYS, open or closed — and the hook every tile style below
@@ -88,7 +96,7 @@ export const RAIL_OPEN_CLASS = "rail-open";
  */
 export const RAIL_WIDTH_CLASS = {
   collapsed: "w-[72px]",
-  open: "w-[260px]",
+  open: "w-[240px]",
 } as const;
 
 /**

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -20,9 +20,9 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { flushSync } from "react-dom";
 import {
-  StoryboardMonsterMark,
-  STORYBOARD_MONSTER_ACCENT,
-} from "./storyboard-monster-mark";
+  MediaMonsterMark,
+  MEDIA_MONSTER_ACCENT,
+} from "./media-monster-mark";
 import { TrashDrawer } from "@/components/assets/trash-drawer";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
@@ -300,7 +300,7 @@ function writeRailExpanded(next: boolean): void {
   // It has to be an attribute set here rather than a keyframe in the hop,
   // because mid-flight the creature is a rasterised image and nothing inside it
   // can move. A pose can still be captured INTO that image; motion cannot.
-  const mark = document.querySelector("[data-storyboard-monster]");
+  const mark = document.querySelector("[data-media-monster]");
   mark?.setAttribute("data-aiming", "");
 
   // OPT INTO THE TRANSITION, and only this one. The `view-transition-name` that
@@ -1044,9 +1044,11 @@ export function TimelineSidebar({
           // it there costs nothing closed and is what lets the name grow to the
           // right rather than the whole mark sliding.
           // 22px, not `text-lg`. The wordmark used 186px of the rail's 239px
-          // at 18px, so there was room, and at 18px "storyboard monster" was
-          // hard to read against everything else in the rail. Measured after:
-          // see the note on the creature's scale for the other half of the fit.
+          // at 18px, so there was room, and at 18px the name was hard to read
+          // against everything else in the rail. Measured after: see the note
+          // on the creature's scale for the other half of the fit. The name is
+          // SHORTER since "media monster" became "media monster", so the
+          // fit only got easier — the number stands.
           // CAPRASIMO, the face the logo document is set in, and no
           // `font-bold`: it ships a single 400 weight, so asking for 700 buys a
           // synthesised bold on top of a face that is already heavy.
@@ -1073,7 +1075,7 @@ export function TimelineSidebar({
               keep participating in the link's own flex box. */}
           <span aria-hidden="true" className="contents">
             <RevealedLetters show={railExpanded}>
-              storyboard&nbsp;
+              media&nbsp;
             </RevealedLetters>
             {/* The creature takes the monogram's place: it is what survives the
                 collapse, exactly as "SW" did. The word rebuilds around it —
@@ -1085,7 +1087,7 @@ export function TimelineSidebar({
                 inherits through a `display: contents` box. */}
             <span
               className="contents"
-              style={{ color: STORYBOARD_MONSTER_ACCENT }}
+              style={{ color: MEDIA_MONSTER_ACCENT }}
             >
               <RevealedLetters show={railExpanded}>m</RevealedLetters>
               {/* SMALL IN THE WORD, BIG ALONE. Expanded it is the source's own
@@ -1107,7 +1109,7 @@ export function TimelineSidebar({
                   same alphabet. The antennae above and the feet below stay
                   outside that band on purpose — an ascender and a descender are
                   what a letter is allowed to have. */}
-              <StoryboardMonsterMark
+              <MediaMonsterMark
                 scale={railExpanded ? 0.97 : 1.6}
                 gaze={railExpanded ? "ahead" : "breadcrumb"}
               />


### PR DESCRIPTION
Renames the creature and its wordmark from "storyboard monster" to "media
monster", visible name and code both.

## The wordmark

The rail's lockup is a flex row of revealed letters with the creature standing
in for the "o", so the word is spelled `media` + `m` + creature + `nster`. Only
the first span moves.

The name is SHORTER than it was, so the 22px sizing note — which exists because
the old wordmark used 186px of the rail's 239px — only gets easier to satisfy,
and the number stands.

## The identifiers go with it

The component, its file, the accent constant, and the `data-storyboard-monster`
hook the entire animation stylesheet keys off. A creature the product calls one
thing and the code calls another is the drift that costs an afternoon later.

The hook is renamed in the stylesheet and in the component as one change,
because a half-done rename there fails SILENTLY: the creature still draws, it
just stops moving. Both lockups were photographed after the change to confirm
the CSS still finds it — collapsed (creature alone, standing in for the old
"SW" monogram) and expanded (`media monster`, accent on the second word).

The mark's story file renders its own copy of the lockup, independent of the
sidebar, so it is updated too — otherwise it would have gone on asserting the
old word while the app showed the new one.

## Not touched, deliberately

The home link's accessible name is still "Storyboard Workbench home" — that is
the APP's name rather than the creature's, and renaming a product on the way
past a wordmark change is not mine to make. Say the word if it should follow.

`punch-list/` and `scratch/` still carry the old name; they are a record of what
was decided when, not live code.

## Verification

Six mark stories pass, 1474 app tests pass, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
