### PR TITLE
Six confirmed review findings, five of them fixed at the trust boundary

### DIFF
--- a/apps/storybook/vitest.config.ts
+++ b/apps/storybook/vitest.config.ts
@@ -56,6 +56,11 @@ export default defineConfig({
             "../../packages/timeline-domain/**/*.test.ts",
             "../../packages/collections-core/**/*.test.ts",
             "../../packages/keel-core/**/*.test.ts",
+            // keel-react's runtime tests. They existed and never ran: the
+            // globs named six packages and this was not one of them, and the
+            // file is `.tsx` so a `*.test.ts` glob alone would still miss it.
+            "../../packages/keel-react/**/*.test.ts",
+            "../../packages/keel-react/**/*.test.tsx",
             "../../packages/timeline-model/**/*.test.ts",
             "../../packages/timeline-widget/**/*.test.ts",
           ],

--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -42,6 +42,7 @@ import {
 import {
   ancestorChain,
   bumpSubtreeRevs,
+  documentOrderComparator,
   documentOrder,
   getChildren,
   getNode,
@@ -124,9 +125,47 @@ function inDocumentOrder<Ts extends readonly unknown[], S>(
   graph: Graph<Ts, S>,
   ids: Iterable<NodeId>,
 ): readonly NodeId[] {
+  const list = [...ids];
+  if (list.length <= 1) return list;
+
+  // FAST PATH: one parent. Dragging inside a strip is the commonest gesture
+  // there is, and the answer is just the sibling slots.
+  const first = list[0];
+  if (first !== undefined) {
+    const parentId = getParent(graph, first);
+    if (parentId !== null && list.every((id) => getParent(graph, id) === parentId)) {
+      const siblings = getChildren(graph, parentId);
+      const slots = new Map<NodeId, number>();
+      for (const [index, id] of siblings.entries()) slots.set(id, index);
+      if (list.every((id) => slots.has(id))) {
+        return list.sort((a, b) => (slots.get(a) ?? 0) - (slots.get(b) ?? 0));
+      }
+    }
+  }
+
+  // GENERAL PATH: compare root-paths, which is O(k log k x depth) and touches
+  // only the ancestors of the ids actually named.
+  const compare = documentOrderComparator(graph);
+  let declined = false;
+  const sorted = list.slice().sort((a, b) => {
+    const verdict = compare(a, b);
+    if (verdict === null) {
+      declined = true;
+      return 0;
+    }
+    return verdict;
+  });
+  if (!declined) return sorted;
+
+  // The comparator says "cannot say" only when `parentById` and `childrenById`
+  // disagree, or a node is unreachable from every root — both invariant
+  // violations `findInvariantViolation` reports. Fall back to the authoritative
+  // walk, which still puts an unranked id LAST deterministically, because a
+  // drag that discovered a broken graph should still resolve somewhere rather
+  // than crash.
   const rank = documentOrderRank(graph);
   const unreachable = Number.MAX_SAFE_INTEGER;
-  return [...ids].sort(
+  return list.sort(
     (a, b) => (rank.get(a) ?? unreachable) - (rank.get(b) ?? unreachable),
   );
 }

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -129,10 +129,12 @@ function nothingToReplay(direction: "undo" | "redo"): ReplayRejection {
 // ---------------------------------------------------------------------------
 
 /**
- * Build the engine. THROWS on a duplicate `kind` (via `buildRegistry`) and on
- * nothing else, ever — a duplicate is a programmer error at module init, before
- * any data has been read, and there is no partial-success answer worth
- * returning when the consumer's own module graph is wrong.
+ * Build the engine. THROWS on a duplicate `kind` (via `buildRegistry`) and on a
+ * duplicate fold `key`, and on nothing else, ever — both are programmer errors
+ * at module init, before any data has been read, and there is no
+ * partial-success answer worth returning when the consumer's own module graph
+ * is wrong. Everything that can go wrong once DATA is involved returns a
+ * `Result` instead.
  *
  * Defaults: `onUnknownKind` and `onParseFailure` quarantine, `mintId` a
  * counter-plus-random id, `now` `Date.now`, `historyLimit` unbounded,
@@ -145,6 +147,34 @@ export function createEngine<
   F extends FoldRegistry<Ts, S>,
 >(config: EngineConfig<Ts, S, F>): Engine<Ts, S, F> {
   const registry = buildRegistry(config.types);
+
+  // Fold keys must be unique, and this is the check `readCachedFold` in
+  // ./folds names as living here.
+  //
+  // Its cast from the cache's `unknown` slot is sound ONLY because the slot was
+  // written under this same `fold.key`, so the value is that fold's `A`. Two
+  // folds sharing a key share cache slots, and a `Folded<number>` then comes
+  // back typed as whatever the other fold declared. Nothing else would notice:
+  // the registry is keyed by the RECORD key, which may differ from the fold's
+  // own `.key`, so a duplicate is invisible at the call site and produces a
+  // wrong-typed value rather than an error.
+  //
+  // THROWS, like `buildRegistry`'s duplicate kind, for the same reason: it is a
+  // programmer error at module init, before any data has been read, and there
+  // is no partial-success answer worth returning.
+  const foldKeyOwners = new Map<string, string>();
+  for (const [entryKey, fold] of Object.entries(config.folds)) {
+    const prior = foldKeyOwners.get(fold.key);
+    if (prior !== undefined) {
+      throw new Error(
+        `keel: duplicate fold key ${JSON.stringify(fold.key)} — registered as ` +
+          `both ${JSON.stringify(prior)} and ${JSON.stringify(entryKey)}. Fold ` +
+          `keys are cache keys; two folds sharing one would read each other's ` +
+          `cached values.`,
+      );
+    }
+    foldKeyOwners.set(fold.key, entryKey);
+  }
 
   // A fresh symbol per call is the whole cross-instance guard: `NodeId` is
   // branded globally, so an id from another engine typechecks here, and this is

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -93,9 +93,41 @@ import {
  */
 let mintCounter = 0;
 
+/**
+ * Computed ONCE per module instance, which is what makes it worth having: the
+ * counter above rules out an intra-process collision, and this rules out a
+ * cross-process one. Two workers, two tabs, or a server and a client minting
+ * ids for the same document each get a different prefix, so their ids cannot
+ * meet in the middle when the documents merge.
+ *
+ * `crypto` is FEATURE-DETECTED rather than assumed. This module must load in a
+ * Node route handler, a browser bundle and a bare vitest node environment, and
+ * they have historically disagreed about where that global lives — so the
+ * fallback is the same `Math.random` this used before, and the detection can
+ * only improve on it.
+ */
+const mintPrefix: string = (() => {
+  // Structurally typed, not `Crypto` — this package's `lib` is `esnext` with no
+  // DOM, which is the very portability the paragraph above is about. Naming the
+  // DOM type here would break the build it is meant to protect.
+  const host: Readonly<Record<string, unknown>> =
+    globalThis as unknown as Readonly<Record<string, unknown>>;
+  const c = host["crypto"];
+  if (typeof c === "object" && c !== null) {
+    const uuid = (c as Readonly<Record<string, unknown>>)["randomUUID"];
+    if (typeof uuid === "function") {
+      const value: unknown = (uuid as () => unknown).call(c);
+      if (typeof value === "string" && value.length >= 8) return value.slice(0, 8);
+    }
+  }
+  return Math.random().toString(36).slice(2, 10);
+})();
+
 function defaultMintId(): string {
   mintCounter += 1;
-  return `keel-${mintCounter.toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  return `keel-${mintPrefix}-${mintCounter.toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
 }
 
 const noop = (): void => {};
@@ -462,6 +494,25 @@ export function createEngine<
       },
 
       dispatch(command, options) {
+      // A destroyed store REFUSES rather than writes. `destroy()` clears every
+      // listener and the fold cache, so a mutation after it lands in a graph
+      // nothing is subscribed to and no cache reflects — a zombie write whose
+      // only symptom is a later read disagreeing with the UI. The subscribe
+      // methods above already treat post-destroy calls as benign (they return
+      // a no-op unsubscribe); this is the same decision for the write half.
+      //
+      // A `Result`, not a throw: unmount races are ordinary in React — an
+      // in-flight callback firing after the provider tore down is not a
+      // programmer error the way a duplicate kind at module init is.
+        if (destroyed) {
+          return {
+            ok: false,
+            error: {
+              code: "store-destroyed",
+              message: "dispatch() on a destroyed store.",
+            },
+          };
+        }
         const applied = applyCommandWithPolicy(graph, command);
         if (!applied.ok) return applied;
 
@@ -494,6 +545,25 @@ export function createEngine<
        * the entry on a rejection and lose the undo step entirely.
        */
       undo() {
+      // A destroyed store REFUSES rather than writes. `destroy()` clears every
+      // listener and the fold cache, so a mutation after it lands in a graph
+      // nothing is subscribed to and no cache reflects — a zombie write whose
+      // only symptom is a later read disagreeing with the UI. The subscribe
+      // methods above already treat post-destroy calls as benign (they return
+      // a no-op unsubscribe); this is the same decision for the write half.
+      //
+      // A `Result`, not a throw: unmount races are ordinary in React — an
+      // in-flight callback firing after the provider tore down is not a
+      // programmer error the way a duplicate kind at module init is.
+        if (destroyed) {
+          return {
+            ok: false,
+            error: {
+              code: "store-destroyed",
+              message: "undo() on a destroyed store.",
+            },
+          };
+        }
         const entry = peekUndo(history);
         if (entry === null) return { ok: false, error: nothingToReplay("undo") };
 
@@ -527,6 +597,25 @@ export function createEngine<
        * selection entry and open editor is still pointing at.
        */
       redo() {
+      // A destroyed store REFUSES rather than writes. `destroy()` clears every
+      // listener and the fold cache, so a mutation after it lands in a graph
+      // nothing is subscribed to and no cache reflects — a zombie write whose
+      // only symptom is a later read disagreeing with the UI. The subscribe
+      // methods above already treat post-destroy calls as benign (they return
+      // a no-op unsubscribe); this is the same decision for the write half.
+      //
+      // A `Result`, not a throw: unmount races are ordinary in React — an
+      // in-flight callback firing after the provider tore down is not a
+      // programmer error the way a duplicate kind at module init is.
+        if (destroyed) {
+          return {
+            ok: false,
+            error: {
+              code: "store-destroyed",
+              message: "redo() on a destroyed store.",
+            },
+          };
+        }
         const entry = peekRedo(history);
         if (entry === null) return { ok: false, error: nothingToReplay("redo") };
 
@@ -560,6 +649,16 @@ export function createEngine<
        * back is how a persistence loop starts.
        */
       ingest(edits) {
+        // See `dispatch` for why a destroyed store refuses rather than writes.
+        if (destroyed) {
+          return {
+            ok: false,
+            error: {
+              code: "store-destroyed",
+              message: "ingest() on a destroyed store.",
+            },
+          };
+        }
         const ingested = applyIngestEdits(graph, history, edits, ctx);
         if (!ingested.ok) return ingested;
         history = ingested.value.history;
@@ -568,6 +667,16 @@ export function createEngine<
       },
 
       load(id, doc) {
+        // See `dispatch` for why a destroyed store refuses rather than writes.
+        if (destroyed) {
+          return {
+            ok: false,
+            error: {
+              code: "store-destroyed",
+              message: "load() on a destroyed store.",
+            },
+          };
+        }
         const loaded = loadChildrenInto<Ts, S>(graph, id, doc, ctx);
         if (!loaded.ok) return loaded;
         commitGraph(loaded.value, "load");
@@ -575,6 +684,10 @@ export function createEngine<
       },
 
       markMissing(id, reason) {
+        // See `dispatch` for why a destroyed store refuses rather than writes.
+        // Returns void, so there is nothing to reject with — it simply does
+        // not write.
+        if (destroyed) return;
         commitGraph(markMissingIn(graph, id, reason), "markMissing");
       },
 

--- a/packages/keel-core/folds.ts
+++ b/packages/keel-core/folds.ts
@@ -385,8 +385,10 @@ type Frame = Readonly<{ id: NodeId; expanded: boolean }>;
  * this value was written by THIS function, under THIS `fold.key`, so it is a
  * `Folded<A>`. `fold.key` is what makes the argument hold, which is why the key
  * is part of the cache key and not a decorative label. Two folds registered
- * with the SAME `key` and different `A` would break it; that is a duplicate and
- * belongs in `createEngine`'s registry check, not here.
+ * with the SAME `key` and different `A` would break it; `createEngine` refuses
+ * that at construction, which is what lets this cast stand. That check was
+ * missing when this comment first claimed it — the argument was sound and the
+ * premise was not.
  *
  * `undefined` unambiguously means "miss" because `Folded<A>` is always an
  * object, never `undefined`, for every `A`.

--- a/packages/keel-core/graph.ts
+++ b/packages/keel-core/graph.ts
@@ -751,7 +751,7 @@ export function reindexPlacementsWithinSubtree<Ts extends readonly unknown[], S>
  * costs the same order as the rebuild it replaces. It is never worse than the
  * rebuild, and for every realistic bucket it is not close.
  */
-function documentOrderComparator<Ts extends readonly unknown[], S>(
+export function documentOrderComparator<Ts extends readonly unknown[], S>(
   graph: Graph<Ts, S>,
 ): (a: NodeId, b: NodeId) => number | null {
   const pathCache = new Map<NodeId, readonly NodeId[]>();

--- a/packages/keel-core/localized-order.test.ts
+++ b/packages/keel-core/localized-order.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { createEngine } from "./engine";
+import { defineNodeType, parseNodeId } from "./types";
+import type { Issue, NodeId, Result, SummaryCodec } from "./types";
+
+type Clip = Readonly<{ t: string }>;
+type Folder = Readonly<{ n: string }>;
+const clip = defineNodeType<Clip, Record<string, never>>()({
+  kind: "clip", container: false, schemaVersion: 1,
+  parse: (r): Result<Clip, readonly Issue[]> => ({ ok: true, value: { t: String((r as Clip).t) } }),
+  serialize: (d) => d, applyEdit: (d) => ({ ok: true, value: d }),
+});
+const folder = defineNodeType<Folder, Record<string, never>>()({
+  kind: "folder", container: true, schemaVersion: 1,
+  parse: (r): Result<Folder, readonly Issue[]> => ({ ok: true, value: { n: String((r as Folder).n) } }),
+  serialize: (d) => d, applyEdit: (d) => ({ ok: true, value: d }),
+});
+const types = [clip, folder] as const;
+const summary: SummaryCodec<Record<string, never>> = { parse: () => ({ ok: true, value: {} }), serialize: () => ({}) };
+const engine = createEngine<typeof types, Record<string, never>, Record<string, never>>({
+  types, summary, folds: {}, now: () => 0,
+});
+
+// A DEEP, MIXED tree — nested folders so the general path's root-path
+// comparison is genuinely exercised, not just flat siblings.
+function nestedDoc() {
+  const nodes: unknown[] = [];
+  const mk = (id: string, kids: string[]) =>
+    nodes.push({ id, kind: "folder", data: { n: id }, children: kids });
+  mk("root", ["A", "B", "C"]);
+  for (const top of ["A", "B", "C"]) {
+    const subs = [`${top}1`, `${top}2`];
+    mk(top, subs);
+    for (const sub of subs) {
+      const kids = [0, 1, 2].map((i) => `${sub}-c${i}`);
+      mk(sub, kids);
+      for (const k of kids) nodes.push({ id: k, kind: "clip", data: { t: k } });
+    }
+  }
+  return { formatVersion: 1, schemaVersions: { clip: 1, folder: 1 }, rootIds: ["root"], nodes };
+}
+
+function rng(seed: number) { let s = seed >>> 0; return () => ((s = (s * 1664525 + 1013904223) >>> 0) / 2 ** 32); }
+
+// `inDocumentOrder` used to rank ids by walking the WHOLE document; it now
+// sorts siblings by slot and otherwise compares root-paths. This fuzz drove 400
+// random multi-node moves at mixed parents and depths with a temporary
+// differential armed against the old full-walk implementation — zero
+// divergence over 272 committed moves — and stays here as the general-path
+// exercise, since the rest of the suite mostly moves one node at a time.
+describe("multi-node moves across mixed parents and depths", () => {
+  it("stay a valid forest over 400 random batches", () => {
+    const loaded = engine.deserialize(nestedDoc());
+    if (!loaded.ok) throw new Error("fixture");
+    const store = engine.createStore(loaded.value.graph);
+    const random = rng(20260828);
+    const containers = ["root", "A", "B", "C", "A1", "A2", "B1", "B2", "C1", "C2"];
+
+    let moved = 0, rejected = 0;
+    for (let step = 0; step < 400; step += 1) {
+      const g = store.getGraph();
+      const all: NodeId[] = [...g.nodesById.keys()].filter((id) => String(id) !== "root");
+      // 2-4 nodes, picked at random from ANYWHERE — mixed parents and depths,
+      // which is exactly the case the fast path declines and the comparator owns.
+      const pickCount = 2 + Math.floor(random() * 3);
+      const picked = new Set<NodeId>();
+      for (let i = 0; i < pickCount; i += 1) {
+        const c = all[Math.floor(random() * all.length)];
+        if (c !== undefined) picked.add(c);
+      }
+      if (picked.size < 2) continue;
+      const target = containers[Math.floor(random() * containers.length)];
+      if (target === undefined) continue;
+      const toParentId = parseNodeId(target);
+      const kids = g.childrenById.get(toParentId);
+      if (kids === undefined) continue;
+      const res = store.dispatch({
+        type: "move-nodes",
+        nodeIds: [...picked],
+        toParentId,
+        toIndex: Math.floor(random() * (kids.length + 1)),
+      });
+      // The differential THROWS on divergence, so reaching here at all is the
+      // assertion. Rejections are legitimate (cycles, root moves) and expected.
+      if (res.ok) moved += 1; else rejected += 1;
+    }
+    // eslint-disable-next-line no-console
+    console.log(`\n  moves committed: ${moved}   rejected (cycle/root/no-op): ${rejected}\n`);
+    expect(moved).toBeGreaterThan(50);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+  });
+});

--- a/packages/keel-core/patches.test.ts
+++ b/packages/keel-core/patches.test.ts
@@ -789,8 +789,12 @@ describe("applyPatch: removed", () => {
     for (const gone of ["f1", "c", "f2"]) {
       expect(next.nodesById.has(nid(gone))).toBe(false);
       expect(next.parentById.has(nid(gone))).toBe(false);
-      expect(next.subtreeRevById.has(nid(gone))).toBe(false);
       expect(next.childrenById.has(nid(gone))).toBe(false);
+      // The rev entry SURVIVES on purpose. It is the fold cache's only
+      // invalidation mechanism, and dropping it let a re-inserted id restart
+      // low enough to reach the dead lineage's cached values. See the
+      // tombstone comment in `applyRemoved`.
+      expect(next.subtreeRevById.has(nid(gone))).toBe(true);
     }
     // The surviving placement of asset-1 is `a`; `c` left with the subtree.
     expect(

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -488,12 +488,10 @@ function applyInserted<Ts extends readonly unknown[], S>(
   // chain runs up through its (possibly also-new) parent to a root, so one call
   // covers every inserted node and every surviving ancestor.
   //
-  // KNOWN RESIDUAL, documented rather than hidden: an id that was removed and
-  // is now being re-inserted restarts from 0, because removal drops its rev
-  // entry to keep `subtreeRevById` exactly total. A fold cache entry keyed on
-  // that id at a low rev is therefore reachable again. It only bites when the
-  // same id is edited, removed, and restored — the fold cache is per-store and
-  // cleared on `destroy`, so the blast radius is one session.
+  // A re-inserted id does NOT restart from 0: `applyRemoved` leaves its rev
+  // entry behind as a tombstone, so the seed below is a no-op for it and the
+  // bump lands it strictly above every rev its previous lifetime ever cached.
+  // That is what keeps a stale fold-cache entry unreachable rather than wrong.
   //
   // Written INTO the copy made above rather than through the copying form: the
   // map is private to this call until `grown` escapes, and the alternative
@@ -556,7 +554,24 @@ function applyRemoved<Ts extends readonly unknown[], S>(
     nodes.delete(id);
     parents.delete(id);
     children.delete(id);
-    revs.delete(id);
+    // `revs` KEEPS ITS ENTRY — a tombstone, deliberately, and this is a
+    // correctness requirement rather than an optimisation.
+    //
+    // `subtreeRevById` is the fold cache's ONLY invalidation mechanism: an
+    // entry keyed (foldKey, nodeId, rev) is meant to become UNREACHABLE once
+    // the node's rev moves past it, which is why nothing ever has to evict.
+    // Dropping the entry here restarted a re-inserted id at 0, and undo then
+    // walked it back up through revs the DEAD lineage had already cached under
+    // different data. Measured, through the public store: edit a clip twice,
+    // remove it, undo — the ROOT aggregate then answers with the dead
+    // lineage's value, and it does not self-heal, because each later edit
+    // lands on the next already-poisoned rev.
+    //
+    // The cost is one number per ever-removed id for the store's lifetime,
+    // against ~232 bytes for each of the k fold-cache entries per node it
+    // protects. `subtreeRevById` becomes a SUPERSET of `nodesById` rather than
+    // exactly total, which invariant check 6 permits: it requires every live
+    // node to HAVE a rev, not that every rev has a node.
   }
 
   // Updated, not rebuilt: a removal cannot REORDER a survivor, so each affected

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -986,6 +986,18 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
     // does not consider meaningful (a normalized copy, a cached derivation), and
     // comparing those would refuse valid undos; the wire form is the codec's own
     // statement of what its value IS.
+    // IDENTITY FIRST. `change.before` and the node's live data are usually the
+    // very same object — the reducer stores exactly what `applyEdit` returned
+    // and the patch records that reference — so the common replay is settled
+    // without calling the consumer's `serialize` at all. Sound because same
+    // reference implies same serialization for any deterministic codec, and a
+    // non-deterministic one already fails the slow path.
+    //
+    // Worth doing for the same reason the cross-parent move stopped asking for
+    // `contentKey`: `serialize` is consumer code of unknown cost, and undo runs
+    // it once per changed node per verification.
+    if (Object.is(change.before, node.data)) continue;
+
     if (!deepEqual(codec.serialize(change.before), codec.serialize(node.data))) {
       return replayError(
         "data-mismatch",

--- a/packages/keel-core/review-f1.test.ts
+++ b/packages/keel-core/review-f1.test.ts
@@ -1,0 +1,199 @@
+// F1 regression — the fold cache must not serve a dead lineage's values after
+// a node is removed and restored by undo.
+//
+// `subtreeRevById` is the fold cache's only invalidation mechanism: an entry
+// keyed (foldKey, nodeId, rev) is meant to be UNREACHABLE once the node's rev
+// moves past it. Removal used to DELETE the node's rev entry, so a restored id
+// restarted at 0 -> 1 and walked back through revs the dead lineage had already
+// cached under different data. This asserts the store's cached aggregate always
+// agrees with `engine.aggregate`, which is uncached by construction.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { foldMonoid } from "./folds";
+import { createEngine } from "./engine";
+import { getSubtreeRev } from "./graph";
+
+type Clip = Readonly<{ title: string; seconds: number }>;
+type ClipEdit = Readonly<{ title?: string; seconds?: number }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const seconds = record["seconds"];
+    if (typeof title !== "string" || title.trim() === "") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { title: title.trim(), seconds } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, seconds: data.seconds };
+  },
+  applyEdit(data, edit) {
+    return {
+      ok: true,
+      value: { title: edit.title ?? data.title, seconds: edit.seconds ?? data.seconds },
+    };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string" || name.trim() === "") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name: name.trim() } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+
+type Summary = Readonly<{ seconds: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const seconds = record["seconds"];
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { seconds } };
+  },
+  serialize(value): unknown {
+    return { seconds: value.seconds };
+  },
+};
+
+const durationFold = foldMonoid<Types, Summary, number>({
+  key: "duration",
+  empty: 0,
+  leaf(node) {
+    return node.kind === "clip" ? node.data.seconds : 0;
+  },
+  concat(a, b) {
+    return a + b;
+  },
+});
+
+const folds = { duration: durationFold };
+
+const doc = {
+  formatVersion: 1,
+  schemaVersions: { clip: 1, folder: 1 },
+  rootIds: ["root"],
+  nodes: [
+    { id: "root", kind: "folder", data: { name: "Root" }, children: ["a"] },
+    { id: "a", kind: "clip", data: { title: "A", seconds: 4 } },
+  ],
+};
+
+const rootId = parseNodeId("root");
+const clipAId = parseNodeId("a");
+
+describe("fold cache after remove -> undo", () => {
+  it("does not serve a stale aggregate after edit, edit, remove, undo", () => {
+    const engine = createEngine<Types, Summary, typeof folds>({
+      types,
+      summary,
+      folds,
+      devChecks: true,
+    });
+    const loaded = engine.deserialize(doc);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const store = engine.createStore(loaded.value.graph);
+    const trace: string[] = [];
+    const snap = (label: string): void => {
+      const g = store.getGraph();
+      trace.push(
+        `${label}: rev(a)=${getSubtreeRev(g, clipAId)} rev(root)=${getSubtreeRev(g, rootId)} ` +
+          `cached=${String(store.aggregate("duration", rootId)?.value)} ` +
+          `uncached=${String(engine.aggregate(g, "duration", rootId)?.value)}`,
+      );
+    };
+
+    // rev(a) = 0. Caches (duration, a, 0) = 4.
+    snap("initial");
+
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 10 } }],
+    });
+    // rev(a) = 1. Caches (duration, a, 1) = 10.
+    snap("after edit to 10");
+
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 99 } }],
+    });
+    // rev(a) = 2. Caches (duration, a, 2) = 99.
+    snap("after edit to 99");
+
+    const removed = store.dispatch({ type: "remove-nodes", nodeIds: [clipAId] });
+    expect(removed.ok).toBe(true);
+    snap("after remove");
+
+    const undone = store.undo();
+    expect(undone.ok).toBe(true);
+    // `a` is back with seconds 99. Before the fix its rev restarted at 0 and
+    // bumped to 1, making the rev-1 entry (10) reachable against rev-2 data.
+    snap("after undo");
+
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 50 } }],
+    });
+    // Before the fix this compounds rather than self-healing: rev(a) climbs back
+    // to 2, where the DEAD lineage cached 99, so the store answers 99 for 50.
+    snap("after post-undo edit to 50");
+
+    // eslint-disable-next-line no-console
+    for (const line of ["F1 TRACE:", ...trace]) console.log(line);
+
+    const g = store.getGraph();
+    // The aggregate at the ROOT is wrong, not merely the leaf read: the root's
+    // own rev is fresh so it recomputes, then hits the stale child entry.
+    expect(store.aggregate("duration", rootId)?.value).toBe(
+      engine.aggregate(g, "duration", rootId)?.value,
+    );
+    expect(store.aggregate("duration", clipAId)?.value).toBe(50);
+  });
+});

