### PR TITLE
The count/height story stops deciding CI by rounding

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1553,12 +1553,41 @@ export const ChangingTheCountResizesTheSamePanels: Story = {
       return neighbour.getBoundingClientRect().height;
     };
     expect(heightsBefore.length).toBeGreaterThan(0);
-    expect(neighbourHeight()).toBeCloseTo(Math.min(...heightsBefore), 0);
+
+    try {
+      // A BUDGET, NOT AN EXACT MATCH, and the number is chosen rather than
+      // inherited. This was `toBeCloseTo(…, 0)`, whose tolerance is 0.5px —
+      // never a stated design tolerance, just what precision 0 happens to mean.
+      //
+      // The height DOES move with the count, by about a pixel, and the
+      // mechanism is in `clip-deck.tsx`'s `fit()`: a card's WIDTH is derived
+      // from the deck's available HEIGHT and rounded to an integer px, and the
+      // card's height follows from that width. Changing the count changes what
+      // is drawn, which perturbs `deck.clientHeight`, which refits to a
+      // slightly different width. Measured at ~1px in CI and ~3px locally,
+      // where the viewport differs — so 0.5px sat exactly on the boundary and
+      // decided runs by rounding. It broke CI three times in one day, once on
+      // a docs-only PR.
+      //
+      // 8px keeps the assertion doing its job. The regression it was written
+      // for was a container query on the panel's own WIDTH: a neighbour went
+      // 490px to 314px on a count change — 176px, twenty times this budget. A
+      // deck that resized its cards per count still fails here.
+      const drift = Math.abs(neighbourHeight() - Math.min(...heightsBefore));
+      expect(drift).toBeLessThanOrEqual(8);
+    } finally {
+      // IN A `finally`, because a failure here used to take the NEXT story
+      // down with it. `viewCount` is module-scope session state: an assertion
+      // that threw before this line left the count at 5, and
+      // `TheSubjectIsWiderThanItsNeighbours` then rendered five panels and
+      // failed `toBe(3)` — one bug reported as two, the second one looking
+      // unrelated to the first.
+      await press("3");
+      await waitFor(() => expect(panels().length).toBe(before.length));
+    }
 
     // Back again, and every panel that remains was one of the originals — the
     // return trip is a resize too, not a fresh set.
-    await press("3");
-    await waitFor(() => expect(panels().length).toBe(before.length));
     for (const panel of panels()) {
       expect(before).toContain(panel);
     }


### PR DESCRIPTION
Fixes the CI-gating half of [#560](https://github.com/josulliv101/storyboard-flow/issues/560).

## Why now

`Changing The Count Resizes The Same Panels` has broken CI **three times today** — most tellingly on a **docs-only PR** ([#563](https://github.com/josulliv101/storyboard-flow/pull/563)) — and each time it took `TheSubjectIsWiderThanItsNeighbours` down with it.

## It was never a flaky test

The height really does move with the count. The mechanism is in `clip-deck.tsx`'s `fit()`:

```
widest = (available - CARD_BREATHING_PX - fixed) * aspect + sideways
next   = round(clamp(widest, 300, 440))
```

A card's **width** is derived from the deck's available **height** and rounded to an integer pixel; the card's height then follows from that width. Changing the count changes what is drawn, which perturbs `deck.clientHeight`, which refits to a slightly different width.

Measured at **~1px in CI and ~3px locally**, where the viewport differs. The tolerance was **0.5px** — not a stated design tolerance, just what `toBeCloseTo(…, 0)` happens to mean. So CI sat exactly on the boundary and rounding decided the run.

## Two changes, both to the story

**An 8px budget, chosen rather than inherited.** The regression this test was written for was a container query on the panel's own width: a neighbour went **490px → 314px** on a count change. That's 176px — twenty times this budget.

**The restore moves into a `finally`.** `viewCount` is module-scope session state, so an assertion that threw before the closing `press("3")` left the count at 5, and the next story rendered five panels and failed `toBe(3)`. One bug reported as two, the second looking unrelated.

## Proven both ways

A loosened assertion that no longer fails is worse than the flake, so:

- **5 consecutive runs** of the file: **23 passed** every time (previously 21 passed / 2 failed).
- **Mutation test:** with `scale` made genuinely count-dependent in `clip-deck.tsx`, the story **fails at 19.93px against the 8px budget**. Reverted after.
- A first mutation attempt did *not* fail, and chasing that was worthwhile: it changed `fit()`'s `available`, which this story never reaches because `fitToHeight` defaults to `false`. The mutation was invalid, not the assertion.

## Not fixed here

Whether the deck's card height *should* be count-invariant is a product question, and **#560 stays open on it**. This stops a 1px coupling from gating merges while that's decided.

## Gates

- tsc → 0 · lint → 0 errors
- story suite → **32 of 33 files green**; the one failure is `VirtualStrip > Nest Into Collection On Strip`, which passes 2/2 in isolation and lives in a package this change doesn't touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)