### PR TITLE
PL16-012 — the collection badge stands down, the disc shrinks, the pause mark dissolves

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-card-badges.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-badges.tsx
@@ -245,27 +245,10 @@ export function SelectionIndicator({
         // because this was reachable outside it; now it only exists once the
         // mode is on, so arming would be a no-op restating the obvious.
       }}
-      // HALF STRENGTH UNTIL IT IS TICKED (PL16-012).
-      //
-      // Arming select mode puts one of these on EVERY card at once, and at full
-      // strength a screen of bright white rings competes with the artwork they
-      // are drawn over — which is the thing being chosen. Dimming the empty
-      // ones lets the eye go to the pictures and back to the controls, instead
-      // of to a grid of identical circles.
-      //
-      // A TICKED ONE STAYS FULL, deliberately. It is not decoration at that
-      // point, it is the answer to "what have I got" — the one piece of state
-      // select mode exists to show — and fading it would dim the signal along
-      // with the noise. So the contrast between chosen and not chosen goes UP
-      // rather than down.
-      //
-      // No "restore on exit" is needed and none is written: the checkbox is not
-      // rendered at all outside select mode (see the early return above), so
-      // there is no other state for it to be in.
       className={[
         "absolute right-2 bottom-2 z-20 grid size-[26px] cursor-pointer place-items-center",
-        "rounded-full border-2 backdrop-blur-sm motion-safe:transition-[colors,opacity]",
-        selected ? "border-blue-500 bg-blue-500 opacity-100" : "border-white/90 bg-black/35 opacity-50",
+        "rounded-full border-2 backdrop-blur-sm motion-safe:transition-colors",
+        selected ? "border-blue-500 bg-blue-500" : "border-white/90 bg-black/35",
       ].join(" ")}
     >
       <Check

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-badges.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-badges.tsx
@@ -245,10 +245,27 @@ export function SelectionIndicator({
         // because this was reachable outside it; now it only exists once the
         // mode is on, so arming would be a no-op restating the obvious.
       }}
+      // HALF STRENGTH UNTIL IT IS TICKED (PL16-012).
+      //
+      // Arming select mode puts one of these on EVERY card at once, and at full
+      // strength a screen of bright white rings competes with the artwork they
+      // are drawn over — which is the thing being chosen. Dimming the empty
+      // ones lets the eye go to the pictures and back to the controls, instead
+      // of to a grid of identical circles.
+      //
+      // A TICKED ONE STAYS FULL, deliberately. It is not decoration at that
+      // point, it is the answer to "what have I got" — the one piece of state
+      // select mode exists to show — and fading it would dim the signal along
+      // with the noise. So the contrast between chosen and not chosen goes UP
+      // rather than down.
+      //
+      // No "restore on exit" is needed and none is written: the checkbox is not
+      // rendered at all outside select mode (see the early return above), so
+      // there is no other state for it to be in.
       className={[
         "absolute right-2 bottom-2 z-20 grid size-[26px] cursor-pointer place-items-center",
-        "rounded-full border-2 backdrop-blur-sm motion-safe:transition-colors",
-        selected ? "border-blue-500 bg-blue-500" : "border-white/90 bg-black/35",
+        "rounded-full border-2 backdrop-blur-sm motion-safe:transition-[colors,opacity]",
+        selected ? "border-blue-500 bg-blue-500 opacity-100" : "border-white/90 bg-black/35 opacity-50",
       ].join(" ")}
     >
       <Check

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -248,7 +248,28 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
                   A background-colour alpha, NOT `opacity` on the wrapper,
                   which would take the glyph down along with it (0.45 × its own
                   0.5). */}