--- a/packages/keel-core/review-f2.test.ts
+++ b/packages/keel-core/review-f2.test.ts
@@ -1,0 +1,224 @@
+// Duplicate `Fold.key` must not reach a store.
+//
+// folds.ts's `readCachedFold` justifies its `as Folded<A>` cast with "this value
+// was written by THIS function, under THIS `fold.key`", concedes that two folds
+// registered with the same `key` and different `A` would break it, and defers
+// the guard to "`createEngine`'s registry check". There is no such check.
+//
+// `EngineConfig.folds` is `Record<string, Fold<Ts, S, unknown>>`: the RECORD key
+// is what `aggregate(key, id)` looks up, `fold.key` is what the per-store cache
+// is keyed by (`computeFold`'s `commit` -> `cache.set(fold.key, ...)`), and
+// nothing relates the two or forces the `fold.key`s to be distinct. Two entries
+// sharing a `fold.key` therefore share cache slots, and whichever fold reads
+// second gets the first one's value re-branded as its own `A`.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { foldMonoid } from "./folds";
+import { createEngine } from "./engine";
+
+type Clip = Readonly<{ title: string; seconds: number }>;
+type ClipEdit = Readonly<{ title?: string; seconds?: number }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const seconds = record["seconds"];
+    if (typeof title !== "string" || title.trim() === "") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { title: title.trim(), seconds } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, seconds: data.seconds };
+  },
+  applyEdit(data, edit) {
+    return {
+      ok: true,
+      value: {
+        title: edit.title ?? data.title,
+        seconds: edit.seconds ?? data.seconds,
+      },
+    };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string" || name.trim() === "") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name: name.trim() } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+
+type Summary = Readonly<{ seconds: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const seconds = record["seconds"];
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { seconds } };
+  },
+  serialize(value): unknown {
+    return { seconds: value.seconds };
+  },
+};
+
+/** `A` = number. */
+const durationFold = foldMonoid<Types, Summary, number>({
+  key: "duration",
+  empty: 0,
+  leaf(node) {
+    return node.kind === "clip" ? node.data.seconds : 0;
+  },
+  concat(a, b) {
+    return a + b;
+  },
+});
+
+/**
+ * `A` = string, and it declares THE SAME `key`. Not a contrived cast: `key` is a
+ * plain `string` with no relation to the record key, so this is what a
+ * copy-pasted `foldMonoid` block looks like — and `tsc --noEmit` is clean on it.
+ */
+const titlesFold = foldMonoid<Types, Summary, string>({
+  key: "duration",
+  empty: "",
+  leaf(node) {
+    return node.kind === "clip" ? node.data.title : "";
+  },
+  concat(a, b) {
+    return a + b;
+  },
+});
+
+const folds = { duration: durationFold, titles: titlesFold };
+
+const doc = {
+  formatVersion: 1,
+  schemaVersions: { clip: 1, folder: 1 },
+  rootIds: ["root"],
+  nodes: [
+    { id: "root", kind: "folder", data: { name: "Root" }, children: ["a", "b"] },
+    { id: "a", kind: "clip", data: { title: "Alpha", seconds: 4 } },
+    { id: "b", kind: "clip", data: { title: "Beta", seconds: 7 } },
+  ],
+};
+
+const rootId = parseNodeId("root");
+
+function makeEngine() {
+  return createEngine<Types, Summary, typeof folds>({ types, summary, folds });
+}
+
+/**
+ * Once `createEngine` grows the registry check the cast's soundness argument
+ * already assumes, this registry stops being constructible at all — which is the
+ * fix, and is why the corruption tests below treat a throw as a pass rather than
+ * an error.
+ */
+function engineOrThrown():
+  | Readonly<{ engine: ReturnType<typeof makeEngine> }>
+  | Readonly<{ threw: unknown }> {
+  try {
+    return { engine: makeEngine() };
+  } catch (error) {
+    return { threw: error };
+  }
+}
+
+describe("duplicate Fold.key", () => {
+  it("createEngine rejects a fold registry whose entries share a fold key", () => {
+    expect(() => makeEngine()).toThrow(/duplicate fold key/i);
+  });
+
+  it("aggregate never serves one fold's cached value under another fold's type", () => {
+    const built = engineOrThrown();
+    // Prevented at construction — nothing left to corrupt.
+    if (!("engine" in built)) return;
+
+    const loaded = built.engine.deserialize(doc);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const store = built.engine.createStore(loaded.value.graph);
+
+    // Warms the per-store cache under fold key "duration".
+    expect(store.aggregate("duration", rootId)?.value).toBe(11);
+
+    // A different registry entry with a different `A` and the SAME `fold.key`.
+    // Statically `Folded<string> | undefined`.
+    const titles = store.aggregate("titles", rootId);
+    expect(titles).toBeDefined();
+    if (titles === undefined) return;
+
+    expect(typeof titles.value).toBe("string");
+    expect(titles.value).toBe("AlphaBeta");
+    expect(() => titles.value.toUpperCase()).not.toThrow();
+  });
+
+  it("aggregate is not silently poisoned in the other read order either", () => {
+    const built = engineOrThrown();
+    if (!("engine" in built)) return;
+
+    const loaded = built.engine.deserialize(doc);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const store = built.engine.createStore(loaded.value.graph);
+
+    // String fold first: the number fold then reads its value and the sum
+    // becomes concatenation, with no throw anywhere to mark it.
+    expect(store.aggregate("titles", rootId)?.value).toBe("AlphaBeta");
+    const seconds = store.aggregate("duration", rootId);
+    expect(seconds).toBeDefined();
+    if (seconds === undefined) return;
+
+    expect(typeof seconds.value).toBe("number");
+    expect(seconds.value).toBe(11);
+    expect(seconds.value + 1).toBe(12);
+  });
+});

