### PR TITLE
Three small tidies in collections-core

### DIFF
--- a/packages/collections-core/index.ts
+++ b/packages/collections-core/index.ts
@@ -1,9 +1,14 @@
 // The framework-free graph engine, as its own package: node-safe, no React,
 // no dnd-kit, no "use client". Non-UI consumers (the timeline-domain
 // adapter, server code) depend on THIS package and stay dependency-light;
-// the UI package (`@storyboard/ui/dnd-collections`) builds its React views
-// on top and re-exports every symbol here through its barrel and its
-// `core/*` shims — one engine, two entry heights, not a second surface.
+// the UI package (`@storyboard/ui/dnd-collections`) builds its React views on
+// top and re-exports the symbols its consumers need through its own barrel.
+//
+// THIS PACKAGE IS THE ONLY PATH TO THE ENGINE. There used to be a second one:
+// `dnd-collections/core/*` held a re-export shim per module, so `./core/graph`
+// resolved too. PL16-016 deleted them and repointed all 75 imports here,
+// because two names for one module is how an engine starts looking like it
+// lives in two places. Import by subpath — `@storyboard/collections-core/graph`.
 
 export {
   buildGraph,

--- a/packages/collections-core/intents.ts
+++ b/packages/collections-core/intents.ts
@@ -77,9 +77,12 @@ export type RectLike = Readonly<{ left: number; top: number; width: number; heig
 /** A panel child's card rect, for gap resolution inside panel drops. */
 export type PanelChildRect = Readonly<{ id: NodeId; rect: RectLike }>;
 
-/** Central band of a collection card that means "nest inside" rather than "insert next to". */
-export const NEST_HOTSPOT_MIN = 0.25;
-export const NEST_HOTSPOT_MAX = 0.75;
+/** Central band of a collection card that means "nest inside" rather than "insert next to".
+ *  Module-private: nothing outside this file has ever read them, and an export
+ *  is a promise to keep a name. The band is still a tuning knob — it is just
+ *  tuned HERE, next to the arithmetic that spends it. */
+const NEST_HOTSPOT_MIN = 0.25;
+const NEST_HOTSPOT_MAX = 0.75;
 
 function isFinitePoint(point: Readonly<{ x: number; y: number }>): boolean {
   return Number.isFinite(point.x) && Number.isFinite(point.y);

--- a/packages/collections-core/numeric.test.ts
+++ b/packages/collections-core/numeric.test.ts
@@ -6,7 +6,6 @@ import {
   finitePositiveOrUndefined,
   nonNegativeIntegerOr,
   openUnitIntervalOr,
-  positiveIntegerOr,
   positiveIntegerOrUndefined,
 } from "./numeric";
 
@@ -29,11 +28,8 @@ describe("numeric option normalization", () => {
   });
 
   test("integer helpers enforce their lower bounds", () => {
-    expect(positiveIntegerOr(3, 7)).toBe(3);
     expect(positiveIntegerOrUndefined(3)).toBe(3);
-    expect(positiveIntegerOr(0, 7)).toBe(7);
     expect(positiveIntegerOrUndefined(0)).toBeUndefined();
-    expect(positiveIntegerOr(1.5, 7)).toBe(7);
     expect(positiveIntegerOrUndefined(Number.NaN)).toBeUndefined();
     expect(nonNegativeIntegerOr(0, 7)).toBe(0);
     expect(nonNegativeIntegerOr(-1, 7)).toBe(7);

--- a/packages/collections-core/numeric.ts
+++ b/packages/collections-core/numeric.ts
@@ -12,10 +12,6 @@ export function finiteNonNegativeOr(value: number | undefined, fallback: number)
   return value !== undefined && Number.isFinite(value) && value >= 0 ? value : fallback;
 }
 
-export function positiveIntegerOr(value: number | undefined, fallback: number): number {
-  return value !== undefined && Number.isInteger(value) && value > 0 ? value : fallback;
-}
-
 export function positiveIntegerOrUndefined(value: number | undefined): number | undefined {
   return value !== undefined && Number.isInteger(value) && value > 0 ? value : undefined;
 }


### PR DESCRIPTION
## Context

A review of `packages/collections-core` found very little to do. **86 of its 89 exported symbols have real consumers** (checked against 533 files across the app and every other package), and `tsc --noUnusedLocals --noUnusedParameters` over the package is clean — **zero internal dead code**. These are the three exceptions.

## The three

| | |
|---|---|
| **`positiveIntegerOr` deleted** | its only caller was its own test. Its six siblings in `numeric.ts` all have real consumers (1–4 each), so the module stays — this was the odd one out, not a dead file. |
| **`NEST_HOTSPOT_MIN`/`_MAX` un-exported** | not dead: the hotspot arithmetic in `intents.ts` reads both. But nothing outside the file ever imported them, and an export is a promise to keep a name. |
| **`index.ts` header fixed** | it still said the UI package re-exports the engine "through its barrel and its `core/*` shims". #561 deleted those shims and repointed all 75 imports here, so the sentence described a route that no longer exists. |

## For the record — what the package looks like

**2,149 lines of real code** across 9 modules (3,155 raw), plus 11 test files / **210 tests** / 3,711 raw lines — about 1.2 lines of test per line of source. Zero runtime dependencies.

The internal dependency graph is a clean DAG: `graph` depends on nothing; `patches`→`graph`; `commands`→`graph,patches`; `intents`→`commands,graph`; `keyboard`→`commands,graph,intents`; `history`→`commands,patches`; `hydrate`→`graph`.

## Gates

- `collections-core` `tsc --noEmit --noUnusedLocals --noUnusedParameters` → 0
- `packages/ui` tsc → 0
- app tsc → 0
- `--project=unit` → 44 files / **813 green**
- app `vitest run` → 110 files / **1408 green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)