-            <span className="rounded-full bg-black/45 p-2">
+            <span
+              data-collection-badge
+              // HALF STRENGTH WHILE SELECT MODE IS ON (PL16-012), back to full
+              // when it ends.
+              //
+              // The badge names what the card IS, which is worth saying while
+              // you are browsing and beside the point while you are picking —
+              // then the question is which cards, and the badge is the loudest
+              // thing on a collection sitting right where the eye is counting.
+              //
+              // ON THE WRAPPER, which the note above warns against — and the
+              // warning is about doing it by ACCIDENT. It says an opacity here
+              // "would take the glyph down along with it (0.45 x its own 0.5)",
+              // and taking the whole badge down together is exactly the intent:
+              // the disc is the glyph's ground, so fading one without the other
+              // leaves strokes floating on a ring or a ring around nothing.
+              // Compounding is the mechanism, not a side effect.
+              className={[
+                "rounded-full bg-black/45 p-2 motion-safe:transition-opacity motion-safe:duration-200",
+                selectMode ? "opacity-50" : "opacity-100",
+              ].join(" ")}
+            >
               <Layers
                 className="h-10 w-10 text-white opacity-50 drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
                 strokeWidth={1.5}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -2758,8 +2758,8 @@ test.describe("graph view E2E", () => {
     expect(
       Math.abs(groupBox!.x + groupBox!.width / 2 - (surfaceBox!.x + surfaceBox!.width / 2)),
     ).toBeLessThanOrEqual(1);
-    // Four 30px ghosts, a 36px play disc, and its 6px margins.
-    expect(Math.round(groupBox!.width)).toBe(168);
+    // Four 30px ghosts, a 32px play disc, and its 6px margins.
+    expect(Math.round(groupBox!.width)).toBe(164);
     expect(await controls.locator("[data-transport-capsule]").count()).toBe(0);
 
     // `m:ss.d`, the same function the scrubber's tooltip spends — the spec
@@ -2961,6 +2961,56 @@ test.describe("graph view E2E", () => {
     await expect.poll(hintOpacity).toBe(0);
   });
 
+  test("the pause mark says its piece and dissolves", async ({ page }) => {
+    // PL16-013. The mark over the picture is an INVITATION while paused and an
+    // ANSWER while playing, and an answer only needs saying once. It used to
+    // sit there for as long as the pointer did — a pause glyph parked over a
+    // running shot, which is a thing in the shot, and the one thing this
+    // overlay exists to avoid.
+    const api = await installGraphApi(page);
+    // The fixture's "video" is a data-URI image, so the first clip is made an
+    // image here to get a real playback surface without reaching the network.
+    api.documents.get(PROJECT_ID)!.clips[0]!.kind = "image";
+    api.documents.get(PROJECT_ID)!.clips[0]!.startTime = 0;
+    await openGraph(page);
+    await previewToggle(page).click();
+
+    const canvas = page.getByTestId("workbench-display-canvas");
+    await expect(canvas).toHaveAttribute("data-preview-playback-surface-ready", "true");
+    const hint = page.getByTestId("workbench-hover-transport-hint");
+    const opacity = () => hint.evaluate((element) => Number(getComputedStyle(element).opacity));
+    const box = (await canvas.boundingBox())!;
+    const centre = { x: box.width / 2, y: box.height / 2 };
+
+    // PAUSED, IT STAYS. Nothing else says the whole picture is a play target,
+    // so the invitation holds for as long as the pointer does.
+    await canvas.hover({ position: centre });
+    await expect.poll(opacity, { timeout: 3000 }).toBeGreaterThan(0);
+    await expect(hint).toHaveAttribute("data-hint", "play");
+    await page.waitForTimeout(1500);
+    expect(await opacity()).toBeGreaterThan(0);
+
+    // PLAYING, IT ANSWERS AND GOES. The pointer does NOT move for the rest of
+    // this — which is the whole point. A hover-driven overlay would still be up.
+    await canvas.click({ position: centre });
+    await expect(page.getByTestId("workbench-display-surface")).toHaveAttribute(
+      "data-preview-playing",
+      "true",
+    );
+    await expect(hint).toHaveAttribute("data-hint", "pause");
+    await expect.poll(opacity, { timeout: 3000 }).toBe(0);
+
+    // AND IT COMES BACK WHEN IT HAS SOMETHING TO SAY AGAIN. Pausing makes the
+    // mark an invitation once more, so it returns and stays.
+    await canvas.click({ position: centre });
+    await expect(page.getByTestId("workbench-display-surface")).toHaveAttribute(
+      "data-preview-playing",
+      "false",
+    );
+    await expect.poll(opacity, { timeout: 3000 }).toBeGreaterThan(0);
+    await expect(hint).toHaveAttribute("data-hint", "play");
+  });
+
   test("preview audio: mute and volume survive a pane toggle", async ({ page }) => {
     const api = await installGraphApi(page);
     api.documents.get(PROJECT_ID)!.clips[0]!.kind = "image";
@@ -3035,9 +3085,9 @@ test.describe("graph view E2E", () => {
       .poll(() =>
         buttonGroup.evaluate((element) => Math.round(element.getBoundingClientRect().width)),
       )
-      // 4 × 30px ghost wells + a 36px play disc + its 6px margins (PL16-007).
+      // 4 × 30px ghost wells + a 32px play disc + its 6px margins.
       // It was 220 — five 44px wells — while the row rode the divider.
-      .toBe(168);
+      .toBe(164);
     await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
     // The whole point of this test is TOUCH reach, so the two new edge buttons
@@ -3078,7 +3128,7 @@ test.describe("graph view E2E", () => {
       .poll(() =>
         buttonGroup.evaluate((element) => Math.round(element.getBoundingClientRect().width)),
       )
-      .toBe(168);
+      .toBe(164);
     await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
     await expect(
@@ -8646,6 +8696,26 @@ test.describe("graph view E2E", () => {
       )
       .toBeGreaterThan(0);
 
+    // AND THE EMPTY ONES SIT BACK (PL16-012). Arming puts a checkbox on EVERY
+    // card at once; at full strength that is a grid of identical bright rings
+    // competing with the artwork being chosen. A TICKED one keeps full
+    // strength, because at that point it is not decoration — it is the answer
+    // to "what have I got", the one piece of state select mode exists to show.
+    //
+    // ASSERTED AS THE CONTRAST, not as two loose numbers: the chosen one must
+    // be strictly stronger than the unchosen. Dimming both, or neither, is the
+    // regression, and either would slip past a pair of independent checks.
+    const opacityOf = (which: "on" | "off") =>
+      surface
+        .locator(`[data-selection-indicator="${which}"]`)
+        .first()
+        .evaluate((element) => Number(getComputedStyle(element).opacity));
+    const chosen = await opacityOf("on");
+    const unchosen = await opacityOf("off");
+    expect(chosen).toBe(1);
+    expect(unchosen).toBe(0.5);
+    expect(chosen).toBeGreaterThan(unchosen);
+
     await selectionAction(page, /^Copy$/);
 
     // The checkboxes go — the mode is over as far as the CARDS are concerned.
@@ -8998,9 +9068,16 @@ test.describe("graph view E2E", () => {
     await page.mouse.move(0, 0);
     await expect(boxes.first()).toBeVisible();
     await expect(boxes.first()).toHaveAttribute("data-selection-indicator-reveal", "armed");
+    // PAINTED WITHOUT A POINTER NEAR IT, which is this test's subject — it
+    // replaced a hover-reveal that could stick on the last-tapped card.
+    //
+    // 0.5, NOT 1 (PL16-012): an unpicked box sits back so a screen of them does
+    // not compete with the artwork. What matters here is that it is on screen
+    // at all with the pointer parked at the origin, so the assertion is against
+    // the armed resting value rather than against full strength.
     await expect
-      .poll(() => boxes.first().evaluate((el) => getComputedStyle(el).opacity))
-      .toBe("1");
+      .poll(() => boxes.first().evaluate((el) => Number(getComputedStyle(el).opacity)))
+      .toBe(0.5);
 
     // Leaving the mode takes them all away again.
     await page.locator("[data-select-mode-toggle]").click();
@@ -9063,9 +9140,11 @@ test.describe("graph view E2E", () => {
       await page.locator("[data-select-mode-toggle]").tap();
       const checkbox = card.locator("[data-selection-indicator]");
       await expect(checkbox).toHaveAttribute("data-selection-indicator-reveal", "armed");
+      // 0.5 since PL16-012 — an unpicked box sits back. On screen is the point
+      // here, not full strength.
       await expect
-        .poll(() => checkbox.evaluate((el) => getComputedStyle(el).opacity))
-        .toBe("1");
+        .poll(() => checkbox.evaluate((el) => Number(getComputedStyle(el).opacity)))
+        .toBe(0.5);
     });
     test("touch gets 44px hit targets on every selection control", async ({ page }) => {
       await installGraphApi(page);

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -8696,25 +8696,6 @@ test.describe("graph view E2E", () => {
       )
       .toBeGreaterThan(0);
 
-    // AND THE EMPTY ONES SIT BACK (PL16-012). Arming puts a checkbox on EVERY
-    // card at once; at full strength that is a grid of identical bright rings
-    // competing with the artwork being chosen. A TICKED one keeps full
-    // strength, because at that point it is not decoration — it is the answer
-    // to "what have I got", the one piece of state select mode exists to show.
-    //
-    // ASSERTED AS THE CONTRAST, not as two loose numbers: the chosen one must
-    // be strictly stronger than the unchosen. Dimming both, or neither, is the
-    // regression, and either would slip past a pair of independent checks.
-    const opacityOf = (which: "on" | "off") =>
-      surface
-        .locator(`[data-selection-indicator="${which}"]`)
-        .first()
-        .evaluate((element) => Number(getComputedStyle(element).opacity));
-    const chosen = await opacityOf("on");
-    const unchosen = await opacityOf("off");
-    expect(chosen).toBe(1);
-    expect(unchosen).toBe(0.5);
-    expect(chosen).toBeGreaterThan(unchosen);
 
     await selectionAction(page, /^Copy$/);
 
@@ -9068,20 +9049,27 @@ test.describe("graph view E2E", () => {
     await page.mouse.move(0, 0);
     await expect(boxes.first()).toBeVisible();
     await expect(boxes.first()).toHaveAttribute("data-selection-indicator-reveal", "armed");
-    // PAINTED WITHOUT A POINTER NEAR IT, which is this test's subject — it
-    // replaced a hover-reveal that could stick on the last-tapped card.
-    //
-    // 0.5, NOT 1 (PL16-012): an unpicked box sits back so a screen of them does
-    // not compete with the artwork. What matters here is that it is on screen
-    // at all with the pointer parked at the origin, so the assertion is against
-    // the armed resting value rather than against full strength.
     await expect
-      .poll(() => boxes.first().evaluate((el) => Number(getComputedStyle(el).opacity)))
-      .toBe(0.5);
+      .poll(() => boxes.first().evaluate((el) => getComputedStyle(el).opacity))
+      .toBe("1");
+
+    // AND A COLLECTION'S BADGE STANDS DOWN WHILE THE MODE IS ON (PL16-012).
+    //
+    // The badge names what the card IS, which is worth saying while browsing
+    // and beside the point while picking — and it is the loudest thing on a
+    // collection, sitting right where the eye is counting. Half strength hands
+    // that ground to the checkbox.
+    const badge = surface.locator("[data-collection-badge]").first();
+    const badgeOpacity = () =>
+      badge.evaluate((element) => Number(getComputedStyle(element).opacity));
+    await expect.poll(badgeOpacity, { timeout: 3000 }).toBe(0.5);
 
     // Leaving the mode takes them all away again.
     await page.locator("[data-select-mode-toggle]").click();
     await expect(surface.locator("[data-selection-indicator]")).toHaveCount(0);
+    // AND GIVES THE BADGE BACK. This is the half that cannot be checked from
+    // inside the mode, and the half a one-way dim would silently fail.
+    await expect.poll(badgeOpacity, { timeout: 3000 }).toBe(1);
   });
 
   test("clicking the checkbox toggles — on a collection, where the rest of the card drills", async ({
@@ -9140,11 +9128,9 @@ test.describe("graph view E2E", () => {
       await page.locator("[data-select-mode-toggle]").tap();
       const checkbox = card.locator("[data-selection-indicator]");
       await expect(checkbox).toHaveAttribute("data-selection-indicator-reveal", "armed");
-      // 0.5 since PL16-012 — an unpicked box sits back. On screen is the point
-      // here, not full strength.
       await expect
-        .poll(() => checkbox.evaluate((el) => Number(getComputedStyle(el).opacity)))
-        .toBe(0.5);
+        .poll(() => checkbox.evaluate((el) => getComputedStyle(el).opacity))
+        .toBe("1");
     });
     test("touch gets 44px hit targets on every selection control", async ({ page }) => {
       await installGraphApi(page);

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -133,11 +133,11 @@ export const StickyPreview: Story = {
     const dividerBox = divider.getBoundingClientRect();
     // THE OLD BAND IS GONE, not restyled.
     expect(divider.querySelector("[data-divider-line]")).toBeNull();
-    // Four 30px ghost wells, a 36px play disc, and its 6px side margins. Pinned
+    // Four 30px ghost wells, a 32px play disc, and its 6px side margins. Pinned
     // rather than derived: it is the number the row's centre column is, and a
     // hard value is what makes a change to the control set fail loudly.
-    expect(Math.round(buttonGroupBox.width)).toBe(168);
-    expect(Math.round(buttonGroupBox.height)).toBe(36);
+    expect(Math.round(buttonGroupBox.width)).toBe(164);
+    expect(Math.round(buttonGroupBox.height)).toBe(32);
     expect(controls.querySelector("[data-transport-capsule]")).toBeNull();
     // 12px (PL16-011): the grip sits ON the edge now rather than floating in a
     // lip above it, so the band that used to hold it is space the pane got back.

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -272,6 +272,11 @@ const DIVIDER_ZONE_OVERHANG_PX = 18;
  *  edge with. */
 const DIVIDER_NUDGE_PX = 8;
 
+/** How long the pause mark stays up after playback starts before dissolving.
+ *  Long enough to be read, short enough that it is gone before it becomes part
+ *  of the shot. */
+const PLAY_HINT_LINGER_MS = 900;
+
 /** The accent the grip and the edge line both take while the split is being
  *  dragged. ONE constant so the two cannot drift apart mid-gesture, and
  *  `sky-400` — the accent this file's focus rings already use — rather than the
@@ -477,7 +482,12 @@ function WorkbenchTransportRow({
           <SkipBack className="size-[17px] fill-current" />
         </button>
 
-        {/* WHITE AT REST, not on hover. The old control was background-free
+        {/* 32px, DOWN FROM THE SPEC'S 36. The disc is the only filled shape in
+            the row and the only white one, so it carries weight out of
+            proportion to its size — a step down still reads as the primary
+            control while sitting closer to the 30px ghosts either side of it.
+
+            WHITE AT REST, not on hover. The old control was background-free
             until the preview or the button was hovered and then inverted to a
             white disc; the spec makes the disc the resting state, because play
             is the one thing in this row you look for without hunting. There is
@@ -487,18 +497,18 @@ function WorkbenchTransportRow({
           type="button"
           onClick={onTogglePlaying}
           disabled={!canPlay}
-          className="mx-1.5 grid size-9 shrink-0 place-items-center rounded-full bg-white text-zinc-950 transition-colors hover:bg-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-40"
+          className="mx-1.5 grid size-8 shrink-0 place-items-center rounded-full bg-white text-zinc-950 transition-colors hover:bg-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label={isPlaying ? "Pause workbench preview" : "Play workbench preview"}
           title={isPlaying ? "Pause" : "Play"}
           data-transport-primary-control
         >
           {isPlaying ? (
-            <Pause className="size-[15px] fill-current" />
+            <Pause className="size-[14px] fill-current" />
           ) : (
             // Nudged right: a triangle's visual centre is left of its bounding
             // box, so a geometrically centred play glyph reads as sitting back
             // in its disc.
-            <Play className="ml-0.5 size-[15px] fill-current" />
+            <Play className="ml-0.5 size-[14px] fill-current" />
           )}
         </button>
 
@@ -916,6 +926,7 @@ export function WorkbenchDisplaySurface({
   const isControlledPlayback = playing !== undefined;
   const [uncontrolledPlaying, setUncontrolledPlaying] = useState(false);
   const [previewHovered, setPreviewHovered] = useState(false);
+
   const isPlaying = playing ?? uncontrolledPlaying;
   const setPlaying = useCallback(
     (next: boolean) => {
@@ -2093,6 +2104,33 @@ export function WorkbenchDisplaySurface({
   }, [activeMuted, activeVolume, applyGain, getMixer]);
 
   const canPlay = duration > 0 && sortedClips.length > 0;
+
+  /**
+   * THE PLAY/PAUSE MARK OVER THE PICTURE — up only while it is saying something.
+   *
+   * PAUSED, it is an invitation and it stays for as long as the pointer does:
+   * the whole picture is a play target and nothing else says so.
+   *
+   * PLAYING, it is an ANSWER, and an answer only needs saying once. It used to
+   * sit there for as long as the pointer did — a pause glyph parked over a
+   * running shot, which is a thing in the shot, and the one thing this overlay
+   * exists to avoid. So it shows for a moment and dissolves.
+   *
+   * RE-ARMED BY THE POINTER ARRIVING, not only by playback starting, so someone
+   * who leaves and comes back still gets told what a click will do. What it
+   * will not do is stay.
+   */
+  const [playHintShown, setPlayHintShown] = useState(false);
+  useEffect(() => {
+    if (!canPlay || !previewHovered) {
+      setPlayHintShown(false);
+      return;
+    }
+    setPlayHintShown(true);
+    if (!isPlaying) return;
+    const timer = window.setTimeout(() => setPlayHintShown(false), PLAY_HINT_LINGER_MS);
+    return () => window.clearTimeout(timer);
+  }, [canPlay, isPlaying, previewHovered]);
   const canSeekPrevious = sortedClips.length > 0 && currentTime > 0;
   const canSeekNext = sortedClips.length > 0 && activeClipIndex < sortedClips.length - 1;
   // The EDGE pair asks a different question from the stepper pair above:
@@ -2205,8 +2243,12 @@ export function WorkbenchDisplaySurface({
           data-hint={isPlaying ? "pause" : "play"}
           className={cn(
             "pointer-events-none absolute inset-0 grid place-items-center",
-            "transition-opacity duration-200 ease-out motion-reduce:transition-none",
-            canPlay && previewHovered ? "opacity-[0.10]" : "opacity-0",
+            // A SLOWER FADE WHILE PLAYING, because that one is a dissolve the
+            // eye is meant to follow out rather than a hover state snapping
+            // off. Paused, the mark tracks the pointer and wants to be quick.
+            isPlaying ? "transition-opacity duration-[600ms]" : "transition-opacity duration-200",
+            "ease-out motion-reduce:transition-none",
+            playHintShown ? "opacity-[0.10]" : "opacity-0",
           )}
         >
           {isPlaying ? (


### PR DESCRIPTION
Three changes to the preview and select-mode chrome, all the same idea: a
control that is present is not the same as a control that is shouting.

## The collection badge stands down while you are picking

Full while browsing, half while select mode is on, full again when it ends.

The badge names what the card IS, which is worth saying while you are browsing
and beside the point while you are picking — then the question is WHICH cards,
and the badge is the loudest thing on a collection, sitting exactly where the
eye is counting. Standing it down hands that ground to the checkbox.

```
BROWSE: 1     SELECT: 0.5     BACK: 1
```

Applied to the WRAPPER, which the note there warns against — and that warning is
about doing it by accident. It says an opacity here "would take the glyph down
along with it (0.45 × its own 0.5)". Taking the whole badge down together is
exactly the intent: the disc is the glyph's ground, so fading one without the
other leaves strokes floating on a ring, or a ring around nothing. The
compounding is the mechanism, not a side effect, and the note now says which of
the two this is.

BOTH HALVES are asserted. A one-way dim would pass a test that only looked
inside the mode, and would leave every collection permanently faded after the
first use. Watched the dim fail without the change.

## The play disc goes 36 → 32

It is the only filled shape in the transport row and the only white one, so it
carries weight out of proportion to its size. A step down still reads as the
primary control while sitting closer to the 30px ghosts either side of it.

## The pause mark says its piece and dissolves

The mark over the picture is an INVITATION while paused — nothing else says the
whole picture is a play target, so it holds for as long as the pointer does.

While playing it is an ANSWER, and an answer only needs saying once. It used to
sit there for as long as the pointer did: a pause glyph parked over a running
shot, which is a thing in the shot, and the one thing that overlay exists to
avoid.

Measured, pointer held still throughout:

```
PAUSED+HOVER: 0.1  hint = play
JUST PLAYED:  0.1  hint = pause
AFTER LINGER: 0
```

Re-armed by the POINTER ARRIVING as well as by playback starting, so someone who
leaves and comes back is still told what a click will do. The fade is slower
while playing than while paused, because that one is a dissolve meant to be
followed out rather than a hover state snapping off.

## A correction inside this PR

The first commit dimmed the selection CHECKBOX, having read "the icon that
appears on items" as that. It meant the collection badge — and the giveaway was
the half of the request that made no sense for a checkbox: "back to full once
select mode is no longer active". The checkbox is not rendered at all outside
select mode, so it has no other state to return to. The badge does.

The second commit puts the checkbox back to full strength and moves the change
to the badge. The disc and the pause dissolve are unaffected.

## Verification

6 preview/selection e2e tests pass, 1474 app tests, 23 split-pane stories, tsc
and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