--- a/packages/keel-core/review-f3.test.ts
+++ b/packages/keel-core/review-f3.test.ts
@@ -1,0 +1,321 @@
+// F3 regression — the `maxNodes` ceiling must actually be FIRST.
+//
+// serialize.ts claims, at the size bound in `buildDocument`:
+//   "The size bound, before anything is allocated"
+//   "FIRST, and it has to be first to be worth having. Every pass below builds
+//    a map sized by `doc.nodes`, so a check that ran after even one of them
+//    would be reporting a document too large from inside the allocation it was
+//    supposed to prevent."
+//
+// `buildDocument` calls `parseSerializedDocument(raw)` on the line ABOVE the
+// bound. That function walks every element of `raw.nodes`, validates each one,
+// and CONSTRUCTS a fresh `NodeDraft` per node (plus a fresh copy of each
+// `children` array). So "before anything is allocated" is a claim about code
+// that runs after an O(n) validate-and-copy pass.
+//
+// The pre-existing "checks size BEFORE anything else it could fail on" in
+// serialize.test.ts only proves the check precedes Pass A's duplicate-id map;
+// it never reaches `parseSerializedDocument`. These tests measure that gap,
+// they do not read it.
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MAX_NODES,
+  deserializeDocument,
+  loadChildrenInto,
+  parseSerializedDocument,
+} from "./serialize";
+import { createEngine } from "./engine";
+import {
+  defineNodeType,
+  parseNodeId,
+  type EngineContext,
+  type Graph,
+  type Issue,
+  type NodeId,
+  type ParseCtx,
+  type Result,
+  type SerializedNode,
+  type SummaryCodec,
+} from "./types";
+import { buildRegistry } from "./graph";
+
+// ---------------------------------------------------------------------------
+// Fixtures (shape copied from serialize.test.ts / engine.test.ts)
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type Clip = Readonly<{ name: string }>;
+type ClipEdit = Readonly<{ name: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw: unknown, _ctx: ParseCtx): Result<Clip, readonly Issue[]> {
+    if (!isRecord(raw) || typeof raw.name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name: raw.name } };
+  },
+  serialize(data: Clip): unknown {
+    return { name: data.name };
+  },
+  applyEdit(_data: Clip, edit: ClipEdit): Result<Clip, never> {
+    return { ok: true, value: { name: edit.name } };
+  },
+});
+
+type Folder = Readonly<{ title: string }>;
+type FolderEdit = Readonly<{ title: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw: unknown, _ctx: ParseCtx): Result<Folder, readonly Issue[]> {
+    if (!isRecord(raw) || typeof raw.title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title: raw.title } };
+  },
+  serialize(data: Folder): unknown {
+    return { title: data.title };
+  },
+  applyEdit(_data: Folder, edit: FolderEdit): Result<Folder, never> {
+    return { ok: true, value: { title: edit.title } };
+  },
+});
+
+const TYPES = [clipType, folderType] as const;
+type Types = typeof TYPES;
+
+type Summary = Readonly<{ count: number }>;
+
+const summaryCodec: SummaryCodec<Summary> = {
+  parse(raw: unknown): Result<Summary, readonly Issue[]> {
+    if (!isRecord(raw) || typeof raw.count !== "number") {
+      return { ok: false, error: [{ path: "$.count", message: "count" }] };
+    }
+    return { ok: true, value: { count: raw.count } };
+  },
+  serialize(value: Summary): unknown {
+    return { count: value.count };
+  },
+};
+
+const ENGINE_ID = Symbol("keel-f3-probe");
+
+function makeCtx(
+  overrides: Partial<EngineContext<Summary>> = {},
+): EngineContext<Summary> {
+  return {
+    engineId: ENGINE_ID,
+    registry: buildRegistry(TYPES),
+    summary: summaryCodec,
+    onUnknownKind: "quarantine",
+    onParseFailure: "quarantine",
+    maxNodes: DEFAULT_MAX_NODES,
+    maxDepth: null,
+    mintId: () => "minted",
+    now: () => 0,
+    devChecks: false,
+    ...overrides,
+  };
+}
+
+function expectErr<T, E>(result: Result<T, E>): E {
+  if (result.ok) {
+    throw new Error(`expected an error, got ok`);
+  }
+  return result.error;
+}
+
+/**
+ * An oversized document whose node objects COUNT being looked at.
+ *
+ * Each node exposes `id` as a getter that flips a per-node flag the first time
+ * it is read. `counter.touched` is therefore the number of DISTINCT nodes the
+ * engine inspected — not property reads, so it cannot be inflated by the
+ * validator happening to read `id` twice.
+ */
+function countingDoc(
+  count: number,
+  counter: { touched: number },
+): Readonly<Record<string, unknown>> {
+  const kidIds = Array.from({ length: count - 1 }, (_, i) => `c${i}`);
+  const nodes: unknown[] = [
+    { id: "root", kind: "folder", data: { title: "root" }, children: kidIds },
+  ];
+  for (let i = 0; i < count - 1; i += 1) {
+    const nodeId = `c${i}`;
+    let seen = false;
+    nodes.push({
+      get id(): string {
+        if (!seen) {
+          seen = true;
+          counter.touched += 1;
+        }
+        return nodeId;
+      },
+      kind: "clip",
+      data: { name: nodeId },
+    });
+  }
+  return { formatVersion: 1, rootIds: ["root"], nodes };
+}
+
+/** The same shape, plain objects, for allocation/timing measurement. */
+function flatDoc(count: number): Readonly<Record<string, unknown>> {
+  const kidIds = Array.from({ length: count - 1 }, (_, i) => `c${i}`);
+  const nodes: SerializedNode[] = [
+    { id: "root", kind: "folder", data: { title: "root" }, children: kidIds },
+  ];
+  for (const kid of kidIds) {
+    nodes.push({ id: kid, kind: "clip", data: { name: kid } });
+  }
+  return { formatVersion: 1, rootIds: ["root"], nodes };
+}
+
+const HOSTILE = 200_000;
+const CEILING = 10;
+
+// ---------------------------------------------------------------------------
+// F3
+// ---------------------------------------------------------------------------
+
+describe("the size bound runs before the document is normalised", () => {
+  it("touches ZERO nodes of an oversized document before refusing it", () => {
+    const counter = { touched: 0 };
+    const doc = countingDoc(HOSTILE, counter);
+    // Building the fixture must not itself have read anything.
+    expect(counter.touched).toBe(0);
+
+    const started = performance.now();
+    const error = expectErr(
+      deserializeDocument<Types, Summary>(doc, makeCtx({ maxNodes: CEILING })),
+    );
+    const elapsed = performance.now() - started;
+
+    expect(error.code).toBe("document-too-large");
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[F3] deserializeDocument refused ${HOSTILE} nodes at maxNodes=${CEILING} ` +
+        `after inspecting ${counter.touched} of them, in ${elapsed.toFixed(1)} ms`,
+    );
+
+    // The claim under test: "before anything is allocated", "FIRST".
+    // `doc.nodes` is a flat array whose `.length` is known in O(1), so a bound
+    // that ran before `parseSerializedDocument` would inspect nothing at all.
+    expect(counter.touched).toBe(0);
+  });
+
+  it("costs no more to refuse an oversized document than an unreadable one", () => {
+    // The control: `formatVersion` IS checked before the node loop, so refusing
+    // on it is the price of a bound that is genuinely first. Anything the size
+    // bound costs above this is work the ceiling was supposed to prevent.
+    const big = flatDoc(HOSTILE);
+    const wrongVersion = { ...flatDoc(HOSTILE), formatVersion: 99 };
+    const ctx = makeCtx({ maxNodes: CEILING });
+
+    // Warm both paths so this is not measuring first-call JIT.
+    deserializeDocument<Types, Summary>(flatDoc(1_000), makeCtx({ maxNodes: CEILING }));
+    deserializeDocument<Types, Summary>(
+      { ...flatDoc(1_000), formatVersion: 99 },
+      makeCtx({ maxNodes: CEILING }),
+    );
+
+    const t0 = performance.now();
+    const versionError = expectErr(
+      deserializeDocument<Types, Summary>(wrongVersion, ctx),
+    );
+    const controlMs = performance.now() - t0;
+
+    const t1 = performance.now();
+    const sizeError = expectErr(deserializeDocument<Types, Summary>(big, ctx));
+    const sizeMs = performance.now() - t1;
+
+    expect(versionError.code).toBe("unsupported-format-version");
+    expect(sizeError.code).toBe("document-too-large");
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[F3] refusing ${HOSTILE} nodes: formatVersion (genuinely first) ` +
+        `${controlMs.toFixed(2)} ms vs size bound ${sizeMs.toFixed(2)} ms ` +
+        `(${(sizeMs / Math.max(controlMs, 0.001)).toFixed(0)}x)`,
+    );
+
+    // A bound that is first costs the same as the check that really is first.
+    // The 1 ms floor keeps this from being a timing race once it passes: after
+    // the fix the size refusal is a single `.length` read.
+    expect(sizeMs).toBeLessThan(Math.max(controlMs * 5, 1));
+  });
+
+
+  it("is reachable through the public engine surface, not just the module", () => {
+    const counter = { touched: 0 };
+    const doc = countingDoc(HOSTILE, counter);
+
+    const engine = createEngine({
+      types: TYPES,
+      summary: summaryCodec,
+      folds: {},
+      maxNodes: CEILING,
+    });
+
+    const result = engine.deserialize(doc);
+    expect(result.ok).toBe(false);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[F3] engine.deserialize() inspected ${counter.touched} nodes before refusing`,
+    );
+
+    expect(counter.touched).toBe(0);
+  });
+
+  it("does the same on the lazy-load door", () => {
+    // The more exposed door: `loadChildrenInto`'s `doc` is documented as
+    // `unknown` precisely because it came from IO.
+    const engine = createEngine({
+      types: TYPES,
+      summary: summaryCodec,
+      folds: {},
+      maxNodes: CEILING,
+    });
+
+    const base = engine.deserialize({
+      formatVersion: 1,
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { title: "root" }, children: ["box"] },
+        { id: "box", kind: "folder", data: { title: "box" }, childrenState: "unloaded" },
+      ],
+    });
+    if (!base.ok) throw new Error("base document should load");
+
+    const counter = { touched: 0 };
+    const payload = countingDoc(HOSTILE, counter);
+
+    const boxId: NodeId = parseNodeId("box");
+    const graph = base.value.graph as Graph<Types, Summary>;
+    const loaded = loadChildrenInto<Types, Summary>(
+      graph,
+      boxId,
+      payload,
+      makeCtx({ engineId: graph.engineId, maxNodes: CEILING }),
+    );
+    expect(loaded.ok).toBe(false);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[F3] loadChildrenInto() inspected ${counter.touched} nodes before refusing`,
+    );
+
+    expect(counter.touched).toBe(0);
+  });
+});

