### PR TITLE
Third review: the tombstone told half the truth, and one listener could silence the rest

### DIFF
--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -319,10 +319,51 @@ export function createEngine<
     let anchorId: NodeId | null = null;
     let destroyed = false;
 
-    const notifyAll = (listeners: ReadonlySet<() => void>): void => {
+    /**
+     * Run ONE consumer callback so that its failure cannot become the engine's.
+     *
+     * Every listener below is consumer code, and before this existed a single
+     * one of them throwing did three things at once, all of them worse than the
+     * original error:
+     *
+     *   1. The exception escaped `dispatch` — a function whose entire contract
+     *      is that it returns a `Result` and does not throw. It escaped AFTER
+     *      the graph had committed and history had been pushed, so the caller
+     *      saw a failure for a mutation that had actually succeeded.
+     *   2. Every listener after it in the same set was starved. One consumer's
+     *      bad callback silently disabled another's.
+     *   3. Worst, `emitChange` is sequenced after `commitGraph`, so a throwing
+     *      GRAPH subscriber meant the change feed never emitted at all. The
+     *      edit existed in memory and in the undo stack and was never announced
+     *      to whatever performs the write. Measured: graph committed, `canUndo`
+     *      true, change-feed listeners fired zero times.
+     *
+     * SWALLOWED AND REPORTED, not rethrown, and it is the same judgement
+     * `auditIfDev` already makes: a throw here takes down a render for a
+     * condition the user cannot fix, and the engine has no way to undo a
+     * notification half-delivered. `console.error` rather than silence, because
+     * a subscriber that throws on every commit is a real bug in the consumer
+     * and must not be invisible.
+     */
+    const notifyOne = (label: string, deliver: () => void): void => {
+      try {
+        deliver();
+      } catch (thrown) {
+        console.error(
+          `keel: a ${label} subscriber threw. The commit is unaffected and the ` +
+            `remaining subscribers still ran, but this callback must not throw.`,
+          thrown,
+        );
+      }
+    };
+
+    const notifyAll = (
+      label: string,
+      listeners: ReadonlySet<() => void>,
+    ): void => {
       // Copied before iterating: a listener that unsubscribes itself (the
       // normal React teardown) mutates the set mid-iteration otherwise.
-      for (const listener of [...listeners]) listener();
+      for (const listener of [...listeners]) notifyOne(label, listener);
     };
 
     /**
@@ -374,21 +415,39 @@ export function createEngine<
       const selectionChanged = pruneSelection();
 
       // Only SUBSCRIBED ids are compared, so this is O(mounted cards) rather
-      // than O(graph). Reading through `getSubtreeRev` (0 for an unknown node)
-      // is what makes a removal and an insertion both register as a change.
+      // than O(graph).
+      //
+      // WHAT MAKES A REMOVAL VISIBLE HERE lives in ./patches, not in this
+      // comparison, and saying so is the whole point of writing it down. An
+      // earlier version of this comment claimed the credit for itself —
+      // "`getSubtreeRev` answers 0 for an unknown node, which is what makes a
+      // removal and an insertion both register as a change" — and that was true
+      // only while `applyRemoved` DELETED the removed id's revision entry. It
+      // now leaves a tombstone behind (a fold-cache requirement, see there), so
+      // a frozen tombstone would read back identical on both sides of this
+      // comparison and the deleted node's own subscribers would never fire.
+      // `applyRemoved` bumps the entry it tombstones for exactly this reason.
+      //
+      // The rule this loop actually depends on, and the only one to preserve:
+      // EVERY MUTATION MOVES THE REVISION OF EVERY NODE IT AFFECTS, including a
+      // node it affects by deleting.
       for (const [id, listeners] of nodeListeners) {
         if (getSubtreeRev(previous, id) === getSubtreeRev(next, id)) continue;
-        for (const listener of [...listeners]) listener();
+        for (const listener of [...listeners]) notifyOne("node", listener);
       }
 
-      notifyAll(graphListeners);
+      notifyAll("graph", graphListeners);
       // A selection change must never notify graph subscribers; the reverse —
       // a graph change pruning the selection — must notify selection ones.
-      if (selectionChanged) notifyAll(selectionListeners);
+      if (selectionChanged) notifyAll("selection", selectionListeners);
     };
 
     const emitChange = (change: Change<Ts, S>): void => {
-      for (const listener of [...changeListeners]) listener(change);
+      for (const listener of [...changeListeners]) {
+        notifyOne("change-feed", () => {
+          listener(change);
+        });
+      }
     };
 
     const setSelection = (
@@ -415,7 +474,7 @@ export function createEngine<
       if (resolvedAnchor === anchorId && sameIds(deduped, selectedIds)) return;
       selectedIds = deduped;
       anchorId = resolvedAnchor;
-      notifyAll(selectionListeners);
+      notifyAll("selection", selectionListeners);
     };
 
     const selection: SelectionSlice = {

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -554,8 +554,10 @@ function applyRemoved<Ts extends readonly unknown[], S>(
     nodes.delete(id);
     parents.delete(id);
     children.delete(id);
-    // `revs` KEEPS ITS ENTRY — a tombstone, deliberately, and this is a
-    // correctness requirement rather than an optimisation.
+    // `revs` KEEPS ITS ENTRY AND MOVES IT. Two separate requirements, and the
+    // first version of this tombstone met only the first of them.
+    //
+    // KEEPING it is a correctness requirement rather than an optimisation.
     //
     // `subtreeRevById` is the fold cache's ONLY invalidation mechanism: an
     // entry keyed (foldKey, nodeId, rev) is meant to become UNREACHABLE once
@@ -572,6 +574,28 @@ function applyRemoved<Ts extends readonly unknown[], S>(
     // protects. `subtreeRevById` becomes a SUPERSET of `nodesById` rather than
     // exactly total, which invariant check 6 permits: it requires every live
     // node to HAVE a rev, not that every rev has a node.
+    //
+    // MOVING it is what makes the removal VISIBLE. The store decides whether to
+    // wake a node's subscribers by comparing `getSubtreeRev` across the commit,
+    // so a tombstone frozen at its last live value compares EQUAL and the card
+    // mounted on the node that just disappeared is never told. Insertion had no
+    // such hole — `applyInserted` bumps every arriving id — so removal was the
+    // one direction that went unannounced. Measured: subscribe to a node,
+    // remove it, and its listener fired zero times while its parent's fired
+    // once. A tree view hides that (the parent re-renders and React unmounts
+    // the child); anything addressing a node directly — a detail pane, an
+    // inspector, a flattened list — renders the deleted node forever.
+    //
+    // `+ 1` rather than a bump through `bumpSubtreeRevsInto`: the ancestors are
+    // already bumped above, against the PRE-state graph, and walking again from
+    // here would double-count them for no gain. The node's own entry is the
+    // only one still standing still.
+    //
+    // This also STRENGTHENS the high-water mark rather than weakening it: the
+    // tombstone now sits strictly above every rev the dead lineage could have
+    // cached, which is exactly the property `applyInserted`'s re-insertion bump
+    // relies on.
+    revs.set(id, (revs.get(id) ?? 0) + 1);
   }
 
   // Updated, not rebuilt: a removal cannot REORDER a survivor, so each affected

--- a/packages/keel-core/review3-removal-notification-and-listener-isolation.test.ts
+++ b/packages/keel-core/review3-removal-notification-and-listener-isolation.test.ts
@@ -1,0 +1,514 @@
+// Third review round — the two tombstone defects and the throwing subscriber.
+//
+// All three reproduce through the PUBLIC store surface, and all three are
+// regressions against a guarantee some other module states in prose:
+//
+//   1. `subscribeToNode` promises to fire when that node changes, and
+//      disappearing is the largest change there is. The rev TOMBSTONE that
+//      round two added to `applyRemoved` made the removed node's revision
+//      compare EQUAL across the commit, so `commitGraph` skipped its listeners.
+//      The comment in ./engine.ts still claimed "0 for an unknown node is what
+//      makes a removal and an insertion both register as a change" — true
+//      before the tombstone, false after it.
+//
+//   2. `applyInserted` honours that same tombstone (`if (!revs.has(id))`), so a
+//      re-inserted id lands strictly above every rev its dead lineage cached.
+//      `loadChildrenInto` wrote 0 unconditionally, which is the identical
+//      fold-cache corruption round two fixed, through the other door.
+//
+//   3. `dispatch` is contracted to return a `Result` and never throw. One
+//      consumer listener throwing escaped it — after the graph had committed
+//      and history had been pushed, and BEFORE the change feed emitted, so the
+//      mutation existed in memory and in undo but was never announced to the
+//      persistence layer.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { getSubtreeRev } from "./graph";
+import { foldMonoid } from "./folds";
+import { createEngine } from "./engine";
+
+type Clip = Readonly<{ title: string; seconds: number }>;
+type ClipEdit = Readonly<{ title?: string; seconds?: number }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const seconds = record["seconds"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { title, seconds } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, seconds: data.seconds };
+  },
+  applyEdit(data, edit) {
+    return {
+      ok: true,
+      value: {
+        title: edit.title ?? data.title,
+        seconds: edit.seconds ?? data.seconds,
+      },
+    };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+
+type Summary = Readonly<{ seconds: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const seconds = record["seconds"];
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { seconds } };
+  },
+  serialize(value): unknown {
+    return { seconds: value.seconds };
+  },
+};
+
+const durationFold = foldMonoid<Types, Summary, number>({
+  key: "duration",
+  empty: 0,
+  leaf(node) {
+    return node.kind === "clip" ? node.data.seconds : 0;
+  },
+  concat(a, b) {
+    return a + b;
+  },
+  placeholder(node) {
+    return node.summary === null ? undefined : node.summary.seconds;
+  },
+});
+
+const folds = { duration: durationFold };
+
+function makeEngine() {
+  return createEngine<Types, Summary, typeof folds>({
+    types,
+    summary,
+    folds,
+    devChecks: true,
+    now: () => 1234,
+  });
+}
+
+const rootId = parseNodeId("root");
+const clipXId = parseNodeId("x");
+const clipYId = parseNodeId("y");
+const boxId = parseNodeId("box");
+
+/** root(loaded) -> [x(clip 4), y(clip 2), box(folder, unloaded)] */
+function loadedStore() {
+  const engine = makeEngine();
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      {
+        id: "root",
+        kind: "folder",
+        data: { name: "Root" },
+        children: ["x", "y", "box"],
+      },
+      { id: "x", kind: "clip", data: { title: "X", seconds: 4 } },
+      { id: "y", kind: "clip", data: { title: "Y", seconds: 2 } },
+      {
+        id: "box",
+        kind: "folder",
+        data: { name: "Box" },
+        childrenState: "unloaded",
+        summary: { seconds: 0 },
+      },
+    ],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to deserialize");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+// ---------------------------------------------------------------------------
+// 1. A removed node's OWN subscribers
+// ---------------------------------------------------------------------------
+
+describe("removal wakes the removed node's own subscribers", () => {
+  it("bumps the removed node's revision so commitGraph sees a change", () => {
+    const { store } = loadedStore();
+
+    const before = getSubtreeRev(store.getGraph(), clipXId);
+    const removed = store.dispatch({
+      type: "remove-nodes",
+      nodeIds: [clipXId],
+    });
+    expect(removed.ok).toBe(true);
+
+    // The tombstone must MOVE. Equal revisions across the commit is precisely
+    // what made `commitGraph` skip the listener.
+    expect(getSubtreeRev(store.getGraph(), clipXId)).toBeGreaterThan(before);
+  });
+
+  it("notifies the subscriber mounted on the node that was deleted", () => {
+    const { store } = loadedStore();
+
+    let xWoke = 0;
+    let yWoke = 0;
+    let rootWoke = 0;
+    store.subscribeToNode(clipXId, () => {
+      xWoke += 1;
+    });
+    store.subscribeToNode(clipYId, () => {
+      yWoke += 1;
+    });
+    store.subscribeToNode(rootId, () => {
+      rootWoke += 1;
+    });
+
+    const removed = store.dispatch({
+      type: "remove-nodes",
+      nodeIds: [clipXId],
+    });
+    expect(removed.ok).toBe(true);
+
+    // The point of the fix.
+    expect(xWoke).toBe(1);
+    // The ancestor still wakes, as it always did.
+    expect(rootWoke).toBe(1);
+    // And an uninvolved sibling still does NOT — the fix must not turn a
+    // targeted notification into a broadcast.
+    expect(yWoke).toBe(0);
+  });
+
+  it("notifies subscribers on every node of a removed SUBTREE, not just its root", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "Root" }, children: ["dir"] },
+        { id: "dir", kind: "folder", data: { name: "Dir" }, children: ["deep"] },
+        { id: "deep", kind: "clip", data: { title: "Deep", seconds: 1 } },
+      ],
+    });
+    if (!loaded.ok) throw new Error("fixture failed to deserialize");
+    const store = engine.createStore(loaded.value.graph);
+
+    const woke = new Set<string>();
+    for (const raw of ["root", "dir", "deep"]) {
+      store.subscribeToNode(parseNodeId(raw), () => {
+        woke.add(raw);
+      });
+    }
+
+    const removed = store.dispatch({
+      type: "remove-nodes",
+      nodeIds: [parseNodeId("dir")],
+    });
+    expect(removed.ok).toBe(true);
+
+    // A card mounted on `deep` is just as gone as one mounted on `dir`.
+    expect([...woke].sort()).toEqual(["deep", "dir", "root"]);
+  });
+
+  it("still wakes the node when it comes back via undo", () => {
+    const { store } = loadedStore();
+    store.dispatch({ type: "remove-nodes", nodeIds: [clipXId] });
+
+    let xWoke = 0;
+    store.subscribeToNode(clipXId, () => {
+      xWoke += 1;
+    });
+
+    const undone = store.undo();
+    expect(undone.ok).toBe(true);
+    expect(xWoke).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The tombstone must survive a lazy load
+// ---------------------------------------------------------------------------
+
+describe("loadChildrenInto seeds strictly above a removal tombstone", () => {
+  it("does not serve the dead lineage's cached fold after a reused id arrives", () => {
+    const { engine, store } = loadedStore();
+
+    // Two cached generations for x: rev 0 -> 4, rev 1 -> 10.
+    expect(store.aggregate("duration", clipXId)?.value).toBe(4);
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipXId, kind: "clip", edit: { seconds: 10 } }],
+    });
+    expect(store.aggregate("duration", clipXId)?.value).toBe(10);
+
+    store.dispatch({ type: "remove-nodes", nodeIds: [clipXId] });
+    const tombstone = getSubtreeRev(store.getGraph(), clipXId);
+
+    // The server moved x into the not-yet-loaded folder, with new content.
+    const loaded = store.load(boxId, {
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["x"],
+      nodes: [{ id: "x", kind: "clip", data: { title: "X", seconds: 999 } }],
+    });
+    expect(loaded.ok).toBe(true);
+
+    // The arriving id must not land on a revision the dead lineage cached.
+    expect(getSubtreeRev(store.getGraph(), clipXId)).toBeGreaterThan(tombstone);
+
+    // The cached read and the uncached read must agree. This is the assertion
+    // the defect fails: the store answered 4 while the truth was 999.
+    const graph = store.getGraph();
+    expect(store.aggregate("duration", clipXId)?.value).toBe(999);
+    expect(engine.aggregate(graph, "duration", clipXId)?.value).toBe(999);
+    expect(store.aggregate("duration", boxId)?.value).toBe(
+      engine.aggregate(graph, "duration", boxId)?.value,
+    );
+  });
+
+  it("keeps agreeing after further edits to the reloaded node", () => {
+    const { engine, store } = loadedStore();
+
+    store.aggregate("duration", clipXId);
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipXId, kind: "clip", edit: { seconds: 10 } }],
+    });
+    store.aggregate("duration", clipXId);
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipXId, kind: "clip", edit: { seconds: 20 } }],
+    });
+    store.aggregate("duration", clipXId);
+
+    store.dispatch({ type: "remove-nodes", nodeIds: [clipXId] });
+    store.load(boxId, {
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["x"],
+      nodes: [{ id: "x", kind: "clip", data: { title: "X", seconds: 999 } }],
+    });
+
+    // The defect does not self-heal: each later edit lands on the NEXT
+    // already-poisoned rev, so the store replays 4 / 10 / 20 in order.
+    for (const seconds of [111, 222]) {
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipXId, kind: "clip", edit: { seconds } }],
+      });
+      const graph = store.getGraph();
+      expect(store.aggregate("duration", clipXId)?.value).toBe(seconds);
+      expect(engine.aggregate(graph, "duration", clipXId)?.value).toBe(seconds);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. One consumer's throwing listener must not derail the engine
+// ---------------------------------------------------------------------------
+
+describe("a throwing subscriber cannot break the commit sequence", () => {
+  function silenceConsoleError() {
+    const original = console.error;
+    const calls: unknown[][] = [];
+    console.error = (...args: unknown[]): void => {
+      calls.push(args);
+    };
+    return {
+      calls,
+      restore: () => {
+        console.error = original;
+      },
+    };
+  }
+
+  it("does not let a graph listener throw out of dispatch, and still runs the rest", () => {
+    const { store } = loadedStore();
+    const spy = silenceConsoleError();
+    try {
+      const ran: string[] = [];
+      store.subscribeToGraph(() => {
+        ran.push("first");
+      });
+      store.subscribeToGraph(() => {
+        ran.push("throws");
+        throw new Error("consumer listener blew up");
+      });
+      store.subscribeToGraph(() => {
+        ran.push("third");
+      });
+      let changeFeedFired = 0;
+      store.subscribeToChanges(() => {
+        changeFeedFired += 1;
+      });
+
+      const result = store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipXId, kind: "clip", edit: { seconds: 7 } }],
+      });
+
+      // The contract: a Result, not an exception.
+      expect(result.ok).toBe(true);
+      // A listener that throws must not starve the ones after it.
+      expect(ran).toEqual(["first", "throws", "third"]);
+      // And the persistence feed must still be told about a mutation that
+      // actually committed. This is the half that loses data.
+      expect(changeFeedFired).toBe(1);
+      // Swallowed, but never silently.
+      expect(spy.calls.length).toBeGreaterThan(0);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("isolates a throwing NODE listener", () => {
+    const { store } = loadedStore();
+    const spy = silenceConsoleError();
+    try {
+      const ran: string[] = [];
+      store.subscribeToNode(clipXId, () => {
+        ran.push("throws");
+        throw new Error("card blew up");
+      });
+      store.subscribeToNode(clipXId, () => {
+        ran.push("sibling");
+      });
+      let graphWoke = 0;
+      store.subscribeToGraph(() => {
+        graphWoke += 1;
+      });
+
+      const result = store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipXId, kind: "clip", edit: { seconds: 7 } }],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(ran).toEqual(["throws", "sibling"]);
+      // The node loop runs BEFORE graph subscribers; a throw there must not
+      // skip them.
+      expect(graphWoke).toBe(1);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("isolates a throwing CHANGE-FEED listener", () => {
+    const { store } = loadedStore();
+    const spy = silenceConsoleError();
+    try {
+      const ran: string[] = [];
+      store.subscribeToChanges(() => {
+        ran.push("throws");
+        throw new Error("persistence blew up");
+      });
+      store.subscribeToChanges(() => {
+        ran.push("second");
+      });
+
+      const result = store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipXId, kind: "clip", edit: { seconds: 7 } }],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(ran).toEqual(["throws", "second"]);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("isolates a throwing SELECTION listener", () => {
+    const { store } = loadedStore();
+    const spy = silenceConsoleError();
+    try {
+      const ran: string[] = [];
+      store.selection.subscribe(() => {
+        ran.push("throws");
+        throw new Error("selection view blew up");
+      });
+      store.selection.subscribe(() => {
+        ran.push("second");
+      });
+
+      expect(() => {
+        store.selection.set([clipXId]);
+      }).not.toThrow();
+      expect(ran).toEqual(["throws", "second"]);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("still surfaces a throwing listener during undo and redo", () => {
+    const { store } = loadedStore();
+    const spy = silenceConsoleError();
+    try {
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipXId, kind: "clip", edit: { seconds: 7 } }],
+      });
+      store.subscribeToGraph(() => {
+        throw new Error("blew up");
+      });
+
+      const undone = store.undo();
+      expect(undone.ok).toBe(true);
+      const redone = store.redo();
+      expect(redone.ok).toBe(true);
+    } finally {
+      spy.restore();
+    }
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -1277,7 +1277,26 @@ export function loadChildrenInto<Ts extends readonly unknown[], S>(
   }
 
   const subtreeRevById = new Map(graph.subtreeRevById);
-  for (const incomingId of payload.order) subtreeRevById.set(incomingId, 0);
+  // SEEDED ABOVE ANY TOMBSTONE, never unconditionally at 0 — the same rule
+  // `applyInserted` follows with `if (!revs.has(node.id))`, and for the same
+  // reason. `applyRemoved` leaves a removed id's revision behind deliberately,
+  // because `subtreeRevById` is the fold cache's ONLY invalidation mechanism:
+  // an entry keyed (foldKey, nodeId, rev) is meant to become unreachable once
+  // the rev moves past it, so nothing ever has to evict.
+  //
+  // Writing 0 here walked a returning id back onto revisions its DEAD lineage
+  // had already cached under different data. The `id-collision` guard above
+  // does not catch it — that one rejects ids the graph CURRENTLY holds, and a
+  // removed id is absent from `nodesById` while still present here. The gesture
+  // is: read a clip's rollup, edit it, delete it, then have the server report
+  // it inside a not-yet-loaded folder. Measured before this fix: the store
+  // answered the dead clip's 4 while the truth was 999, at the clip AND at
+  // every ancestor rollup, and it did not self-heal — each later edit landed on
+  // the next already-poisoned rev.
+  for (const incomingId of payload.order) {
+    const tombstone = graph.subtreeRevById.get(incomingId);
+    subtreeRevById.set(incomingId, tombstone === undefined ? 0 : tombstone + 1);
+  }
 
   const base: Graph<Ts, S> = {
     engineId: graph.engineId,
@@ -1286,8 +1305,10 @@ export function loadChildrenInto<Ts extends readonly unknown[], S>(
     parentById,
     rootIds: graph.rootIds,
     // Bumped against the PRE-load graph on purpose: the ancestor chain is read
-    // from `parentById`, and the target's ancestors are unchanged by loading,
-    // while the newly arrived nodes are brand new and start at 0.
+    // from `parentById`, and the target's ancestors are unchanged by loading.
+    // The arriving nodes need no bump of their own — the loop above has already
+    // seeded each one at 0, or above its tombstone if the id has lived here
+    // before.
     subtreeRevById: bumpSubtreeRevs(subtreeRevById, graph, [id]),
     placementsByContentKey: new Map(),
     ownerBySourceKey: new Map(),


### PR DESCRIPTION
Three defects in `@storyboard/keel-core`, all reproduced through the public store before any code moved. Two are regressions against round two's own fix.

### 1 — A removed node's own subscribers were never notified

`commitGraph` wakes a node's listeners by comparing `getSubtreeRev` across the commit. Round two made `applyRemoved` keep the removed id's revision as a tombstone — correct, and a fold-cache requirement — but kept it **frozen**, so both sides read the same number and the card mounted on the node that just disappeared was never told.

```
BEFORE remove: getSubtreeRev(a) = 0, node present = true
AFTER  remove: getSubtreeRev(a) = 0, node present = false
node "a"'s OWN subscriber woke 0 times
node "root"'s subscriber woke 1 time
```

A tree view hides this — the parent re-renders and React unmounts the child — which is why it survived a round. Anything addressing a node directly (a detail pane, an inspector, a flattened list) renders the deleted node forever.

The tombstone now moves. `+ 1` rather than a walk through `bumpSubtreeRevsInto`, since the ancestors are already bumped against the pre-state graph. This *strengthens* the high-water mark: the tombstone now sits strictly above every rev the dead lineage could have cached.

### 2 — `loadChildrenInto` overwrote that tombstone with 0

The same fold-cache corruption round two fixed, through the other door. `applyInserted` honours the tombstone with `if (!revs.has(node.id))`; the lazy path wrote `0` unconditionally. The `id-collision` guard doesn't catch it — that rejects ids the graph *currently* holds, and a removed id is absent from `nodesById` while still present in `subtreeRevById`.

```
after load:      rev(x)=0  cached=4    truth=999
after edit→111:  rev(x)=1  cached=10   truth=111
after edit→222:  rev(x)=2  cached=20   truth=222
```

It does not self-heal, it reaches every ancestor rollup, and `devChecks: true` caught nothing. Now seeded at `tombstone + 1`.

### 3 — One throwing subscriber did three things at once

The exception escaped `dispatch` — whose contract is that it returns a `Result` — *after* the graph had committed and history had been pushed. Every listener after it was starved. And because `emitChange` is sequenced after `commitGraph`, a throwing graph subscriber meant **the change feed never emitted at all**: the edit existed in memory and in undo and was never announced to whatever performs the write.

```
dispatch threw:  "consumer listener blew up"
listeners that ran:  [graph-1, graph-2-THROWS]   ← graph-3 never ran
change-feed listeners fired:  0
graph node count after the throw:  5             ← the write COMMITTED
canUndo after the throw:  true                   ← history pushed
```

In React that's one error thrown inside a `useSyncExternalStore` callback away. `notifyOne` now wraps every consumer callback across all four feeds, swallowed and reported via `console.error` — the same judgement `auditIfDev` already makes.

### Two comments corrected

The comment in `engine.ts` claimed `getSubtreeRev` answering 0 for an unknown node "is what makes a removal and an insertion both register as a change" — true only while `applyRemoved` deleted the entry, and that stale sentence is *why* defect 1 shipped. A second comment in `serialize.ts`, three lines below the fix for defect 2, said arriving nodes "start at 0"; this change made it stale, so it went in the same pass rather than becoming next round's finding.

### Verification

| | |
|---|---|
| New regression tests | 11, of which **10 failed** before the fix |
| Per-fix mutation proof | revert 1 → 3 fail · revert 2 → 2 fail · revert 3 → 5 fail, exactly partitioned |
| Unit suite | 1,343 tests / 64 files, all pass |
| KEEL stories | 9 pass in real headless Chromium |
| `tsc` | clean, keel-core and keel-react |

### Not fixed, named rather than skipped

- The React layer still has no render-counting browser test, so the binding's end-to-end behaviour on removal remains unproven — the same gap round two flagged.
- `packages/keel-core` sits **outside the app's eslint base path**, so nothing in these packages is linted at all. Its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)