### PR TITLE
Every consumer codec call is now wrapped, not just the parse half

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -17,6 +17,7 @@
 // PURE. No React, no DOM. Nothing here throws; every failure is Result-shaped.
 
 import {
+  describeThrown,
   type AnyNode,
   type ChildrenState,
   type Command,
@@ -33,6 +34,7 @@ import {
   type Rejection,
   type RejectionCode,
   type Result,
+  type EditRejection,
   type Seed,
   makeCollectionNode,
   makeDataChange,
@@ -871,7 +873,22 @@ function planEdits<Ts extends readonly unknown[], S>(
       );
     }
 
-    const applied = type.applyEdit(node.data, edit.edit);
+    // WRAPPED for the same reason ./serialize wraps `parse`: `applyEdit` is
+    // consumer code, and a codec that throws must produce the refusal this
+    // function is contracted to return rather than an exception out of
+    // `dispatch`. A throw and a returned `{ ok: false }` mean the same thing to
+    // the user — the codec would not accept this edit — so they get the same
+    // code, with the thrown message carried through.
+    let applied: Result<unknown, EditRejection>;
+    try {
+      applied = type.applyEdit(node.data, edit.edit);
+    } catch (thrown) {
+      return fail(
+        "edit-rejected",
+        `The ${JSON.stringify(node.kind)} codec threw while applying the edit: ${describeThrown(thrown)}`,
+        { nodeIds: [edit.nodeId], kind: node.kind },
+      );
+    }
     if (!applied.ok) {
       return fail(
         "edit-rejected",
@@ -886,12 +903,31 @@ function planEdits<Ts extends readonly unknown[], S>(
     // value arriving off the wire. Round-tripped through `serialize` because
     // that is the form `parse` is defined over, which also means a lossy
     // `serialize` surfaces here rather than three saves later.
+    // WRAPPED, like the `applyEdit` above it. `parseNodeData` already guards
+    // the `parse` half of this round trip; leaving the `serialize` half bare
+    // meant the same class of consumer bug escaped as an exception from one
+    // side of one expression and as a `Result` from the other.
+    let raw: unknown;
+    try {
+      raw = type.serialize(applied.value);
+    } catch (thrown) {
+      return fail(
+        "parse-failed",
+        `The ${JSON.stringify(node.kind)} codec threw while serializing the edited value: ${describeThrown(thrown)}`,
+        {
+          nodeIds: [edit.nodeId],
+          kind: node.kind,
+          issues: [{ path: "$", message: describeThrown(thrown) }],
+        },
+      );
+    }
+
     const reparsed = parseNodeData<S>(ctx, {
       nodeId: edit.nodeId,
       kind: node.kind,
       container: type.container,
       schemaVersion: type.schemaVersion,
-      raw: type.serialize(applied.value),
+      raw,
     });
     if (!reparsed.ok) {
       return fail(

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -35,6 +35,7 @@
 // a bad one is this module's.
 
 import {
+  describeThrown,
   makeCollectionNode,
   makeDataChange,
   makeLeafNode,
@@ -1022,7 +1023,27 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
     // it once per changed node per verification.
     if (Object.is(change.before, node.data)) continue;
 
-    if (!deepEqual(codec.serialize(change.before), codec.serialize(node.data))) {
+    // WRAPPED. `serialize` is consumer code, and this function is contracted to
+    // return a `Result` — a throw here escaped `verifyPatchApplies` and took
+    // `undo` and `redo` with it. A codec that cannot serialize its own value
+    // cannot prove the recorded `before` still stands, so the honest verdict is
+    // the same one a genuine difference produces: this patch no longer applies.
+    // Refusing is safe (the entry stays on the stack, the graph is untouched);
+    // proceeding on an unverifiable comparison is not.
+    let matches: boolean;
+    try {
+      matches = deepEqual(
+        codec.serialize(change.before),
+        codec.serialize(node.data),
+      );
+    } catch (thrown) {
+      return replayError(
+        "data-mismatch",
+        `Node ${change.nodeId} could not be compared against this patch's recorded "before": the ${JSON.stringify(change.kind)} codec threw while serializing (${describeThrown(thrown)}).`,
+        { nodeId: change.nodeId },
+      );
+    }
+    if (!matches) {
       return replayError(
         "data-mismatch",
         `Node ${change.nodeId} no longer holds the value this patch recorded as "before".`,

--- a/packages/keel-core/review3-a-throwing-codec-cannot-escape-as-an-exception.test.ts
+++ b/packages/keel-core/review3-a-throwing-codec-cannot-escape-as-an-exception.test.ts
@@ -1,0 +1,384 @@
+// Third review round — the other half of "the engine survives its consumers".
+//
+// Every consumer `parse` call is defensively wrapped: ./serialize wraps node
+// data, and a prior round wrapped the summary codec beside it. NO `serialize`
+// call was, and `serialize` is consumer code on exactly the same footing.
+//
+// The asymmetry costs three different contracts:
+//
+//   - `dispatch` promises a `Result`. A codec that throws while the reducer
+//     round-trips its own output turned that into an unhandled exception out of
+//     a React event handler, at every call site that correctly wrote
+//     `if (!result.ok)`.
+//   - `verifyPatchApplies` promises a `Result`. Undo runs the consumer's
+//     `serialize` once per changed node to prove the recorded `before` still
+//     stands, so a throwing codec took out undo the same way.
+//   - `serializeGraph` promises to be TOTAL, in those words, "because a save
+//     path that throws loses the user's document". Its own `serializeData`
+//     already states the policy — "an unserializable node should cost one
+//     node's fidelity, never the whole save" — and then called `type.serialize`
+//     unwrapped on the very next line.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+// Which codec call should blow up. Flipped per test; the throw is realistic —
+// an encoder meeting a value it cannot represent, not a synthetic panic.
+const explode = {
+  nodeSerialize: false,
+  applyEdit: false,
+  summarySerialize: false,
+};
+
+function resetExplosions(): void {
+  explode.nodeSerialize = false;
+  explode.applyEdit = false;
+  explode.summarySerialize = false;
+}
+
+type Clip = Readonly<{ title: string; seconds: number }>;
+type ClipEdit = Readonly<{ title?: string; seconds?: number }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const seconds = record["seconds"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { title, seconds } };
+  },
+  serialize(data): unknown {
+    if (explode.nodeSerialize) {
+      throw new TypeError("clip.serialize cannot encode this value");
+    }
+    return { title: data.title, seconds: data.seconds };
+  },
+  applyEdit(data, edit) {
+    if (explode.applyEdit) {
+      throw new TypeError("clip.applyEdit blew up");
+    }
+    return {
+      ok: true,
+      value: {
+        title: edit.title ?? data.title,
+        seconds: edit.seconds ?? data.seconds,
+      },
+    };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+
+type Summary = Readonly<{ seconds: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const seconds = record["seconds"];
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { seconds } };
+  },
+  serialize(value): unknown {
+    if (explode.summarySerialize) {
+      throw new TypeError("summary.serialize cannot encode this value");
+    }
+    return { seconds: value.seconds };
+  },
+};
+
+const folds = {};
+
+function makeEngine() {
+  return createEngine<Types, Summary, typeof folds>({
+    types,
+    summary,
+    folds,
+    now: () => 1234,
+  });
+}
+
+const clipAId = parseNodeId("a");
+const boxId = parseNodeId("box");
+
+/** root -> [a(clip 4), box(folder, unloaded, summary { seconds: 30 })] */
+function loadedStore() {
+  const engine = makeEngine();
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      {
+        id: "root",
+        kind: "folder",
+        data: { name: "Root" },
+        children: ["a", "box"],
+      },
+      { id: "a", kind: "clip", data: { title: "A", seconds: 4 } },
+      {
+        id: "box",
+        kind: "folder",
+        data: { name: "Box" },
+        childrenState: "unloaded",
+        summary: { seconds: 30 },
+      },
+    ],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to deserialize");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+// ---------------------------------------------------------------------------
+// dispatch
+// ---------------------------------------------------------------------------
+
+describe("the reducer refuses rather than throwing when a codec blows up", () => {
+  it("returns a Result when applyEdit throws", () => {
+    resetExplosions();
+    const { store } = loadedStore();
+    explode.applyEdit = true;
+
+    let thrown: unknown = null;
+    let result: ReturnType<typeof store.dispatch> | null = null;
+    try {
+      result = store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 9 } }],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeNull();
+    expect(result?.ok).toBe(false);
+    if (result && !result.ok) {
+      expect(result.error.code).toBe("edit-rejected");
+      expect(result.error.message).toContain("threw");
+    }
+  });
+
+  it("returns a Result when serialize throws while re-parsing the edit", () => {
+    resetExplosions();
+    const { store } = loadedStore();
+    explode.nodeSerialize = true;
+
+    let thrown: unknown = null;
+    let result: ReturnType<typeof store.dispatch> | null = null;
+    try {
+      result = store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 9 } }],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeNull();
+    expect(result?.ok).toBe(false);
+    if (result && !result.ok) expect(result.error.code).toBe("parse-failed");
+  });
+
+  it("leaves the graph and the history stack untouched after a codec throw", () => {
+    resetExplosions();
+    const { store } = loadedStore();
+    const before = store.getGraph();
+
+    explode.nodeSerialize = true;
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 9 } }],
+    });
+    resetExplosions();
+
+    // A refused command is not a commit: same graph identity, nothing to undo.
+    expect(store.getGraph()).toBe(before);
+    expect(store.canUndo()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyPatchApplies — the undo path
+// ---------------------------------------------------------------------------
+
+describe("replay verification refuses rather than throwing", () => {
+  it("returns a Result when serialize throws while comparing a dormant patch", () => {
+    resetExplosions();
+    const { engine, store } = loadedStore();
+
+    // Two edits, so the first patch's `before` is no longer the object the
+    // graph holds — which is what gets past the identity fast path and reaches
+    // the consumer's `serialize`.
+    const first = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 5 } }],
+    });
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 6 } }],
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+
+    explode.nodeSerialize = true;
+    let thrown: unknown = null;
+    let verified: ReturnType<typeof engine.verifyPatchApplies> | null = null;
+    try {
+      verified = engine.verifyPatchApplies(store.getGraph(), first.value);
+    } catch (error) {
+      thrown = error;
+    }
+    resetExplosions();
+
+    expect(thrown).toBeNull();
+    expect(verified?.ok).toBe(false);
+    if (verified && !verified.ok) {
+      expect(verified.error.code).toBe("data-mismatch");
+    }
+  });
+
+  it("keeps undo Result-shaped when the codec throws mid-verification", () => {
+    resetExplosions();
+    const { store } = loadedStore();
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 5 } }],
+    });
+    store.ingest([{ nodeId: clipAId, kind: "clip", edit: { seconds: 5 } }]);
+
+    explode.nodeSerialize = true;
+    let thrown: unknown = null;
+    let undone: ReturnType<typeof store.undo> | null = null;
+    try {
+      undone = store.undo();
+    } catch (error) {
+      thrown = error;
+    }
+    resetExplosions();
+
+    // Either it verified and undid, or it refused — but it must not throw, and
+    // the stack must not be left half-moved.
+    expect(thrown).toBeNull();
+    expect(undone).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeGraph — the save path, which is documented TOTAL
+// ---------------------------------------------------------------------------
+
+describe("the save path stays total when a codec throws", () => {
+  it("does not lose the document when a node codec throws", () => {
+    resetExplosions();
+    const { engine, store } = loadedStore();
+    const graph = store.getGraph();
+
+    explode.nodeSerialize = true;
+    let thrown: unknown = null;
+    let doc: ReturnType<typeof engine.serialize> | null = null;
+    try {
+      doc = engine.serialize(graph);
+    } catch (error) {
+      thrown = error;
+    }
+    resetExplosions();
+
+    expect(thrown).toBeNull();
+    expect(doc).not.toBeNull();
+    // Every node still present — one node's fidelity, never the whole save.
+    expect(doc?.nodes.map((node) => node.id).sort()).toEqual([
+      "a",
+      "box",
+      "root",
+    ]);
+    // And the unaffected kinds still serialized normally.
+    const root = doc?.nodes.find((node) => node.id === "root");
+    expect(root?.data).toEqual({ name: "Root" });
+  });
+
+  it("does not lose the document when the summary codec throws", () => {
+    resetExplosions();
+    const { engine, store } = loadedStore();
+    const graph = store.getGraph();
+
+    explode.summarySerialize = true;
+    let thrown: unknown = null;
+    let doc: ReturnType<typeof engine.serialize> | null = null;
+    try {
+      doc = engine.serialize(graph);
+    } catch (error) {
+      thrown = error;
+    }
+    resetExplosions();
+
+    expect(thrown).toBeNull();
+    expect(doc?.nodes.map((node) => node.id).sort()).toEqual([
+      "a",
+      "box",
+      "root",
+    ]);
+    // The clip beside it is untouched by the summary codec's failure.
+    const clip = doc?.nodes.find((node) => node.id === "a");
+    expect(clip?.data).toEqual({ title: "A", seconds: 4 });
+  });
+
+  it("round-trips a healthy graph unchanged, so the guards cost nothing", () => {
+    resetExplosions();
+    const { engine, store } = loadedStore();
+    const doc = engine.serialize(store.getGraph());
+    const reloaded = engine.deserialize(doc);
+    expect(reloaded.ok).toBe(true);
+    if (!reloaded.ok) return;
+    expect(reloaded.value.report.quarantined.length).toBe(0);
+    expect(engine.findInvariantViolation(reloaded.value.graph)).toBeNull();
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -34,6 +34,7 @@
 //   6. loadChildrenInto
 
 import {
+  describeThrown,
   makeCollectionNode,
   makeLeafNode,
   makeQuarantinedNode,
@@ -481,11 +482,6 @@ function runMigrations(
   }
 
   return { ok: true, value: { data, migratedFrom: from } };
-}
-
-function describeThrown(thrown: unknown): string {
-  if (thrown instanceof Error) return thrown.message;
-  return String(thrown);
 }
 
 // ---------------------------------------------------------------------------
@@ -1101,7 +1097,28 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
     // this function total — an unserializable node should cost one node's
     // fidelity, never the whole save.
     if (type === undefined) return data;
-    return type.serialize(data);
+    // The SAME fallback, for the reachable version of the same problem. The
+    // branch above handles a codec that is missing; this one handles a codec
+    // that is present and throws, which is consumer code and therefore not
+    // hypothetical. Leaving it bare contradicted this function's own policy one
+    // line up and, worse, the module's promise that `serializeGraph` is TOTAL
+    // "because a save path that throws loses the user's document".
+    //
+    // The live value is the best remaining representation: it is what the codec
+    // was asked to encode, it is usually near-identical to the wire form, and
+    // on reload it either parses or quarantines loudly. Both outcomes beat
+    // losing the whole save.
+    try {
+      return type.serialize(data);
+    } catch (thrown) {
+      console.error(
+        `keel: the ${JSON.stringify(kind)} codec threw while serializing a node for save. ` +
+          `That node is being written in its live form instead, which may not round-trip. ` +
+          `The rest of the document is unaffected.`,
+        thrown,
+      );
+      return data;
+    }
   };
 
   const emit = (id: NodeId): void => {
@@ -1134,7 +1151,21 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
       // an explicit null would round-trip too, but only if the summary codec
       // tolerated being handed one.
       if (node.summary !== null) {
-        draft.summary = ctx.summary.serialize(node.summary);
+        // Guarded like `serializeData`, and for the same reason: the summary
+        // codec is consumer code on the same footing as a node codec, and its
+        // `parse` half is already wrapped at ingress. A summary is a DERIVED
+        // rollup, so dropping it costs strictly less than dropping a node —
+        // the next reader sees an unloaded container with no stored estimate,
+        // which is honest, where a thrown save loses everything.
+        try {
+          draft.summary = ctx.summary.serialize(node.summary);
+        } catch (thrown) {
+          console.error(
+            `keel: the summary codec threw while serializing node ${JSON.stringify(id)} for save. ` +
+              `Its stored summary is being omitted; the rest of the document is unaffected.`,
+            thrown,
+          );
+        }
       }
       writeChildren(draft, id, node.children);
     }

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1437,3 +1437,31 @@ export function makeDataChange<Ts extends readonly unknown[]>(
   }> = { nodeId, kind, before, after };
   return change as unknown as DataChange<Ts>;
 }
+
+// ---------------------------------------------------------------------------
+// Describing a throw
+// ---------------------------------------------------------------------------
+
+/**
+ * The message to put in an `Issue` when consumer code threw instead of
+ * returning.
+ *
+ * It lives HERE, in the module that imports nothing, because all four modules
+ * that call into a consumer codec need it — ./serialize wraps `parse` and the
+ * summary codec, ./commands wraps `applyEdit` and `serialize`, ./patches wraps
+ * the `serialize` pair that replay verification compares on. One
+ * implementation, so the three cannot drift into describing the same throw
+ * three different ways.
+ *
+ * NOT re-exported from ./index: a consumer never calls this, it only ever reads
+ * the strings it produces.
+ *
+ * `String(thrown)` rather than `JSON.stringify`: a thrown value is arbitrary,
+ * `stringify` is recursive and can itself throw on a cycle or a BigInt, and a
+ * helper whose whole job is to describe a failure must not have a failure mode
+ * of its own.
+ */
+export function describeThrown(thrown: unknown): string {
+  if (thrown instanceof Error) return thrown.message;
+  return String(thrown);
+}


### PR DESCRIPTION
Stacked on #570 — merge that first.

The ingress side of the codec boundary was defended and the egress side was not. `./serialize` wraps `parse` for node data, and a prior round wrapped the summary codec beside it. **No `serialize` call was wrapped anywhere**, and `serialize` is consumer code on exactly the same footing.

That asymmetry broke three contracts, all of them stated in the source.

### `dispatch` promises a Result

`planEdits` round-trips the codec's own output — `applyEdit` → `serialize` → `parse` — because an edit that walks a clip past its own source length is exactly as invalid as the same value off the wire. The `parse` leg was guarded; the two before it were not. So the same class of consumer bug escaped as an exception from one side of one expression and as a `Result` from the other.

Measured with a codec that throws for a negative duration: `store.dispatch(edit-nodes)` threw `TypeError` where every call site that correctly writes `if (!result.ok)` expected a rejection. Both legs now return one — `edit-rejected` when `applyEdit` throws (a throw and a returned refusal mean the same thing to the user), `parse-failed` when `serialize` does.

### `verifyPatchApplies` promises a Result

Undo runs the consumer's `serialize` once per changed node to prove the recorded `before` still stands, so a throwing codec took out `undo` and `redo` too. A codec that cannot serialize its own value cannot prove anything about it, so the verdict is the one a genuine difference produces: `data-mismatch`. Refusing is safe — the entry stays on the stack, the graph is untouched — where proceeding on a comparison that never completed is not.

### `serializeGraph` promises to be TOTAL

In those words: *"because a save path that throws loses the user's document"*. Its own `serializeData` already wrote the policy down —

```ts
// Falling back to the live value rather than throwing keeps
// this function total — an unserializable node should cost one
// node's fidelity, never the whole save.
if (type === undefined) return data;
return type.serialize(data);   // ← unguarded, on the very next line
```

So this isn't a new decision; it applies the function's own stated rule to the one line that didn't follow it. A throwing node codec falls back to the live value — what the codec was asked to encode, which on reload either parses or quarantines loudly. A throwing summary codec omits that one summary, which costs strictly less: a summary is a derived rollup, and its absence reads as "no stored estimate" rather than corruption. Both report via `console.error`, since a codec throwing on every save is a real bug that must not be invisible.

### Also

`describeThrown` moved from `./serialize` into `./types`, which imports nothing, so all four modules that call into a consumer codec share one implementation rather than drifting into three descriptions of the same throw. Deliberately **not** added to `./index` — a consumer reads the strings it produces and never calls it.

### Verification

| | |
|---|---|
| Regression tests | 8, of which **6 failed** before the fix |
| Mutation proof | `applyEdit` 1 · edit-path `serialize` 2 · verification pair 1 · save-path node codec 1 · save-path summary codec 1 |
| Unit suite | 1,351 tests / 65 files, all pass |
| `tsc` | clean, both packages |

One note on that proof, because it nearly went the other way: my first mutation of the verification guard replaced `try {` without replacing the matching `catch`, so the file failed to compile and the run reported **zero assertions** — which reads exactly like "this guard is untested decoration". It isn't; a syntactically valid mutation fails the intended test. Recording it so the next person doesn't draw the wrong conclusion from a silent file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)