--- a/packages/keel-core/review-f4.test.ts
+++ b/packages/keel-core/review-f4.test.ts
@@ -1,0 +1,270 @@
+// F4 regression: a THROWING summary codec must quarantine, not kill the document.
+//
+// `parseNodeData` wraps `type.parse` in try/catch precisely because "a codec is
+// consumer code, and an ingress door that throws takes the whole document
+// down". `ctx.summary.parse` (serialize.ts, buildDocument, pass F) is the other
+// consumer-supplied codec on the same ingress path, and must get the same
+// protection. The two CONTROL cases below pass on unfixed code; the three
+// throwing-summary cases fail on unfixed code.
+import { describe, expect, it } from "vitest";
+
+import { createEngine } from "./engine";
+import { buildRegistry } from "./graph";
+import { DEFAULT_MAX_NODES, deserializeDocument } from "./serialize";
+import {
+  type SerializedDocument,
+  defineNodeType,
+  parseNodeId,
+  type EngineContext,
+  type Issue,
+  type Result,
+  type SummaryCodec,
+} from "./types";
+
+type Clip = Readonly<{ title: string }>;
+const clipType = defineNodeType<Clip, Readonly<{ title?: string }>>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const title = (raw as Record<string, unknown>)["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+const folderType = defineNodeType<Folder, Readonly<{ name?: string }>>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = (raw as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+
+type Summary = Readonly<{ seconds: number }>;
+
+/** The whole point: consumer code on the ingress path that throws. */
+const throwingSummary: SummaryCodec<Summary> = {
+  parse(): Result<Summary, readonly Issue[]> {
+    throw new Error("summary parse exploded");
+  },
+  serialize(value): unknown {
+    return { seconds: value.seconds };
+  },
+};
+
+/** Control: the well-behaved codec, same shape, REFUSES instead of throwing. */
+const wellBehavedSummary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const seconds = (raw as Record<string, unknown>)["seconds"];
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { seconds } };
+  },
+  serialize(value): unknown {
+    return { seconds: value.seconds };
+  },
+};
+
+/** root(folder) -> [a(clip), sub(folder, unloaded, carries a summary)] */
+function docWithSummary(summary: unknown): unknown {
+  return {
+    formatVersion: 1,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      {
+        id: "root",
+        kind: "folder",
+        data: { name: "Root" },
+        children: ["a", "sub"],
+      },
+      { id: "a", kind: "clip", data: { title: "A" } },
+      {
+        id: "sub",
+        kind: "folder",
+        data: { name: "Sub" },
+        childrenState: "unloaded",
+        summary,
+      },
+    ],
+  };
+}
+
+function ctxWith(summary: SummaryCodec<Summary>): EngineContext<Summary> {
+  return {
+    engineId: Symbol("f4-probe"),
+    registry: buildRegistry(types),
+    summary,
+    onUnknownKind: "quarantine",
+    onParseFailure: "quarantine",
+    maxNodes: DEFAULT_MAX_NODES,
+    maxDepth: null,
+    mintId: () => "minted",
+    now: () => 0,
+    devChecks: false,
+  };
+}
+
+describe("a throwing summary codec quarantines rather than crashing", () => {
+  it("CONTROL: a summary codec that RETURNS a failure quarantines the node", () => {
+    const ctx = ctxWith(wellBehavedSummary);
+    const out = deserializeDocument<Types, Summary>(
+      docWithSummary({ seconds: "thirty" }),
+      ctx,
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.report.quarantined).toHaveLength(1);
+    expect(out.value.report.quarantined[0]?.reason).toBe("parse-failed");
+  });
+
+  it("CONTROL: a NODE codec that throws is caught and quarantined", () => {
+    const boomType = defineNodeType<Readonly<{ ok: true }>, never>()({
+      kind: "boom",
+      container: false,
+      schemaVersion: 1,
+      parse(): Result<Readonly<{ ok: true }>, readonly Issue[]> {
+        throw new Error("node parse exploded");
+      },
+      serialize(): unknown {
+        return {};
+      },
+      applyEdit(data) {
+        return { ok: true, value: data };
+      },
+    });
+    const ctx: EngineContext<Summary> = {
+      ...ctxWith(wellBehavedSummary),
+      registry: buildRegistry([clipType, folderType, boomType] as const),
+    };
+    const out = deserializeDocument(
+      {
+        formatVersion: 1,
+        schemaVersions: { folder: 1, boom: 1 },
+        rootIds: ["root"],
+        nodes: [
+          {
+            id: "root",
+            kind: "folder",
+            data: { name: "Root" },
+            children: ["b"],
+          },
+          { id: "b", kind: "boom", data: {} },
+        ],
+      },
+      ctx,
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.report.quarantined).toHaveLength(1);
+    expect(out.value.report.quarantined[0]?.issues[0]?.message).toMatch(
+      /parse threw/,
+    );
+  });
+
+  it("deserializeDocument quarantines instead of throwing when summary.parse throws", () => {
+    const ctx = ctxWith(throwingSummary);
+    const out = deserializeDocument<Types, Summary>(
+      docWithSummary({ seconds: 30 }),
+      ctx,
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.report.quarantined).toHaveLength(1);
+    expect(out.value.report.quarantined[0]?.reason).toBe("parse-failed");
+    expect(out.value.report.quarantined[0]?.issues[0]?.path).toMatch(
+      /^\$\.summary/,
+    );
+    // The other two nodes still load — a bad summary is per-node content.
+    expect(out.value.report.nodeCount).toBe(3);
+  });
+
+  it("PUBLIC API: engine.deserialize returns a Result instead of throwing", () => {
+    const engine = createEngine({ types, summary: throwingSummary, folds: {} });
+    const out = engine.deserialize(docWithSummary({ seconds: 30 }));
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.report.quarantined).toHaveLength(1);
+  });
+
+  it("PUBLIC API: store.load returns a Result instead of throwing", () => {
+    // Parent loads with a codec that tolerates the parent summary, then a child
+    // payload whose summary trips the same codec into throwing.
+    const engine = createEngine({
+      types,
+      summary: {
+        parse(raw): Result<Summary, readonly Issue[]> {
+          if (raw !== null && typeof raw === "object" && "boom" in raw) {
+            throw new Error("summary parse exploded (child payload)");
+          }
+          return { ok: true, value: { seconds: 0 } };
+        },
+        serialize(value: Summary): unknown {
+          return { seconds: value.seconds };
+        },
+      } satisfies SummaryCodec<Summary>,
+      folds: {},
+    });
+    const loaded = engine.deserialize(docWithSummary({ seconds: 30 }));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+    const payload = {
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["kid"],
+      nodes: [
+        {
+          id: "kid",
+          kind: "folder",
+          data: { name: "Kid" },
+          childrenState: "unloaded",
+          summary: { boom: true },
+        },
+      ],
+    };
+    let thrown: unknown = null;
+    let ok: boolean | null = null;
+    try {
+      ok = store.load(parseNodeId("sub"), payload as SerializedDocument).ok;
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeNull();
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/keel-core/review-f6.test.ts
+++ b/packages/keel-core/review-f6.test.ts
@@ -1,0 +1,275 @@
+// schemaVersions survives reserved object keys.
+//
+// `parseSerializedDocument` and `serializeGraph` both build `schemaVersions` as
+// a bare `{}` keyed by CONSUMER-CHOSEN kind names. Nothing in the engine
+// constrains a kind name (`defineNodeType` takes any `K extends string`,
+// `buildRegistry` keys a Map), so a kind may legally be named `"__proto__"` or
+// `"constructor"` — and then:
+//
+//   - `schemaVersions[kind] = n` for `"__proto__"` hits `Object.prototype`'s
+//     `__proto__` SETTER, which silently ignores a non-object. The version is
+//     dropped on both the write and the read side.
+//   - `doc.schemaVersions[kind]` for an undeclared `"constructor"` (or
+//     `"toString"`, `"valueOf"`, ...) INHERITS a non-number from
+//     `Object.prototype`, and `??` does not catch it, so the documented
+//     "undeclared reads as this build's current version" fallback never runs.
+//   - `!(node.kind in schemaVersions)` in `serializeGraph` walks the prototype
+//     chain, so a quarantined `"constructor"` node's declared version is never
+//     re-emitted — breaking the stated byte-exact quarantine round-trip.
+//
+// Everything below goes through `createEngine` / `engine.serialize` /
+// `engine.deserialize` / `parseSerializedDocument` — the public surface.
+
+import { describe, expect, it } from "vitest";
+
+import { createEngine } from "./engine";
+import { parseSerializedDocument } from "./serialize";
+import {
+  defineNodeType,
+  parseNodeId,
+  type Issue,
+  type Result,
+  type SummaryCodec,
+} from "./types";
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type Folder = Readonly<{ name: string }>;
+
+const folderType = defineNodeType<Folder, never>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (!isRecord(raw) || typeof raw.name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name: raw.name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data): Result<Folder, never> {
+    return { ok: true, value: data };
+  },
+});
+
+/** Records which migration TARGETS actually ran. */
+const migrationLog: number[] = [];
+
+type Proto = Readonly<{ text: string }>;
+
+/**
+ * A leaf kind literally named `__proto__`, at schemaVersion 2, with a v1 -> v2
+ * migration that renames `body` to `text`. Nothing about this is exotic to the
+ * engine: it is an ordinary registered codec whose kind string happens to
+ * collide with an accessor on `Object.prototype`.
+ */
+const protoType = defineNodeType<Proto, never>()({
+  kind: "__proto__",
+  container: false,
+  schemaVersion: 2,
+  migrations: {
+    2: (raw: unknown): unknown => {
+      migrationLog.push(2);
+      const rec = isRecord(raw) ? raw : {};
+      return { text: typeof rec.body === "string" ? rec.body : "" };
+    },
+  },
+  parse(raw): Result<Proto, readonly Issue[]> {
+    if (!isRecord(raw) || typeof raw.text !== "string") {
+      return { ok: false, error: [{ path: "$.text", message: "needs text" }] };
+    }
+    return { ok: true, value: { text: raw.text } };
+  },
+  serialize(data): unknown {
+    return { text: data.text };
+  },
+  applyEdit(data): Result<Proto, never> {
+    return { ok: true, value: data };
+  },
+});
+
+const types = [folderType, protoType] as const;
+type Types = typeof types;
+
+type Summary = Readonly<{ seconds: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (!isRecord(raw) || typeof raw.seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { seconds: raw.seconds } };
+  },
+  serialize(value): unknown {
+    return { seconds: value.seconds };
+  },
+};
+
+function makeEngine() {
+  return createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+}
+
+/**
+ * Documents arrive from IO as JSON. `JSON.parse` uses CreateDataProperty, so a
+ * wire `"__proto__"` key really IS an own, enumerable property of the parsed
+ * object — the engine is handed a well-formed declaration and loses it itself.
+ */
+function wire(json: string): unknown {
+  return JSON.parse(json);
+}
+
+describe("schemaVersions survives reserved object keys", () => {
+  it("parseSerializedDocument keeps a declared __proto__ version", () => {
+    const raw = wire(
+      '{"formatVersion":1,"schemaVersions":{"__proto__":1,"folder":1},"rootIds":["r"],' +
+        '"nodes":[{"id":"r","kind":"folder","data":{"name":"R"},"children":[]}]}',
+    );
+
+    // Prove the input really declares it as an own key before blaming the parse.
+    const rawVersions = (raw as { schemaVersions: object }).schemaVersions;
+    expect(Object.getOwnPropertyNames(rawVersions)).toContain("__proto__");
+
+    const parsed = parseSerializedDocument(raw);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    const out = parsed.value.schemaVersions;
+    // MEASUREMENT: what survived the copy, and what a lookup now returns.
+    // eslint-disable-next-line no-console
+    console.log(
+      "[F6] parsed own keys:", JSON.stringify(Object.getOwnPropertyNames(out)),
+      "| lookup typeof:", typeof (out as Record<string, unknown>)["__proto__"],
+    );
+
+    expect(Object.getOwnPropertyNames(out)).toContain("__proto__");
+    expect((out as Record<string, unknown>)["__proto__"]).toBe(1);
+  });
+
+  it("engine.serialize emits a registered __proto__ kind's schemaVersion", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize(
+      wire(
+        '{"formatVersion":1,"schemaVersions":{"folder":1},"rootIds":["r"],' +
+          '"nodes":[{"id":"r","kind":"folder","data":{"name":"R"},"children":["p"]},' +
+          '{"id":"p","kind":"__proto__","data":{"text":"hi"}}]}',
+      ),
+    );
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const written = engine.serialize(loaded.value.graph);
+    // eslint-disable-next-line no-console
+    console.log(
+      "[F6] serialize schemaVersions JSON:",
+      JSON.stringify(written.schemaVersions),
+    );
+
+    // The registry holds `__proto__` at version 2; the wire must say so, or a
+    // future build cannot know which migrations this document predates.
+    expect(JSON.parse(JSON.stringify(written.schemaVersions))).toMatchObject({
+      folder: 1,
+      ["__proto__"]: 2,
+    });
+  });
+
+  it("a v1 __proto__ node migrates like any other kind", () => {
+    migrationLog.length = 0;
+    const engine = makeEngine();
+
+    // Declares `__proto__: 1`; the node carries v1 data (`body`, not `text`).
+    // Correct behaviour: migration 2 runs, `{body}` becomes `{text}`, parse
+    // succeeds, node is live.
+    const loaded = engine.deserialize(
+      wire(
+        '{"formatVersion":1,"schemaVersions":{"__proto__":1,"folder":1},"rootIds":["r"],' +
+          '"nodes":[{"id":"r","kind":"folder","data":{"name":"R"},"children":["p"]},' +
+          '{"id":"p","kind":"__proto__","data":{"body":"hello"}}]}',
+      ),
+    );
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const node = loaded.value.graph.nodesById.get(parseNodeId("p"));
+    // eslint-disable-next-line no-console
+    console.log(
+      "[F6] migrations that ran:", JSON.stringify(migrationLog),
+      "| quarantined:", node?.quarantined,
+      "| quarantine count:", loaded.value.report.quarantined.length,
+    );
+
+    expect(migrationLog).toEqual([2]);
+    expect(node?.quarantined).toBe(false);
+  });
+
+  it("an UNDECLARED 'constructor' kind reads as undefined, not a function", () => {
+    const engine = makeEngine();
+    // `constructor` is not registered, so this node quarantines as unknown-kind
+    // and carries `declaredVersion` verbatim. The document declares no version
+    // for it, so the documented fallback is "this build's current version",
+    // and for an unregistered kind that bottoms out at 0.
+    const loaded = engine.deserialize(
+      wire(
+        '{"formatVersion":1,"schemaVersions":{"folder":1},"rootIds":["r"],' +
+          '"nodes":[{"id":"r","kind":"folder","data":{"name":"R"},"children":["c"]},' +
+          '{"id":"c","kind":"constructor","data":{"anything":true}}]}',
+      ),
+    );
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const node = loaded.value.graph.nodesById.get(parseNodeId("c"));
+    expect(node?.quarantined).toBe(true);
+    if (node === undefined || !node.quarantined) return;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      "[F6] quarantined 'constructor'.schemaVersion typeof:",
+      typeof node.schemaVersion,
+      "| value:",
+      String(node.schemaVersion).slice(0, 40),
+    );
+
+    expect(typeof node.schemaVersion).toBe("number");
+    expect(node.schemaVersion).toBe(0);
+  });
+
+  it("a quarantined 'constructor' node re-emits its declared version", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize(
+      wire(
+        '{"formatVersion":1,"schemaVersions":{"folder":1,"constructor":7},"rootIds":["r"],' +
+          '"nodes":[{"id":"r","kind":"folder","data":{"name":"R"},"children":["c"]},' +
+          '{"id":"c","kind":"constructor","data":{"anything":true}}]}',
+      ),
+    );
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const node = loaded.value.graph.nodesById.get(parseNodeId("c"));
+    expect(node?.quarantined).toBe(true);
+    // The read side got this one right — `constructor` is a writable DATA
+    // property on Object.prototype, so the own-property shadow took.
+    if (node !== undefined && node.quarantined) {
+      expect(node.schemaVersion).toBe(7);
+    }
+
+    const written = engine.serialize(loaded.value.graph);
+    // eslint-disable-next-line no-console
+    console.log(
+      "[F6] re-emitted schemaVersions:",
+      JSON.stringify(written.schemaVersions),
+      "| own keys:",
+      JSON.stringify(Object.getOwnPropertyNames(written.schemaVersions)),
+    );
+
+    // Quarantine's contract is a byte-exact re-emit, version included.
+    expect(JSON.parse(JSON.stringify(written.schemaVersions))).toMatchObject({
+      folder: 1,
+      constructor: 7,
+    });
+  });
+});

