### PR TITLE
PL16-011 — the grip sits on the edge, and the band it needed goes away

### DIFF
--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1762,12 +1762,13 @@ test.describe("graph view E2E", () => {
     await expect.poll(heightOf).toBeGreaterThan(0);
     const initial = await heightOf();
 
-    // 22px IN FLOW (PL16-007): the spec's 8px gap under the controls row, then
-    // the pane's 14px lip. It was 44 — a well tall enough to hold the
-    // transport, which used to ride on it and no longer does.
+    // 12px IN FLOW (PL16-011). It was 44 when it was a well tall enough to hold
+    // the transport, 22 when the transport left and it became the pane's lip,
+    // and 12 now that the grip sits ON the edge instead of floating in a lip
+    // above it — the band that used to hold the grip is space the pane got back.
     expect(
       await divider.evaluate((el) => Math.round(el.getBoundingClientRect().height)),
-    ).toBe(22);
+    ).toBe(12);
     // THE HIT TARGET IS BIGGER THAN THE BOX, and reaches DOWN only. It
     // straddles the edge so a pointer aimed at the gap between the panes still
     // catches it; reaching up would put it under the controls row.
@@ -1782,6 +1783,19 @@ test.describe("graph view E2E", () => {
     const gripBox = await grip.boundingBox();
     expect(Math.round(gripBox!.width)).toBe(40);
     expect(Math.round(gripBox!.height)).toBe(4);
+    // HALF ON, HALF OFF (PL16-011). The grip is centred on the boundary between
+    // the divider and the pane it drags, so it reads as attached to that pane
+    // rather than as a separate bar floating above it with a gap of its own to
+    // explain.
+    //
+    // MEASURED AGAINST THE DIVIDER'S OWN BOTTOM EDGE, not against the lower
+    // pane's box. They are the same line in flow, but the preview region is
+    // STICKY — once the page scrolls, the pane's box starts well above the
+    // divider while the divider is pinned, and the reading becomes about scroll
+    // position rather than about the grip.
+    const dividerBottom = dividerBoxForZone!.y + dividerBoxForZone!.height;
+    expect(Math.round(gripBox!.y + gripBox!.height / 2)).toBe(Math.round(dividerBottom));
+    expect(Math.round(gripBox!.y + gripBox!.height - dividerBottom)).toBe(2);
     const splitPane = page.getByTestId("workbench-split-pane");
     const displaySurface = page.getByTestId("workbench-display-surface");
     expect(
@@ -2784,7 +2798,7 @@ test.describe("graph view E2E", () => {
 
     // THE DIVIDER IS THE PANE'S EDGE. Its old band is gone entirely, and the
     // resting affordance is a grip pill rather than a rule.
-    expect(Math.round(dividerBox!.height)).toBe(22);
+    expect(Math.round(dividerBox!.height)).toBe(12);
     await expect(divider.locator("[data-divider-line]")).toHaveCount(0);
     const gripBox = (await divider.locator("[data-divider-grip]").boundingBox())!;
     expect(Math.round(gripBox.width)).toBe(40);

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -139,8 +139,9 @@ export const StickyPreview: Story = {
     expect(Math.round(buttonGroupBox.width)).toBe(168);
     expect(Math.round(buttonGroupBox.height)).toBe(36);
     expect(controls.querySelector("[data-transport-capsule]")).toBeNull();
-    // 22px: the spec's 8px gap under the row, then the pane's 14px lip.
-    expect(Math.round(dividerBox.height)).toBe(22);
+    // 12px (PL16-011): the grip sits ON the edge now rather than floating in a
+    // lip above it, so the band that used to hold it is space the pane got back.
+    expect(Math.round(dividerBox.height)).toBe(12);
     // THE GRIP IS THE RESTING AFFORDANCE now — a 40x4 pill, painted at every
     // width. It used to be a coarse-pointer-only mark, hidden at desktop.
     const grip = divider.querySelector<HTMLElement>("[data-divider-grip]");
@@ -148,6 +149,11 @@ export const StickyPreview: Story = {
     const gripBox = grip!.getBoundingClientRect();
     expect(Math.round(gripBox.width)).toBe(40);
     expect(Math.round(gripBox.height)).toBe(4);
+    // HALF ON, HALF OFF: centred on the divider's own bottom edge, which is the
+    // top of the pane it drags.
+    expect(Math.round(gripBox.y + gripBox.height / 2)).toBe(
+      Math.round(dividerBox.y + dividerBox.height),
+    );
     // A PILL, NOT A RULE — the distinction the redesign turns on.
     expect(gripBox.width).toBeLessThan(dividerBox.width / 4);
     // THE HIT TARGET STRADDLES THE EDGE: it reaches 8px past the box into the

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -232,27 +232,41 @@ const MIN_TIMELINE_SPACE = 260;
  * THE DIVIDER'S HEIGHT IN FLOW, and what `--workbench-preview-offset` is built
  * from, so anything pinned below the sticky stack follows it.
  *
- * 22, DOWN FROM 44. It used to be a well tall enough to hold the transport,
- * which rode on it; the transport is a row of its own now, so this is back to
- * the size of the thing it actually draws — the spec's 8px gap under the
- * controls row, then the pane's 14px lip.
+ * 12, DOWN FROM 22, DOWN FROM 44. It was 44 when it was a well tall enough to
+ * hold the transport; 22 when the transport left and it became the pane's lip.
+ * It is 12 now because the grip no longer needs a lip to sit IN — it sits ON
+ * the edge, half over the content below, so the band that used to hold it is
+ * space the pane gets back.
  *
- * IT IS NO LONGER THE HIT TARGET. The zone inside it reaches 8px further down,
- * into the pane below, for the 30px the spec asks for. It deliberately does not
- * reach UP: 8px above this box is the controls row, and a resize that starts on
- * a button is what the old arrangement needed a `stopPropagation` on every
+ * IT IS NO LONGER THE HIT TARGET. The zone inside it reaches further down, into
+ * the pane below, for the ~30px the spec asks for. It deliberately does not
+ * reach UP: just above this box is the controls row, and a resize that starts
+ * on a button is what the old arrangement needed a `stopPropagation` on every
  * control to prevent.
  */
-const DIVIDER_HEIGHT_PX = 22;
+const DIVIDER_HEIGHT_PX = 12;
+// KEPT IN STEP BY HAND with the `h-[12px]` on the button below, and it has to
+// be: Tailwind scans source text, so `h-[${DIVIDER_HEIGHT_PX}px]` compiles to
+// nothing and the divider collapses to zero height. Changing one and not the
+// other is a silent disagreement — the box is one size while every sticky
+// offset built from this constant assumes another — which is exactly what
+// happened on the first pass of this change.
 
-/** The gap between the controls row and the pane's lip, and therefore where the
- *  lip — and the edge line drawn along its top — begins inside the box. */
-const DIVIDER_LIP_TOP_PX = 8;
+/**
+ * HALF THE GRIP, so it can be centred ON the boundary rather than above it.
+ *
+ * The grip is drawn 4px tall at the divider's own bottom edge minus this, which
+ * puts two pixels inside the divider and two over the content below. That is
+ * the whole point of the placement: a handle that overlaps the thing it moves
+ * reads as attached to it, where one floating clear of it reads as a separate
+ * bar with a gap of its own to explain.
+ */
+const DIVIDER_GRIP_HALF_PX = 2;
 
-/** How far the invisible zone reaches PAST the box, into the pane below. 8 + 22
- *  is the spec's ~30px target, straddling the edge so a pointer aimed at the
- *  gap between the panes still catches it. */
-const DIVIDER_ZONE_OVERHANG_PX = 8;
+/** How far the invisible zone reaches PAST the box, into the pane below.
+ *  12 + 18 is the spec's ~30px target, straddling the edge so a pointer aimed
+ *  at the gap between the panes still catches it. */
+const DIVIDER_ZONE_OVERHANG_PX = 18;
 
 /** One arrow press. Big enough to be worth pressing, small enough to place an
  *  edge with. */
@@ -3148,7 +3162,7 @@ export function WorkbenchSplitPane({
           // it. It does NOT reach upward: 8px above this box is the controls
           // row, and a resize that starts on a button is the bug the old
           // arrangement needed a `stopPropagation` on every control to avoid.
-          className="group relative block h-[22px] w-full cursor-ns-resize bg-transparent transition-opacity duration-300 ease-out [[data-preview-chrome='out']_&]:opacity-0 motion-reduce:transition-none focus-visible:outline-none"
+          className="group relative block h-[12px] w-full cursor-ns-resize bg-transparent transition-opacity duration-300 ease-out [[data-preview-chrome='out']_&]:opacity-0 motion-reduce:transition-none focus-visible:outline-none"
           data-workbench-divider
           data-divider-dragging={isDividerDragging ? "" : undefined}
           // PUBLISHED, so the reach state is a fact a test can read directly
@@ -3198,7 +3212,9 @@ export function WorkbenchSplitPane({
             // exactly that reason: it is the fact, and it is readable the
             // instant it is true.
             style={{
-              top: DIVIDER_LIP_TOP_PX,
+              // ON THE EDGE ITSELF, not on a lip above it — this line IS the
+              // top of the content below.
+              bottom: 0,
               backgroundColor: isDividerDragging
                 ? DIVIDER_ACCENT
                 : isDividerHovered
@@ -3207,14 +3223,20 @@ export function WorkbenchSplitPane({
             }}
             data-divider-edge
           />
-          {/* THE LIP, and the grip pill centred in it. The pill is the resting
-              affordance — the one thing visible when nothing is hovered — and
-              it is a shape rather than a line, so it says "handle" without
-              adding a rule that competes with the scrubber. */}
+          {/* THE GRIP, STRADDLING THE EDGE — half over the divider, half over
+              the content it moves. The pill is the resting affordance, the one
+              thing visible when nothing is hovered, and it is a shape rather
+              than a line so it says "handle" without adding a rule that
+              competes with the scrubber.
+
+              IT USED TO FLOAT IN A LIP ABOVE THE CONTENT, which cost 10px of
+              band to hold it and read as a separate bar with its own gap to
+              explain. Sitting ON the edge is what makes it read as attached to
+              the thing it drags, and it is why the band could go. */}
           <span
             aria-hidden="true"
             className="pointer-events-none absolute inset-x-0 grid place-items-center"
-            style={{ top: DIVIDER_LIP_TOP_PX, height: DIVIDER_HEIGHT_PX - DIVIDER_LIP_TOP_PX }}
+            style={{ bottom: -DIVIDER_GRIP_HALF_PX, height: DIVIDER_GRIP_HALF_PX * 2 }}
           >
             <span
               className="block h-1 w-10 rounded-sm transition-colors duration-[120ms]"


### PR DESCRIPTION
The handle floated in a lip ABOVE the pane it drags, with a gap of its own
between the two. It sits on the boundary now — half over the divider, half over
the content — and the band that existed to hold it is space the pane gets back.

## The placement is what paid for the height

A grip needs a lip only while it is floating clear of the thing it moves.
Centred on the edge it needs two pixels either side of a line that already
exists.

So **22px becomes 12**: the 8px gap under the controls row stays, and the 14px
lip becomes 4px of grip straddling the boundary. Ten pixels back, and the handle
reads as attached to the pane rather than as a separate bar with its own gap to
explain.

Measured:

```
dividerH: 12   dividerBottom: 318   lowerTop: 318
gripTop: 316   gripBottom: 320      gripOverContent: 2
```

The hover line moves with it, from the lip's top to the boundary itself, so the
line and the grip are now the SAME line — one object lighting up rather than two
marks agreeing.

## The hit target is unchanged

Still ~30px, which is the point of taking the height out of the overhang rather
than out of the box: the zone reaches 18px into the pane below instead of 8, so
a shorter divider is not a harder one to grab. It still does not reach UP, where
the controls row is.

## One number, two places

`DIVIDER_HEIGHT_PX` feeds the sticky-offset arithmetic, while the box's actual
height is a LITERAL Tailwind class (`h-[12px]`) because Tailwind scans source
text and a template compiles to nothing.

The first pass of this change moved the constant alone, which left the box at 22
while every offset built from the constant assumed 12. The measurement caught it
immediately. Both move together now, with a note saying they must.

## The assertion

The grip's centre line IS the divider's own bottom edge — a relationship rather
than two numbers that happen to agree today.

Measured against that edge and not against the lower pane's box: they are the
same line in flow, but the preview region is sticky, so once the page scrolls
the pane's box starts well above the divider and the reading becomes about
scroll position instead of about the grip. That cost one failed run to notice.

## Verification

8 preview/divider e2e tests pass, 23 split-pane stories pass, tsc and lint clean.
Rest, hover and drag states all photographed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
