### PR TITLE
PL16-009 — the home link says Media Monster

### DIFF
--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.stories.tsx
@@ -186,6 +186,32 @@ export const Expanded: Story = {
     await waitFor(() => {
       expect(document.cookie).toContain("sw_rail_expanded=true");
     });
+
+    // WHAT YOU SEE IS IN WHAT YOU SAY (WCAG 2.5.3, "Label in Name").
+    //
+    // The mark's letters are split into per-letter spans for the reveal and
+    // hidden from assistive tech, so the link's whole accessible name comes
+    // from its `aria-label`. That leaves a pairing nothing else checks: the
+    // word on screen has to be CONTAINED in that label, or someone driving by
+    // voice says what they can see and matches nothing.
+    //
+    // The two used to disagree — the label read "Storyboard Workbench home"
+    // over a mark that read "storyboard monster" — and the disagreement was
+    // invisible precisely because the letters are hidden. Asserted as a
+    // RELATIONSHIP rather than as two literals, so renaming the product in one
+    // place and not the other fails here rather than shipping.
+    //
+    // The creature stands in for the "o", so it is added back before the
+    // comparison: the DOM says "media mnster" and the eye reads "media
+    // monster".
+    // The link that CONTAINS THE CREATURE, so this can never drift onto some
+    // other labelled link in the rail and compare the wrong pair.
+    const home = canvasElement.querySelector<HTMLElement>("a:has([data-media-monster])")!;
+    expect(home).not.toBeNull();
+    const label = home.getAttribute("aria-label") ?? "";
+    const seen = (home.textContent ?? "").replace(/\s+/g, " ").trim().replace("mnster", "monster");
+    expect(seen.length).toBeGreaterThan(0);
+    expect(label.toLowerCase()).toContain(seen.toLowerCase());
   },
 };
 

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -1038,7 +1038,7 @@ export function TimelineSidebar({
       >
         <Link
           href="/"
-          aria-label="Storyboard Workbench home"
+          aria-label="Media Monster home"
           // LEADING, at the glyph column's inset, in both states. Centring "SW"
           // in the 72px rail already put it within a pixel of 22px, so pinning
           // it there costs nothing closed and is what lets the name grow to the
@@ -1054,22 +1054,27 @@ export function TimelineSidebar({
           // synthesised bold on top of a face that is already heavy.
           className="flex h-[72px] w-full items-center justify-start overflow-hidden whitespace-nowrap pl-[22px] font-[family-name:var(--font-grandstander)] font-bold text-[21px] text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
         >
-          {/* THE INITIALS NEVER LEAVE. The rest of each word collapses to
-              nothing, so closing slides the S and the W together into "SW"
-              rather than swapping one piece of text for another. The letters
-              you keep are the same letters throughout — same size, same font,
-              same position — which is the whole reason this reads as the mark
-              contracting instead of a label being replaced by an abbreviation.
+          {/* THE CREATURE NEVER LEAVES. The letters around it collapse to
+              nothing, so closing contracts the word onto the one thing that
+              stays — same size, same font, same position throughout — which is
+              why this reads as the mark contracting rather than a label being
+              swapped for an abbreviation. It used to be "SW" that survived, and
+              the creature inherited that job.
 
-              The accessible name comes from `aria-label` on the link, so the
-              split spans are never read out letter by letter.
+              HIDDEN FROM ASSISTIVE TECH. The word is split into per-letter
+              spans so it can be revealed a letter at a time, and exposed spans
+              like that risk being read out one letter at a time. The
+              `aria-label` on the link carries the whole name instead.
 
-              HIDDEN FROM ASSISTIVE TECH, for the same reason. Collapsed, the
-              mark reads "SW", which is not contained in "Storyboard Workbench
-              home" — Lighthouse flags that as `label-content-name-mismatch`
-              (WCAG 2.5.3 "Label in Name"): someone driving by voice says what
-              they see and matches nothing. The mark is branding, not a label,
-              so the label carries the name and the letters carry none.
+              AND THE TWO NAMES AGREE NOW, which they did not before. The label
+              was "Storyboard Workbench home" while the mark read "storyboard
+              monster" — a visible name not contained in the accessible one,
+              which is `label-content-name-mismatch` (WCAG 2.5.3 "Label in
+              Name"): someone driving by voice says what they see and matches
+              nothing. With the label reading "Media Monster home" over a mark
+              that reads "media monster", what you say is what is there. The
+              letters stay hidden regardless — that is about how they are
+              split, not about what they spell.
 
               `display: contents` so hiding them costs no layout — the letters
               keep participating in the link's own flex box. */}


### PR DESCRIPTION
The rail's home link was still called "Storyboard Workbench home". It is the
media monster's now.

## This closes a real mismatch, not just a name

The mark's letters are split into per-letter spans so they can be revealed one
at a time, and they are hidden from assistive tech for that reason — so the
link's entire accessible name comes from its `aria-label`, and the word on
screen has to be CONTAINED in it.

It was not. The label said "Storyboard Workbench home" over a mark that read
"storyboard monster". That is WCAG 2.5.3 "Label in Name", and the failure mode
is someone driving by voice saying what they can see and matching nothing.

It was invisible precisely BECAUSE the letters are hidden — there is no way to
notice it by using the app, and nothing checked it.

## So it is checked now

The pairing is asserted in the sidebar's `Expanded` story as a RELATIONSHIP
rather than as two literals: whatever the mark shows must appear in whatever the
label says. Renaming the product in one place and not the other fails there
instead of shipping.

Watched it fail first against the old label, which is the whole point of writing
it:

```
AssertionError: expected 'storyboard workbench home' to contain 'media monster'
```

The creature stands in for the "o", so it is put back before the comparison: the
DOM says `media mnster` and the eye reads `media monster`. The story finds the
link BY the creature rather than by taking the first labelled anchor, so it
cannot drift onto some other link in the rail and compare the wrong pair.

## Stale comments corrected

Two neighbouring notes went stale a rename ago: the mark has not collapsed to
"SW" since the creature took the monogram's place, and the note explaining why
the letters are hidden was arguing from the mismatch this removes.

## Verification

12 sidebar and mark stories pass, 1474 app tests, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