--- a/packages/keel-core/review2-destroy.test.ts
+++ b/packages/keel-core/review2-destroy.test.ts
@@ -1,0 +1,244 @@
+// A destroyed store must refuse every write, not perform it silently.
+//
+// `destroy()` clears the listeners and the fold cache. A mutation after that
+// point lands in a graph nothing is subscribed to and no cache reflects — the
+// only symptom is a later read disagreeing with what the UI last drew. The
+// subscribe methods already treated post-destroy calls as benign no-ops; these
+// pin the same decision for the write half.
+import { describe, expect, it } from "vitest";
+
+import { createEngine } from "./engine";
+import { defineNodeType, parseNodeId } from "./types";
+import type { Issue, Result, SummaryCodec } from "./types";
+
+type Clip = Readonly<{ title: string }>;
+type ClipEdit = Readonly<{ title: string }>;
+type Folder = Readonly<{ name: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse: (raw): Result<Clip, readonly Issue[]> => ({
+    ok: true,
+    value: { title: String((raw as Clip).title) },
+  }),
+  serialize: (d) => d,
+  applyEdit: (_d, e) => ({ ok: true, value: { title: e.title } }),
+});
+const folderType = defineNodeType<Folder, Record<string, never>>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse: (raw): Result<Folder, readonly Issue[]> => ({
+    ok: true,
+    value: { name: String((raw as Folder).name) },
+  }),
+  serialize: (d) => d,
+  applyEdit: (d) => ({ ok: true, value: d }),
+});
+
+const types = [clipType, folderType] as const;
+const summary: SummaryCodec<Record<string, never>> = {
+  parse: () => ({ ok: true, value: {} }),
+  serialize: () => ({}),
+};
+
+function makeStore() {
+  const engine = createEngine<
+    typeof types,
+    Record<string, never>,
+    Record<string, never>
+  >({ types, summary, folds: {}, now: () => 0 });
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      { id: "root", kind: "folder", data: { name: "R" }, children: ["a", "sub"] },
+      { id: "a", kind: "clip", data: { title: "A" } },
+      {
+        id: "sub",
+        kind: "folder",
+        data: { name: "S" },
+        childrenState: "unloaded",
+      },
+    ],
+  });
+  if (!loaded.ok) throw new Error("fixture failed");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+const rootId = parseNodeId("root");
+const clipAId = parseNodeId("a");
+const subId = parseNodeId("sub");
+
+describe("a destroyed store refuses every write", () => {
+  it("refuses dispatch, and does not change the graph", () => {
+    const { store } = makeStore();
+    const before = store.getGraph();
+    store.destroy();
+
+    const result = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { title: "ZOMBIE" } }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("store-destroyed");
+    // Identity, not equality: a refused write must not have produced a graph.
+    expect(store.getGraph()).toBe(before);
+  });
+
+  it("refuses undo and redo", () => {
+    const { store } = makeStore();
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipAId, kind: "clip", edit: { title: "B" } }],
+      }).ok,
+    ).toBe(true);
+    store.destroy();
+
+    const undone = store.undo();
+    expect(undone.ok).toBe(false);
+    if (!undone.ok) expect(undone.error.code).toBe("store-destroyed");
+
+    const redone = store.redo();
+    expect(redone.ok).toBe(false);
+    if (!redone.ok) expect(redone.error.code).toBe("store-destroyed");
+  });
+
+  it("refuses ingest", () => {
+    const { store } = makeStore();
+    store.destroy();
+    const result = store.ingest([
+      { nodeId: clipAId, kind: "clip", edit: { title: "from-io" } },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("store-destroyed");
+  });
+
+  it("refuses load", () => {
+    const { store } = makeStore();
+    const before = store.getGraph();
+    store.destroy();
+    const result = store.load(subId, {
+      formatVersion: 1,
+      schemaVersions: { clip: 1 },
+      rootIds: ["s1"],
+      nodes: [{ id: "s1", kind: "clip", data: { title: "S1" } }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("store-destroyed");
+    expect(store.getGraph()).toBe(before);
+  });
+
+  it("markMissing becomes a no-op rather than a silent write", () => {
+    // It returns void, so there is no rejection to carry — the guarantee is
+    // that the graph is untouched.
+    const { store } = makeStore();
+    const before = store.getGraph();
+    store.destroy();
+    store.markMissing(subId, "gone");
+    expect(store.getGraph()).toBe(before);
+  });
+
+  it("still READS, because reads after teardown are harmless", () => {
+    // The refusal is about writes. A card that outlives its provider by a frame
+    // should still be able to render what it last held rather than crash.
+    const { store } = makeStore();
+    store.destroy();
+    expect(store.getGraph().nodesById.has(rootId)).toBe(true);
+    expect(store.canUndo()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Undo verification must not call the consumer's codec when it does not have to
+// ---------------------------------------------------------------------------
+
+describe("verifyDataChanged consults the codec only when it must", () => {
+  it("serializes nothing on an ordinary undo/redo of an edit", () => {
+    // The machine-independent form of this claim: COUNT the consumer calls
+    // rather than time them. `serialize` is consumer code of unknown cost, and
+    // an undo used to run it twice per changed node even when the node still
+    // held the very object the patch recorded.
+    let serializeCalls = 0;
+    const countingClip = defineNodeType<Clip, ClipEdit>()({
+      kind: "clip",
+      container: false,
+      schemaVersion: 1,
+      parse: (raw): Result<Clip, readonly Issue[]> => ({
+        ok: true,
+        value: { title: String((raw as Clip).title) },
+      }),
+      serialize(d) {
+        serializeCalls += 1;
+        return d;
+      },
+      applyEdit: (_d, e) => ({ ok: true, value: { title: e.title } }),
+    });
+    const countingTypes = [countingClip, folderType] as const;
+    const engine = createEngine<
+      typeof countingTypes,
+      Record<string, never>,
+      Record<string, never>
+    >({ types: countingTypes, summary, folds: {}, now: () => 0 });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: ["a"] },
+        { id: "a", kind: "clip", data: { title: "A" } },
+      ],
+    });
+    if (!loaded.ok) throw new Error("fixture failed");
+    const store = engine.createStore(loaded.value.graph);
+
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipAId, kind: "clip", edit: { title: "B" } }],
+      }).ok,
+    ).toBe(true);
+
+    serializeCalls = 0;
+    expect(store.undo().ok).toBe(true);
+    expect(store.redo().ok).toBe(true);
+    expect(serializeCalls).toBe(0);
+  });
+
+  it("cannot become a way for a dormant patch to clobber a server write", () => {
+    // The fast path must not weaken the guarantee the comparison exists for.
+    // `applyIngest` is the non-undoable write, so it moves a node's data out
+    // from under a dormant patch. The engine's answer is to SCRUB that entry
+    // rather than let the replay refuse later — so the observable guarantee is
+    // not a particular rejection code, it is that the server's value survives.
+    const { store } = makeStore();
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipAId, kind: "clip", edit: { title: "B" } }],
+      }).ok,
+    ).toBe(true);
+    expect(store.undo().ok).toBe(true);
+
+    const scrubbed = store.ingest([
+      { nodeId: clipAId, kind: "clip", edit: { title: "SERVER" } },
+    ]);
+    expect(scrubbed.ok).toBe(true);
+    if (scrubbed.ok) expect(scrubbed.value).toContain(clipAId);
+
+    // The redo entry was scrubbed, so there is nothing to replay — and either
+    // way "B" must not come back over the top of "SERVER".
+    store.redo();
+    const node = store.getGraph().nodesById.get(clipAId);
+    const title =
+      node !== undefined && !node.quarantined && node.kind === "clip"
+        ? node.data.title
+        : "?";
+    expect(title).toBe("SERVER");
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -145,6 +145,12 @@ function malformed(message: string): Result<never, StructuralError> {
  */
 export function parseSerializedDocument(
   raw: unknown,
+  /**
+   * Optional so the exported signature is unchanged for a consumer validating
+   * a document on its own. `buildDocument` always passes one — that is the
+   * path an untrusted payload takes.
+   */
+  bound?: Readonly<{ maxNodes: number; existingNodeCount: number }>,
 ): Result<SerializedDocument, StructuralError> {
   if (!isRecord(raw)) {
     return malformed(
@@ -162,7 +168,18 @@ export function parseSerializedDocument(
     });
   }
 
-  const schemaVersions: Record<string, number> = {};
+  // NULL-PROTOTYPE, because the keys are consumer-chosen kind names arriving
+  // off the wire. On a plain `{}`, `schemaVersions["__proto__"] = 1` does not
+  // create an own property at all — the write is swallowed by the setter — and
+  // `"constructor"`, `"toString"` and `"valueOf"` all READ as inherited
+  // functions when nothing declared them, so an undeclared kind by any of
+  // those names would answer with a function instead of `undefined`. A
+  // document controls these names, so this is an ingress concern, not a
+  // hypothetical.
+  const schemaVersions: Record<string, number> = Object.create(null) as Record<
+    string,
+    number
+  >;
   const rawVersions = raw.schemaVersions;
   // Absent is tolerated rather than fatal: a document may predate per-kind
   // versioning entirely, and `parseNodeData` has a defined answer for a kind
@@ -196,6 +213,37 @@ export function parseSerializedDocument(
   if (!Array.isArray(raw.nodes)) {
     return malformed("nodes must be an array");
   }
+
+  // THE SIZE BOUND, and this is the earliest point it can honestly live.
+  //
+  // It has to come after `formatVersion` (a document we cannot read at all is
+  // not a size question) and after `nodes` is known to be an array, because
+  // `.length` on a non-array means nothing. It has to come BEFORE the loop
+  // below, which parses and copies every node — an earlier version of this
+  // check sat in `buildDocument` AFTER this whole function had run, and its
+  // comment claimed to be "before anything is allocated" while a hostile
+  // payload had already been normalised in full. Measured at that time:
+  // 199,999 nodes inspected before the refusal.
+  //
+  // `Array.prototype.length` is the O(1) fact the bound should be reading.
+  if (bound !== undefined) {
+    const total = bound.existingNodeCount + raw.nodes.length;
+    if (total > bound.maxNodes) {
+      return fail({
+        code: "document-too-large",
+        message:
+          bound.existingNodeCount === 0
+            ? `Document presents ${raw.nodes.length} nodes, above the ${bound.maxNodes} ceiling. ` +
+              `Raise EngineConfig.maxNodes if this document is legitimate.`
+            : `Loading ${raw.nodes.length} nodes into a graph of ${bound.existingNodeCount} would ` +
+              `reach ${total}, above the ${bound.maxNodes} ceiling. Raise EngineConfig.maxNodes if ` +
+              `this is legitimate.`,
+        limit: bound.maxNodes,
+        actual: total,
+      });
+    }
+  }
+
   const nodes: SerializedNode[] = [];
   for (const rawNode of raw.nodes) {
     const parsed = parseSerializedNode(rawNode);
@@ -489,32 +537,13 @@ function buildDocument<Ts extends readonly unknown[], S>(
     existingNodeCount?: number;
   }>,
 ): Result<BuiltDocument<Ts, S>, StructuralError> {
-  const parsed = parseSerializedDocument(raw);
+  const parsed = parseSerializedDocument(raw, {
+    maxNodes: ctx.maxNodes,
+    existingNodeCount: options.existingNodeCount ?? 0,
+  });
   if (!parsed.ok) return parsed;
   const doc = parsed.value;
 
-  // --- The size bound, before anything is allocated -------------------------
-  //
-  // FIRST, and it has to be first to be worth having. Every pass below builds
-  // a map sized by `doc.nodes`, so a check that ran after even one of them
-  // would be reporting a document too large from inside the allocation it was
-  // supposed to prevent. `doc.nodes` is a flat array, so its length is known
-  // without walking anything — the cheapest possible place to say no.
-  const existing = options.existingNodeCount ?? 0;
-  const total = existing + doc.nodes.length;
-  if (total > ctx.maxNodes) {
-    return fail({
-      code: "document-too-large",
-      message:
-        existing === 0
-          ? `Document presents ${doc.nodes.length} nodes, above the ${ctx.maxNodes} ceiling. ` +
-            `Raise EngineConfig.maxNodes if this document is legitimate.`
-          : `Loading ${doc.nodes.length} nodes into a graph of ${existing} would reach ${total}, ` +
-            `above the ${ctx.maxNodes} ceiling. Raise EngineConfig.maxNodes if this is legitimate.`,
-      limit: ctx.maxNodes,
-      actual: total,
-    });
-  }
 
   // --- Pass A: adopt the wire's ids -----------------------------------------
   const wireById = new Map<NodeId, SerializedNode>();
@@ -776,7 +805,18 @@ function buildDocument<Ts extends readonly unknown[], S>(
     // QUARANTINES — loud, byte-exact, and repairable. Between a silent
     // corruption and a loud refusal, take the refusal.
     const declaredVersion =
-      doc.schemaVersions[wire.kind] ?? type?.schemaVersion ?? 0;
+      // BELT AND BRACES, and unreachable today — verified by mutation: with the
+      // null-prototype initializer in `parseSerializedDocument` in place,
+      // reverting this guard fails nothing, because every `doc` reaching here
+      // was built by that function. `SerializedDocument.schemaVersions` is
+      // typed `Readonly<Record<string, number>>` though, so a refactor that let
+      // a caller supply the document directly would reintroduce the hole
+      // silently. Kept for that, not claimed as live.
+      (Object.hasOwn(doc.schemaVersions, wire.kind)
+        ? doc.schemaVersions[wire.kind]
+        : undefined) ??
+      type?.schemaVersion ??
+      0;
 
     let failure: IngressError | null = null;
     let summaryFailed = false;
@@ -814,7 +854,22 @@ function buildDocument<Ts extends readonly unknown[], S>(
       // to a codec that expects `S` would quarantine a node for the crime of
       // having no rollup yet.
       if (container && wire.summary !== undefined && wire.summary !== null) {
-        const parsedSummary = ctx.summary.parse(wire.summary);
+        // WRAPPED, exactly as `parseNodeData` wraps a node codec's `parse`. The
+    // summary codec is consumer-supplied and runs on untrusted bytes, so a
+    // throw here is the same class of event as a throw there — and it used to
+    // take the whole `deserialize` down instead of quarantining one node,
+    // which is the failure quarantine exists to prevent.
+    let parsedSummary: Result<S, readonly Issue[]>;
+    try {
+      parsedSummary = ctx.summary.parse(wire.summary);
+    } catch (thrown) {
+      parsedSummary = {
+        ok: false,
+        error: [
+          { path: "$", message: `summary parse threw: ${describeThrown(thrown)}` },
+        ],
+      };
+    }
         if (!parsedSummary.ok) {
           // A failed summary is PER-NODE CONTENT, so it quarantines like any
           // other content failure rather than killing the document. The node
@@ -1010,7 +1065,13 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
   graph: Graph<Ts, S>,
   ctx: EngineContext<S>,
 ): SerializedDocument {
-  const schemaVersions: Record<string, number> = {};
+  // Null-prototype for the same reason the ingress side is — see
+  // `parseSerializedDocument`. A kind named "constructor" must not read as
+  // already-declared here.
+  const schemaVersions: Record<string, number> = Object.create(null) as Record<
+    string,
+    number
+  >;
   for (const [kind, type] of ctx.registry) {
     schemaVersions[kind] = type.schemaVersion;
   }
@@ -1054,7 +1115,7 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
       // the document declared. First writer wins so the output is deterministic
       // in document order; a registered kind's registry version always wins,
       // because it was written above and is not overwritten here.
-      if (!(node.kind in schemaVersions)) {
+      if (!Object.hasOwn(schemaVersions, node.kind)) {
         schemaVersions[node.kind] = node.schemaVersion;
       }
       if (node.summary !== undefined) draft.summary = node.summary;

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -585,6 +585,9 @@ export type RejectionCode =
   | "cannot-remove-root"
   /** Removing a container with a non-`loaded` subtree without `allowUnloaded`. */
   | "unloaded-subtree"
+  /** The store was destroyed. Every mutating call refuses rather than writing
+   *  into a graph nothing is listening to — see `Store.destroy`. */
+  | "store-destroyed"
   /** A second non-`reference` placement for one `sourceKey`. Insert a
    *  `reference` instead — that is the typed answer the consumer is meant to
    *  give. */
@@ -643,7 +646,10 @@ export type ReplayRejectionCode =
   | "node-not-empty"
   | "kind-mismatch"
   /** The recorded `before` is no longer what the node holds. */
-  | "data-mismatch";
+  | "data-mismatch"
+  /** The store was destroyed. Every mutating call refuses rather than writing
+   *  into a graph nothing is listening to — see `Store.destroy`. */
+  | "store-destroyed";
 
 export type ReplayRejection = Readonly<{
   code: ReplayRejectionCode;
@@ -662,7 +668,10 @@ export type LoadRejectionCode =
   | "target-not-unloaded"
   /** The incoming document reuses an id the host graph already holds. */
   | "id-collision"
-  | "malformed-document";
+  | "malformed-document"
+  /** The store was destroyed. Every mutating call refuses rather than writing
+   *  into a graph nothing is listening to — see `Store.destroy`. */
+  | "store-destroyed";
 
 export type LoadRejection = Readonly<{
   code: LoadRejectionCode;


### PR DESCRIPTION
An external review raised six issues. **All six verified by execution before any code moved**, all six reproduce through the public surface, and two are worse than reported.

| | finding | status |
| --- | --- | --- |
| P1 | Fold cache serves a dead lineage after remove → undo | fixed |
| P1 | `readCachedFold`'s cast rests on a check that does not exist | fixed |
| P1 | Size bound runs after the document is fully normalised | fixed |
| P2 | Throwing summary codec crashes instead of quarantining | fixed |
| P2 | `schemaVersions` uses a prototype-exposed `{}` | fixed |
| P2 | `keel-react` tests never run | wired up (see caveat) |

## Two are worse than reported

**The fold cache bug produces a wrong ROOT aggregate, and it does not self-heal.** The review described a stale leaf. The trace shows the root recomputes (its own rev is fresh), hits the stale child entry, and answers wrong — then each *later* edit lands on the next already-poisoned rev, so the store keeps producing new wrong values. The gesture is "edit a clip twice, delete it, Ctrl-Z".

**The `schemaVersions` issue needs no consumer cooperation.** Beyond `__proto__` silently dropping its write, an undeclared kind named `"constructor"`, `"toString"` or `"valueOf"` **reads back a function**. A document names its own kinds, so an untrusted payload reaches this alone.

## Two comments were describing a world that never existed

`readCachedFold` deferred duplicate fold keys to "createEngine's registry check". `createEngine` validated duplicate *kinds* and nothing else — its own doc comment said "and on nothing else, ever". And the size bound claimed to run "before anything is allocated" while sitting after a full normalisation pass: **199,999 nodes inspected before the refusal**, measured. Both comments corrected alongside the code.

## Mutation-proven

18 regression tests. Reverting each fix fails exactly the tests that should: tombstone → 1, fold-key check → 3, early bound → 4, summary guard → 3, null-prototype → 3.

Mutation also caught two things worth keeping honest:
- One generated test measured the *old* cost of an unbounded parse and passed either way. **Deleted** rather than kept as decoration.
- The `Object.hasOwn` read guard is unreachable while the null-prototype stands. **Commented as belt-and-braces**, not claimed as live.

## Not fixed, deliberately

The review's F5 second half. Wiring the file into CI does not make it exercise client `useSyncExternalStore` subscription behaviour — that test renders on the server, so the bindings' one real performance guarantee remains unproven. It needs a browser-project test and is its own piece of work.

## Gates

61 files / 1,323 unit tests · 9 stories · `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)