### PR TITLE
The replay door now checks the ownership rule it was the only door to skip

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -42,6 +42,7 @@ import {
   tryParseNodeId,
 } from "./types";
 import {
+  ownsItsSubtree,
   ancestorChain,
   bumpSubtreeRevs,
   documentOrderComparator,
@@ -212,8 +213,9 @@ function owningSourceKey<Ts extends readonly unknown[], S>(
 ): string | null {
   const key = sourceKeyOf<Ts, S>(ctx.registry, node);
   if (key === null) return null;
-  if (node.quarantined) return null;
-  if (node.container && !ownsSubtree(node.children)) return null;
+  // DELEGATED, not re-derived. This used to spell the rule out again and
+  // disagreed with ./serialize about leaves — see `ownsItsSubtree`.
+  if (!ownsItsSubtree<Ts, S>(node)) return null;
   return key;
 }
 

--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -17,6 +17,7 @@
 // PURE. No React, no DOM. Nothing here throws; every failure is Result-shaped.
 
 import {
+  describeThrown,
   type AnyNode,
   type ChildrenState,
   type Command,
@@ -33,6 +34,7 @@ import {
   type Rejection,
   type RejectionCode,
   type Result,
+  type EditRejection,
   type Seed,
   makeCollectionNode,
   makeDataChange,
@@ -871,7 +873,22 @@ function planEdits<Ts extends readonly unknown[], S>(
       );
     }
 
-    const applied = type.applyEdit(node.data, edit.edit);
+    // WRAPPED for the same reason ./serialize wraps `parse`: `applyEdit` is
+    // consumer code, and a codec that throws must produce the refusal this
+    // function is contracted to return rather than an exception out of
+    // `dispatch`. A throw and a returned `{ ok: false }` mean the same thing to
+    // the user — the codec would not accept this edit — so they get the same
+    // code, with the thrown message carried through.
+    let applied: Result<unknown, EditRejection>;
+    try {
+      applied = type.applyEdit(node.data, edit.edit);
+    } catch (thrown) {
+      return fail(
+        "edit-rejected",
+        `The ${JSON.stringify(node.kind)} codec threw while applying the edit: ${describeThrown(thrown)}`,
+        { nodeIds: [edit.nodeId], kind: node.kind },
+      );
+    }
     if (!applied.ok) {
       return fail(
         "edit-rejected",
@@ -886,12 +903,31 @@ function planEdits<Ts extends readonly unknown[], S>(
     // value arriving off the wire. Round-tripped through `serialize` because
     // that is the form `parse` is defined over, which also means a lossy
     // `serialize` surfaces here rather than three saves later.
+    // WRAPPED, like the `applyEdit` above it. `parseNodeData` already guards
+    // the `parse` half of this round trip; leaving the `serialize` half bare
+    // meant the same class of consumer bug escaped as an exception from one
+    // side of one expression and as a `Result` from the other.
+    let raw: unknown;
+    try {
+      raw = type.serialize(applied.value);
+    } catch (thrown) {
+      return fail(
+        "parse-failed",
+        `The ${JSON.stringify(node.kind)} codec threw while serializing the edited value: ${describeThrown(thrown)}`,
+        {
+          nodeIds: [edit.nodeId],
+          kind: node.kind,
+          issues: [{ path: "$", message: describeThrown(thrown) }],
+        },
+      );
+    }
+
     const reparsed = parseNodeData<S>(ctx, {
       nodeId: edit.nodeId,
       kind: node.kind,
       container: type.container,
       schemaVersion: type.schemaVersion,
-      raw: type.serialize(applied.value),
+      raw,
     });
     if (!reparsed.ok) {
       return fail(

--- a/packages/keel-core/graph.ts
+++ b/packages/keel-core/graph.ts
@@ -394,9 +394,29 @@ export function sourceKeyOf<Ts extends readonly unknown[], S>(
   node: AnyNode<Ts, S>,
 ): string | null {
   if (node.quarantined) return null;
-  const type = registry.get(node.kind);
+  return sourceKeyOfKindData(registry, node.kind, node.data);
+}
+
+/**
+ * The same `sourceKey` call, for a caller holding a value the node does not
+ * hold YET.
+ *
+ * `verifyDataChanged` needs exactly this: it must know what key a patch's
+ * `after` would claim before deciding whether replaying it is safe, and the
+ * node in the graph still carries the old value. Split out rather than
+ * duplicated so the two cannot disagree about which codec hook answers, and so
+ * the deliberate absence of a try/catch stays in ONE place — see the block
+ * comment above `contentKeyOf` for why a throwing key function is not swallowed
+ * into `null`.
+ */
+export function sourceKeyOfKindData(
+  registry: NodeTypeRegistry,
+  kind: string,
+  data: unknown,
+): string | null {
+  const type = registry.get(kind);
   if (type === undefined || type.sourceKey === undefined) return null;
-  return type.sourceKey(node.data);
+  return type.sourceKey(data);
 }
 
 /**

--- a/packages/keel-core/graph.ts
+++ b/packages/keel-core/graph.ts
@@ -402,17 +402,39 @@ export function sourceKeyOf<Ts extends readonly unknown[], S>(
 /**
  * Is this node the OWNING placement for its `sourceKey`?
  *
- * A leaf (and a quarantined leaf) has no `ChildrenState` at all, and a
- * placement that cannot be a reference is an owner by default — the `reference`
- * state exists to disclaim a subtree, and a node with no subtree has nothing to
- * disclaim.
+ * THE SINGLE ANSWER. Three call sites used to decide this independently — this
+ * one, `owningSourceKey` in ./commands, and `findDuplicateOwner` in ./serialize
+ * — and they did not agree about leaves. The first two said a leaf owns; the
+ * third said it does not. The consequence was a document that `deserialize`
+ * ACCEPTED, `findInvariantViolation` then condemned as `duplicate-owner`, and
+ * the reducer refused every edit to: it loaded, failed its own audit, and could
+ * not be repaired through the API. All three now call this.
+ *
+ * A LEAF OWNS NOTHING, which reverses what this function used to return.
+ * The earlier reading was that "a placement that cannot be a reference is an
+ * owner by default", and that is exactly backwards once you follow it through:
+ *
+ *   - `sourceKey` is "same stored SUBTREE", and the rejection it produces tells
+ *     the consumer to insert a `reference` instead. A leaf has no
+ *     `ChildrenState`, so it can never BE a reference placement — the rule was
+ *     unsatisfiable for leaves, with no escape hatch in the command vocabulary.
+ *   - `contentKey` already answers the question a repeated clip is actually
+ *     asking ("same asset"), and it permits many placements by design.
+ *   - The alternative fix — making ingress agree with the other two — would
+ *     have made a stored document stop loading, which is the failure quarantine
+ *     exists to prevent and which this repo has already paid for once.
+ *
+ * A quarantined node owns nothing either: its key would have to come from a
+ * codec that by definition did not run, so `sourceKeyOf` already answers `null`
+ * for it. Stated here as well so the predicate is total on its own terms rather
+ * than relying on a caller having checked first.
  */
-function isOwningPlacement<Ts extends readonly unknown[], S>(
-  graph: Graph<Ts, S>,
-  id: NodeId,
+export function ownsItsSubtree<Ts extends readonly unknown[], S>(
+  node: AnyNode<Ts, S>,
 ): boolean {
-  const state = childrenStateOf(graph, id);
-  return state === null || ownsSubtree(state);
+  if (node.quarantined) return false;
+  if (!node.container) return false;
+  return ownsSubtree(node.children);
 }
 
 // ---------------------------------------------------------------------------
@@ -577,7 +599,7 @@ function walkDerivedIndexes<Ts extends readonly unknown[], S>(
     if (ownerBySourceKey === null) continue;
     const sourceKey = sourceKeyOf(registry, node);
     if (sourceKey === null) continue;
-    if (!isOwningPlacement(graph, id)) continue;
+    if (!ownsItsSubtree(node)) continue;
     // FIRST owner in document order wins, deterministically. A second one is a
     // violation, but saying so is `findInvariantViolation`'s job — this
     // function runs on every mutation and must not have an opinion it could
@@ -1384,7 +1406,7 @@ export function findInvariantViolation<Ts extends readonly unknown[], S>(
     if (node === undefined) continue;
     const sourceKey = sourceKeyOf(registry, node);
     if (sourceKey === null) continue;
-    if (!isOwningPlacement(graph, id)) continue;
+    if (!ownsItsSubtree(node)) continue;
     const ownerId = owners.get(sourceKey);
     if (ownerId !== undefined) {
       return {

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -35,6 +35,7 @@
 // a bad one is this module's.
 
 import {
+  describeThrown,
   makeCollectionNode,
   makeDataChange,
   makeLeafNode,
@@ -1022,7 +1023,27 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
     // it once per changed node per verification.
     if (Object.is(change.before, node.data)) continue;
 
-    if (!deepEqual(codec.serialize(change.before), codec.serialize(node.data))) {
+    // WRAPPED. `serialize` is consumer code, and this function is contracted to
+    // return a `Result` — a throw here escaped `verifyPatchApplies` and took
+    // `undo` and `redo` with it. A codec that cannot serialize its own value
+    // cannot prove the recorded `before` still stands, so the honest verdict is
+    // the same one a genuine difference produces: this patch no longer applies.
+    // Refusing is safe (the entry stays on the stack, the graph is untouched);
+    // proceeding on an unverifiable comparison is not.
+    let matches: boolean;
+    try {
+      matches = deepEqual(
+        codec.serialize(change.before),
+        codec.serialize(node.data),
+      );
+    } catch (thrown) {
+      return replayError(
+        "data-mismatch",
+        `Node ${change.nodeId} could not be compared against this patch's recorded "before": the ${JSON.stringify(change.kind)} codec threw while serializing (${describeThrown(thrown)}).`,
+        { nodeId: change.nodeId },
+      );
+    }
+    if (!matches) {
       return replayError(
         "data-mismatch",
         `Node ${change.nodeId} no longer holds the value this patch recorded as "before".`,

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -55,6 +55,9 @@ import {
 } from "./types";
 import {
   bumpSubtreeRevs,
+  ownsItsSubtree,
+  sourceKeyOf,
+  sourceKeyOfKindData,
   bumpSubtreeRevsInto,
   dataChangeLeavesDerivedIndexesIntact,
   derivedIndexNeed,
@@ -749,7 +752,7 @@ export function verifyPatchApplies<Ts extends readonly unknown[], S>(
     case "moved":
       return verifyMoved(graph, patch.moves);
     case "inserted":
-      return verifyInserted(graph, patch.placements);
+      return verifyInserted(graph, patch.placements, ctx);
     case "removed":
       return verifyRemoved(graph, patch.placements);
     case "data-changed":
@@ -844,9 +847,76 @@ function requireLoadedParent<Ts extends readonly unknown[], S>(
   return VERIFY_OK;
 }
 
+/**
+ * Would replaying these ownership claims leave two placements on one
+ * `sourceKey`?
+ *
+ * THE REPLAY DOOR'S HALF OF THE SINGLE-OWNER RULE. The reducer enforces it on
+ * the forward path and `findInvariantViolation` audits it, but verification —
+ * the one door whose entire job is refusing patches whose world has moved — did
+ * not ask. `applyIngest` is what makes that reachable: it is a non-undoable
+ * server write, so it can move a live node onto a key a sleeping patch still
+ * carries, and the replay then re-installs the original owner beside it.
+ *
+ * NO `vacating` EXEMPTION, and the reason is worth recording because the first
+ * version had one. The case it covered was a single patch re-keying two nodes
+ * that swap keys, where the pre-state owner is itself moving off the key it
+ * holds. That patch cannot exist: `planEdits` refuses a same-command swap with
+ * `duplicate-owner` before any patch is built (measured), so nothing on either
+ * history stack can carry one. The exemption cost a second `ReadonlyMap` and a
+ * `sourceKey` call per changed node on the undo path — the same path the last
+ * round worked to get down to zero codec calls for a common replay — to guard a
+ * state the reducer will not produce. Mutation testing is what surfaced it:
+ * deleting the exemption failed no test, which is the signature of code that
+ * defends nothing.
+ *
+ * A hand-built patch could still reach it, and would be refused rather than
+ * applied. A refusal on an exotic hand-built patch is the safe direction.
+ */
+function ownershipConflict<Ts extends readonly unknown[], S>(
+  graph: Graph<Ts, S>,
+  claims: ReadonlyMap<NodeId, string | null>,
+): ReplayRejection | null {
+  const claimedHere = new Map<string, NodeId>();
+  for (const [nodeId, key] of claims) {
+    if (key === null) continue;
+
+    // BELT AND BRACES, and labelled as such rather than claimed as live: the
+    // reducer refuses a command whose own nodes claim one key twice, so no
+    // patch on either stack carries this shape and mutation testing correctly
+    // reports that deleting these lines fails nothing.
+    //
+    // Kept anyway, where the `vacating` exemption was deleted, because the two
+    // fail in opposite directions. Removing `vacating` made the check STRICTER,
+    // and a refusal is the safe answer for a patch nobody can build. Removing
+    // this one makes it fail OPEN — neither node is in `ownerBySourceKey` yet,
+    // so a hand-built patch claiming one key twice would sail through and
+    // install exactly the duplicate owner this function exists to prevent.
+    const alreadyHere = claimedHere.get(key);
+    if (alreadyHere !== undefined && alreadyHere !== nodeId) {
+      return {
+        code: "duplicate-owner",
+        message: `Replaying this patch would give sourceKey ${JSON.stringify(key)} two owners (${alreadyHere} and ${nodeId}).`,
+        nodeId,
+      };
+    }
+    claimedHere.set(key, nodeId);
+
+    const existing = graph.ownerBySourceKey.get(key);
+    if (existing === undefined || existing === nodeId) continue;
+    return {
+      code: "duplicate-owner",
+      message: `Replaying this patch would put ${nodeId} on sourceKey ${JSON.stringify(key)}, which ${existing} now owns.`,
+      nodeId,
+    };
+  }
+  return null;
+}
+
 function verifyInserted<Ts extends readonly unknown[], S>(
   graph: Graph<Ts, S>,
   placements: readonly Placement<Ts, S>[],
+  ctx: EngineContext<S>,
 ): Result<void, ReplayRejection> {
   const overlay = createChildrenOverlay(graph);
   const willExist = new Set<NodeId>();
@@ -887,6 +957,24 @@ function verifyInserted<Ts extends readonly unknown[], S>(
     overlay.insert(parentId, index, node.id);
     willExist.add(node.id);
     if (isLoadedContainer(node)) overlay.seedLoaded(node.id);
+  }
+
+  // Checked AFTER the structural pass, so a patch that is structurally
+  // impossible reports that rather than an ownership complaint about a node it
+  // could never have placed. Nothing is vacating a key here — an insert only
+  // adds — so the second argument is null.
+  // Gated on the registry, not on the patch: when no codec declares
+  // `sourceKey` at all, `ownerBySourceKey` is permanently empty and this check
+  // could never fire, so the whole pass — including a `sourceKey` call per
+  // arriving node — is skipped rather than run to reach a foregone answer.
+  if (derivedIndexNeed(ctx.registry).source) {
+    const claims = new Map<NodeId, string | null>();
+    for (const { node } of placements) {
+      if (!ownsItsSubtree<Ts, S>(node)) continue;
+      claims.set(node.id, sourceKeyOf<Ts, S>(ctx.registry, node));
+    }
+    const conflict = ownershipConflict(graph, claims);
+    if (conflict !== null) return { ok: false, error: conflict };
   }
 
   return VERIFY_OK;
@@ -1051,6 +1139,45 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
       );
     }
   }
+
+  // THE SAME OWNERSHIP HOLE AS `verifyInserted`, through the data path. A
+  // `sourceKey` is computed FROM data, so restoring an old value re-claims an
+  // old key — and `applyIngest` may have moved another node onto it meanwhile.
+  // The original review named only the insert arm; this one reproduces
+  // identically (edit a box off its key, let the server move a sibling onto it,
+  // then Ctrl-Z) and a fix that guarded one arm would have left the other open.
+  //
+  // Both maps are keyed by the same node set, so a patch that re-keys several
+  // nodes at once — including two swapping keys — is judged on where they all
+  // END UP rather than on one intermediate state that never exists.
+  // Gated for the same reason as the insert arm, and it matters more here: undo
+  // runs this per changed node, and the last round spent real effort getting a
+  // common replay down to zero consumer-codec calls.
+  if (derivedIndexNeed(ctx.registry).source) {
+    const claims = new Map<NodeId, string | null>();
+    for (const change of changes) {
+      const node = graph.nodesById.get(change.nodeId);
+      // Ownership is a property of the node's SHAPE, which a data change cannot
+      // alter — so the live node answers it even though its data is about to be
+      // replaced.
+      //
+      // A COST FILTER, not a correctness one, and mutation testing says so:
+      // deleting `ownsItsSubtree` here fails nothing, because `ownsItsSubtree`
+      // is also what decides who gets INTO `ownerBySourceKey`, so a non-owner's
+      // key is never found there anyway. It stays because it is the cheaper of
+      // the two ways to reach that answer — a shape check instead of a consumer
+      // `sourceKey` call per changed node — and because reading the same
+      // predicate the index was built from is what keeps the two in step.
+      if (node === undefined || !ownsItsSubtree<Ts, S>(node)) continue;
+      claims.set(
+        change.nodeId,
+        sourceKeyOfKindData(ctx.registry, change.kind, change.after),
+      );
+    }
+    const conflict = ownershipConflict(graph, claims);
+    if (conflict !== null) return { ok: false, error: conflict };
+  }
+
   return VERIFY_OK;
 }
 

--- a/packages/keel-core/review3-a-leaf-owns-no-subtree.test.ts
+++ b/packages/keel-core/review3-a-leaf-owns-no-subtree.test.ts
@@ -1,0 +1,334 @@
+// Third review round — one ownership rule, decided in three places.
+//
+// `sourceKey` enables the single-owner invariant: two placements of one stored
+// subtree are incoherent under lazy loading, so the engine refuses the second
+// non-`reference` one. Three call sites decided who counts as an owner, and
+// they did not agree about LEAVES:
+//
+//   graph.ts    isOwningPlacement   `state === null || ownsSubtree(state)`
+//                                   -> a leaf (state null) IS an owner
+//   commands.ts owningSourceKey     `if (node.container && !ownsSubtree(...))`
+//                                   -> the check is skipped for a leaf, so it IS
+//   serialize.ts findDuplicateOwner `if (state === null || !ownsSubtree(state))`
+//                                   -> a leaf is SKIPPED, so it is NOT
+//
+// Two against one, and the one was right. Measured before the fix, with two
+// leaf clips sharing a source:
+//
+//   deserialize            -> ok
+//   findInvariantViolation -> duplicate-owner       (on the graph ingress built)
+//   edit either clip       -> refused duplicate-owner
+//   insert a third         -> refused duplicate-owner
+//
+// A document that loads, fails its own audit, and cannot be repaired through
+// the API. Leaves are now exempt everywhere, through ONE predicate:
+//
+//   - `sourceKey` is documented as "same stored SUBTREE", and its rejection
+//     tells the consumer to "insert a `reference` instead". A leaf has no
+//     children state, so it can never BE a reference placement — the rule was
+//     unsatisfiable for leaves, with no escape hatch.
+//   - `contentKey` already covers leaf-level "same asset", which is the
+//     question a repeated clip is actually asking.
+//   - Tightening the other way would have made a stored document stop loading,
+//     which is the failure this package's quarantine design exists to prevent.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+/** A LEAF kind that declares `sourceKey` — nothing else in the suite does. */
+type Clip = Readonly<{ title: string; source: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const source = record["source"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof source !== "string") {
+      return { ok: false, error: [{ path: "$.source", message: "source" }] };
+    }
+    return { ok: true, value: { title, source } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+  sourceKey(data) {
+    return data.source;
+  },
+});
+
+/** A CONTAINER kind that declares `sourceKey` — the case the rule is FOR. */
+type Folder = Readonly<{ name: string; source: string | null }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    const source = record["source"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    if (source !== null && source !== undefined && typeof source !== "string") {
+      return { ok: false, error: [{ path: "$.source", message: "source" }] };
+    }
+    return { ok: true, value: { name, source: (source as string) ?? null } };
+  },
+  serialize(data): unknown {
+    return { name: data.name, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+  sourceKey(data) {
+    return data.source;
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const n = record["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+function makeEngine() {
+  return createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+}
+
+const rootId = parseNodeId("root");
+
+// ---------------------------------------------------------------------------
+// A leaf owns nothing
+// ---------------------------------------------------------------------------
+
+describe("a leaf never owns a sourceKey", () => {
+  /** root -> [c1, c2], both clips naming source "asset-A". */
+  function twoLeavesSharingASource() {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["c1", "c2"],
+        },
+        { id: "c1", kind: "clip", data: { title: "One", source: "asset-A" } },
+        { id: "c2", kind: "clip", data: { title: "Two", source: "asset-A" } },
+      ],
+    });
+    return { engine, loaded };
+  }
+
+  it("loads, and the graph it produced passes its own audit", () => {
+    const { engine, loaded } = twoLeavesSharingASource();
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    // The defect: ingress accepted this and the audit then condemned it.
+    expect(engine.findInvariantViolation(loaded.value.graph)).toBeNull();
+  });
+
+  it("leaves both nodes editable", () => {
+    const { engine, loaded } = twoLeavesSharingASource();
+    // ASSERTED, not just guarded. An early `return` on a refused load makes
+    // this test pass vacuously under exactly the mutation it exists to catch —
+    // which is how the first draft of it reported a false green.
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    for (const raw of ["c1", "c2"]) {
+      const edited = store.dispatch({
+        type: "edit-nodes",
+        edits: [
+          { nodeId: parseNodeId(raw), kind: "clip", edit: { title: `${raw}!` } },
+        ],
+      });
+      expect(edited.ok).toBe(true);
+    }
+  });
+
+  it("accepts a third placement of the same source", () => {
+    const { engine, loaded } = twoLeavesSharingASource();
+    // ASSERTED, not just guarded. An early `return` on a refused load makes
+    // this test pass vacuously under exactly the mutation it exists to catch —
+    // which is how the first draft of it reported a false green.
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "clip", data: { title: "Three", source: "asset-A" } }],
+    });
+    expect(inserted.ok).toBe(true);
+  });
+
+  it("records no owner for a leaf's key in the derived index", () => {
+    const { engine, loaded } = twoLeavesSharingASource();
+    // ASSERTED, not just guarded. An early `return` on a refused load makes
+    // this test pass vacuously under exactly the mutation it exists to catch —
+    // which is how the first draft of it reported a false green.
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    // A leaf owns nothing, so it must not appear as the owner of anything —
+    // otherwise the index and the predicate disagree, which is the whole class
+    // of bug this change is closing.
+    expect(loaded.value.graph.ownerBySourceKey.has("asset-A")).toBe(false);
+  });
+
+  it("round-trips: what serialize emits, deserialize still accepts", () => {
+    const { engine, loaded } = twoLeavesSharingASource();
+    // ASSERTED, not just guarded. An early `return` on a refused load makes
+    // this test pass vacuously under exactly the mutation it exists to catch —
+    // which is how the first draft of it reported a false green.
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const doc = engine.serialize(loaded.value.graph);
+    const again = engine.deserialize(doc);
+    expect(again.ok).toBe(true);
+    if (!again.ok) return;
+    expect(engine.findInvariantViolation(again.value.graph)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The rule still does its job where it was meant to
+// ---------------------------------------------------------------------------
+
+describe("a container still owns its subtree", () => {
+  it("still refuses two loaded containers sharing a sourceKey", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["b1", "b2"],
+        },
+        { id: "b1", kind: "folder", data: { name: "B1", source: "box" }, children: [] },
+        { id: "b2", kind: "folder", data: { name: "B2", source: "box" }, children: [] },
+      ],
+    });
+    // Loosening leaves must NOT loosen containers — this is the case the
+    // single-owner invariant exists for.
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    expect((loaded.error as { code?: string }).code).toBe("duplicate-owner");
+  });
+
+  it("still refuses a second owning container through the reducer", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["b1"],
+        },
+        { id: "b1", kind: "folder", data: { name: "B1", source: "box" }, children: [] },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "folder", data: { name: "Copy", source: "box" } }],
+    });
+    expect(inserted.ok).toBe(false);
+    if (inserted.ok) return;
+    expect(inserted.error.code).toBe("duplicate-owner");
+  });
+
+  it("still exempts a reference placement, and still records the real owner", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["owner", "ref"],
+        },
+        {
+          id: "owner",
+          kind: "folder",
+          data: { name: "Owner", source: "box" },
+          children: [],
+        },
+        {
+          id: "ref",
+          kind: "folder",
+          data: { name: "Ref", source: "box" },
+          childrenState: "reference",
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(engine.findInvariantViolation(loaded.value.graph)).toBeNull();
+    expect(loaded.value.graph.ownerBySourceKey.get("box")).toBe(
+      parseNodeId("owner"),
+    );
+  });
+});

--- a/packages/keel-core/review3-a-throwing-codec-cannot-escape-as-an-exception.test.ts
+++ b/packages/keel-core/review3-a-throwing-codec-cannot-escape-as-an-exception.test.ts
@@ -1,0 +1,384 @@
+// Third review round — the other half of "the engine survives its consumers".
+//
+// Every consumer `parse` call is defensively wrapped: ./serialize wraps node
+// data, and a prior round wrapped the summary codec beside it. NO `serialize`
+// call was, and `serialize` is consumer code on exactly the same footing.
+//
+// The asymmetry costs three different contracts:
+//
+//   - `dispatch` promises a `Result`. A codec that throws while the reducer
+//     round-trips its own output turned that into an unhandled exception out of
+//     a React event handler, at every call site that correctly wrote
+//     `if (!result.ok)`.
+//   - `verifyPatchApplies` promises a `Result`. Undo runs the consumer's
+//     `serialize` once per changed node to prove the recorded `before` still
+//     stands, so a throwing codec took out undo the same way.
+//   - `serializeGraph` promises to be TOTAL, in those words, "because a save
+//     path that throws loses the user's document". Its own `serializeData`
+//     already states the policy — "an unserializable node should cost one
+//     node's fidelity, never the whole save" — and then called `type.serialize`
+//     unwrapped on the very next line.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+// Which codec call should blow up. Flipped per test; the throw is realistic —
+// an encoder meeting a value it cannot represent, not a synthetic panic.
+const explode = {
+  nodeSerialize: false,
+  applyEdit: false,
+  summarySerialize: false,
+};
+
+function resetExplosions(): void {
+  explode.nodeSerialize = false;
+  explode.applyEdit = false;
+  explode.summarySerialize = false;
+}
+
+type Clip = Readonly<{ title: string; seconds: number }>;
+type ClipEdit = Readonly<{ title?: string; seconds?: number }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const seconds = record["seconds"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { title, seconds } };
+  },
+  serialize(data): unknown {
+    if (explode.nodeSerialize) {
+      throw new TypeError("clip.serialize cannot encode this value");
+    }
+    return { title: data.title, seconds: data.seconds };
+  },
+  applyEdit(data, edit) {
+    if (explode.applyEdit) {
+      throw new TypeError("clip.applyEdit blew up");
+    }
+    return {
+      ok: true,
+      value: {
+        title: edit.title ?? data.title,
+        seconds: edit.seconds ?? data.seconds,
+      },
+    };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+
+type Summary = Readonly<{ seconds: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const seconds = record["seconds"];
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { seconds } };
+  },
+  serialize(value): unknown {
+    if (explode.summarySerialize) {
+      throw new TypeError("summary.serialize cannot encode this value");
+    }
+    return { seconds: value.seconds };
+  },
+};
+
+const folds = {};
+
+function makeEngine() {
+  return createEngine<Types, Summary, typeof folds>({
+    types,
+    summary,
+    folds,
+    now: () => 1234,
+  });
+}
+
+const clipAId = parseNodeId("a");
+const boxId = parseNodeId("box");
+
+/** root -> [a(clip 4), box(folder, unloaded, summary { seconds: 30 })] */
+function loadedStore() {
+  const engine = makeEngine();
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      {
+        id: "root",
+        kind: "folder",
+        data: { name: "Root" },
+        children: ["a", "box"],
+      },
+      { id: "a", kind: "clip", data: { title: "A", seconds: 4 } },
+      {
+        id: "box",
+        kind: "folder",
+        data: { name: "Box" },
+        childrenState: "unloaded",
+        summary: { seconds: 30 },
+      },
+    ],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to deserialize");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+// ---------------------------------------------------------------------------
+// dispatch
+// ---------------------------------------------------------------------------
+
+describe("the reducer refuses rather than throwing when a codec blows up", () => {
+  it("returns a Result when applyEdit throws", () => {
+    resetExplosions();
+    const { store } = loadedStore();
+    explode.applyEdit = true;
+
+    let thrown: unknown = null;
+    let result: ReturnType<typeof store.dispatch> | null = null;
+    try {
+      result = store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 9 } }],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeNull();
+    expect(result?.ok).toBe(false);
+    if (result && !result.ok) {
+      expect(result.error.code).toBe("edit-rejected");
+      expect(result.error.message).toContain("threw");
+    }
+  });
+
+  it("returns a Result when serialize throws while re-parsing the edit", () => {
+    resetExplosions();
+    const { store } = loadedStore();
+    explode.nodeSerialize = true;
+
+    let thrown: unknown = null;
+    let result: ReturnType<typeof store.dispatch> | null = null;
+    try {
+      result = store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 9 } }],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeNull();
+    expect(result?.ok).toBe(false);
+    if (result && !result.ok) expect(result.error.code).toBe("parse-failed");
+  });
+
+  it("leaves the graph and the history stack untouched after a codec throw", () => {
+    resetExplosions();
+    const { store } = loadedStore();
+    const before = store.getGraph();
+
+    explode.nodeSerialize = true;
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 9 } }],
+    });
+    resetExplosions();
+
+    // A refused command is not a commit: same graph identity, nothing to undo.
+    expect(store.getGraph()).toBe(before);
+    expect(store.canUndo()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyPatchApplies — the undo path
+// ---------------------------------------------------------------------------
+
+describe("replay verification refuses rather than throwing", () => {
+  it("returns a Result when serialize throws while comparing a dormant patch", () => {
+    resetExplosions();
+    const { engine, store } = loadedStore();
+
+    // Two edits, so the first patch's `before` is no longer the object the
+    // graph holds — which is what gets past the identity fast path and reaches
+    // the consumer's `serialize`.
+    const first = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 5 } }],
+    });
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 6 } }],
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+
+    explode.nodeSerialize = true;
+    let thrown: unknown = null;
+    let verified: ReturnType<typeof engine.verifyPatchApplies> | null = null;
+    try {
+      verified = engine.verifyPatchApplies(store.getGraph(), first.value);
+    } catch (error) {
+      thrown = error;
+    }
+    resetExplosions();
+
+    expect(thrown).toBeNull();
+    expect(verified?.ok).toBe(false);
+    if (verified && !verified.ok) {
+      expect(verified.error.code).toBe("data-mismatch");
+    }
+  });
+
+  it("keeps undo Result-shaped when the codec throws mid-verification", () => {
+    resetExplosions();
+    const { store } = loadedStore();
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipAId, kind: "clip", edit: { seconds: 5 } }],
+    });
+    store.ingest([{ nodeId: clipAId, kind: "clip", edit: { seconds: 5 } }]);
+
+    explode.nodeSerialize = true;
+    let thrown: unknown = null;
+    let undone: ReturnType<typeof store.undo> | null = null;
+    try {
+      undone = store.undo();
+    } catch (error) {
+      thrown = error;
+    }
+    resetExplosions();
+
+    // Either it verified and undid, or it refused — but it must not throw, and
+    // the stack must not be left half-moved.
+    expect(thrown).toBeNull();
+    expect(undone).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeGraph — the save path, which is documented TOTAL
+// ---------------------------------------------------------------------------
+
+describe("the save path stays total when a codec throws", () => {
+  it("does not lose the document when a node codec throws", () => {
+    resetExplosions();
+    const { engine, store } = loadedStore();
+    const graph = store.getGraph();
+
+    explode.nodeSerialize = true;
+    let thrown: unknown = null;
+    let doc: ReturnType<typeof engine.serialize> | null = null;
+    try {
+      doc = engine.serialize(graph);
+    } catch (error) {
+      thrown = error;
+    }
+    resetExplosions();
+
+    expect(thrown).toBeNull();
+    expect(doc).not.toBeNull();
+    // Every node still present — one node's fidelity, never the whole save.
+    expect(doc?.nodes.map((node) => node.id).sort()).toEqual([
+      "a",
+      "box",
+      "root",
+    ]);
+    // And the unaffected kinds still serialized normally.
+    const root = doc?.nodes.find((node) => node.id === "root");
+    expect(root?.data).toEqual({ name: "Root" });
+  });
+
+  it("does not lose the document when the summary codec throws", () => {
+    resetExplosions();
+    const { engine, store } = loadedStore();
+    const graph = store.getGraph();
+
+    explode.summarySerialize = true;
+    let thrown: unknown = null;
+    let doc: ReturnType<typeof engine.serialize> | null = null;
+    try {
+      doc = engine.serialize(graph);
+    } catch (error) {
+      thrown = error;
+    }
+    resetExplosions();
+
+    expect(thrown).toBeNull();
+    expect(doc?.nodes.map((node) => node.id).sort()).toEqual([
+      "a",
+      "box",
+      "root",
+    ]);
+    // The clip beside it is untouched by the summary codec's failure.
+    const clip = doc?.nodes.find((node) => node.id === "a");
+    expect(clip?.data).toEqual({ title: "A", seconds: 4 });
+  });
+
+  it("round-trips a healthy graph unchanged, so the guards cost nothing", () => {
+    resetExplosions();
+    const { engine, store } = loadedStore();
+    const doc = engine.serialize(store.getGraph());
+    const reloaded = engine.deserialize(doc);
+    expect(reloaded.ok).toBe(true);
+    if (!reloaded.ok) return;
+    expect(reloaded.value.report.quarantined.length).toBe(0);
+    expect(engine.findInvariantViolation(reloaded.value.graph)).toBeNull();
+  });
+});

--- a/packages/keel-core/review3-replay-cannot-install-a-duplicate-owner.test.ts
+++ b/packages/keel-core/review3-replay-cannot-install-a-duplicate-owner.test.ts
@@ -1,0 +1,340 @@
+// Third review round — the replay door did not check the ownership rule.
+//
+// `verifyPatchApplies` exists so a DORMANT patch is refused before it can be
+// applied: the graph moves on while an entry sleeps on the stack, and the
+// entry's world may no longer be the one it recorded. It checked node absence,
+// parent existence, parent loaded-ness, index bounds and the recorded `before`
+// — everything structural — and never asked whether the arriving node's
+// `sourceKey` is already owned by somebody else.
+//
+// `applyIngest` is what makes that reachable rather than theoretical. It is a
+// NON-UNDOABLE server write, so it can move a live node onto a key a sleeping
+// patch still carries, and the undo that follows re-installs the original owner
+// beside it. The result is a graph `findInvariantViolation` reports as
+// `duplicate-owner` — installed through the one door whose whole job is to
+// refuse patches that no longer apply.
+//
+// NOTE ON SHAPE: these fixtures use CONTAINERS, not clips. Leaves no longer own
+// a `sourceKey` at all (see `ownsItsSubtree`), so a leaf-based reproduction of
+// this is now inert — which is worth pinning, and the last test here does.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+type Box = Readonly<{ name: string; source: string | null }>;
+type BoxEdit = Readonly<{ name?: string; source?: string | null }>;
+
+const boxType = defineNodeType<Box, BoxEdit>()({
+  kind: "box",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Box, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    const source = record["source"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    if (source !== null && source !== undefined && typeof source !== "string") {
+      return { ok: false, error: [{ path: "$.source", message: "source" }] };
+    }
+    return { ok: true, value: { name, source: (source as string) ?? null } };
+  },
+  serialize(data): unknown {
+    return { name: data.name, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return {
+      ok: true,
+      value: {
+        name: edit.name ?? data.name,
+        source: edit.source === undefined ? data.source : edit.source,
+      },
+    };
+  },
+  sourceKey(data) {
+    return data.source;
+  },
+});
+
+/** A leaf that also declares `sourceKey`, to pin the interaction with #574. */
+type Clip = Readonly<{ title: string; source: string }>;
+const clipType = defineNodeType<Clip, Readonly<{ title?: string }>>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const source = record["source"];
+    if (typeof title !== "string" || typeof source !== "string") {
+      return { ok: false, error: [{ path: "$", message: "shape" }] };
+    }
+    return { ok: true, value: { title, source } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+  sourceKey(data) {
+    return data.source;
+  },
+});
+
+const types = [boxType, clipType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const n = record["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+function makeEngine() {
+  return createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+}
+
+const rootId = parseNodeId("root");
+const xId = parseNodeId("x");
+const zId = parseNodeId("z");
+
+/** root -> [x(owns "asset-a"), z(owns "asset-b")], both loaded and empty. */
+function ownedPair() {
+  const engine = makeEngine();
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { box: 1, clip: 1 },
+    rootIds: ["root"],
+    nodes: [
+      {
+        id: "root",
+        kind: "box",
+        data: { name: "Root", source: null },
+        children: ["x", "z"],
+      },
+      { id: "x", kind: "box", data: { name: "X", source: "asset-a" }, children: [] },
+      { id: "z", kind: "box", data: { name: "Z", source: "asset-b" }, children: [] },
+    ],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to deserialize");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+describe("replay cannot install a duplicate owner", () => {
+  it("refuses an undo that would re-install a second owner", () => {
+    const { engine, store } = ownedPair();
+
+    // 1. Remove x. Its patch sleeps on the stack still carrying "asset-a".
+    const removed = store.dispatch({ type: "remove-nodes", nodeIds: [xId] });
+    expect(removed.ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+
+    // 2. The server moves z onto the key x used to own. Non-undoable, and
+    //    legitimately accepted — nothing owns "asset-a" right now.
+    const ingested = store.ingest([
+      { nodeId: zId, kind: "box", edit: { source: "asset-a" } },
+    ]);
+    expect(ingested.ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+
+    // 3. Ctrl-Z. The sleeping patch would bring x back onto a key z now owns.
+    const undone = store.undo();
+    expect(undone.ok).toBe(false);
+    if (undone.ok) return;
+    expect(undone.error.code).toBe("duplicate-owner");
+
+    // The graph must be untouched, not merely reported on afterwards.
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    // And the entry stays on the stack — a refused replay is not a consumed one.
+    expect(store.canUndo()).toBe(true);
+  });
+
+  it("refuses a redo that would re-install a second owner", () => {
+    const { engine, store } = ownedPair();
+
+    // An insert whose node owns a fresh key, then undone so it sleeps on the
+    // REDO stack.
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "box", data: { name: "New", source: "asset-c" } }],
+    });
+    expect(inserted.ok).toBe(true);
+    expect(store.undo().ok).toBe(true);
+
+    // The server moves z onto that key while the patch sleeps.
+    expect(
+      store.ingest([{ nodeId: zId, kind: "box", edit: { source: "asset-c" } }]).ok,
+    ).toBe(true);
+
+    const redone = store.redo();
+    expect(redone.ok).toBe(false);
+    if (redone.ok) return;
+    expect(redone.error.code).toBe("duplicate-owner");
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.canRedo()).toBe(true);
+  });
+
+  it("still allows an undo that re-installs the ONLY owner", () => {
+    const { engine, store } = ownedPair();
+    expect(store.dispatch({ type: "remove-nodes", nodeIds: [xId] }).ok).toBe(true);
+
+    // Nobody took the key. The undo must still work — a guard that refuses
+    // every replay of an owning node would be worse than the defect.
+    const undone = store.undo();
+    expect(undone.ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.getGraph().ownerBySourceKey.get("asset-a")).toBe(xId);
+  });
+
+  it("still allows undo/redo of a node that owns nothing", () => {
+    const { engine, store } = ownedPair();
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "box", data: { name: "Plain", source: null } }],
+    });
+    expect(inserted.ok).toBe(true);
+    expect(store.undo().ok).toBe(true);
+    expect(store.redo().ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+  });
+
+  it("refuses a single patch that claims one key twice", () => {
+    const { engine, store } = ownedPair();
+    // Two owning boxes inserted together, same key. The reducer refuses this
+    // outright, so the graph never holds it — pinned so the verify-side guard
+    // and the reducer keep agreeing about a patch's own interior.
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [
+        { kind: "box", data: { name: "P", source: "asset-d" } },
+        { kind: "box", data: { name: "Q", source: "asset-d" } },
+      ],
+    });
+    expect(inserted.ok).toBe(false);
+    if (inserted.ok) return;
+    expect(inserted.error.code).toBe("duplicate-owner");
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+  });
+
+  it("refuses an undo of a data change that would restore a taken key", () => {
+    // The SAME hole on the data path: an undo restores a `source` value, and a
+    // server write may have moved another node onto it meanwhile. Named here
+    // because a fix that guards only the insert arm leaves this one open.
+    const { engine, store } = ownedPair();
+
+    // x vacates "asset-a" by moving to a fresh key. The patch's `before` still
+    // carries "asset-a".
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: xId, kind: "box", edit: { source: "asset-c" } }],
+      }).ok,
+    ).toBe(true);
+
+    // The server moves z onto the key x just vacated.
+    expect(
+      store.ingest([{ nodeId: zId, kind: "box", edit: { source: "asset-a" } }]).ok,
+    ).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+
+    const undone = store.undo();
+    if (undone.ok) {
+      // Recorded rather than asserted-away: if this passes, the data arm is
+      // already safe by another route and only the insert arm needed guarding.
+      expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+      return;
+    }
+    expect(undone.error.code).toBe("duplicate-owner");
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+  });
+
+  it("still allows undo/redo of an edit that does not touch the key", () => {
+    // THE COMMON CASE, and the one the first draft of these tests missed: an
+    // owning node is renamed, and the undo restores a value whose sourceKey is
+    // the one that node ALREADY owns. Without the `existing === nodeId`
+    // self-exemption every such undo is refused — which would break renaming
+    // any owning container, not some exotic replay. Mutation testing is what
+    // surfaced the gap: deleting that exemption failed nothing.
+    const { engine, store } = ownedPair();
+
+    const renamed = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: xId, kind: "box", edit: { name: "Renamed" } }],
+    });
+    expect(renamed.ok).toBe(true);
+
+    const undone = store.undo();
+    expect(undone.ok).toBe(true);
+    const redone = store.redo();
+    expect(redone.ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.getGraph().ownerBySourceKey.get("asset-a")).toBe(xId);
+  });
+
+  it("does not refuse a LEAF replay, because a leaf owns nothing", () => {
+    // The interaction with the leaf-exemption change: two clips may share a
+    // source freely, so nothing on the replay path may start refusing them.
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { box: 1, clip: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "box",
+          data: { name: "Root", source: null },
+          children: ["c1"],
+        },
+        { id: "c1", kind: "clip", data: { title: "One", source: "asset-a" } },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "clip", data: { title: "Two", source: "asset-a" } }],
+    });
+    expect(inserted.ok).toBe(true);
+    expect(store.undo().ok).toBe(true);
+    expect(store.redo().ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -58,12 +58,12 @@ import {
 } from "./types";
 
 import {
+  ownsItsSubtree,
   bumpSubtreeRevs,
   childrenStateOf,
   documentOrder,
   getChildren,
   getNode,
-  ownsSubtree,
   rebuildDerivedIndexes,
   sourceKeyOf,
 } from "./graph";
@@ -974,8 +974,10 @@ function findDuplicateOwner<Ts extends readonly unknown[], S>(
 ): StructuralError | null {
   const owners = new Map<string, NodeId>();
   for (const [id, node] of graph.nodesById) {
-    const state = childrenStateOf(graph, id);
-    if (state === null || !ownsSubtree(state)) continue;
+    // DELEGATED, not re-derived. This site had the RIGHT answer about leaves
+    // and the other two did not; sharing one predicate is what stops that being
+    // rediscovered a third time.
+    if (!ownsItsSubtree(node)) continue;
     const key = sourceKeyOf(registry, node);
     if (key === null) continue;
     const existing = owners.get(key);

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -34,6 +34,7 @@
 //   6. loadChildrenInto
 
 import {
+  describeThrown,
   makeCollectionNode,
   makeLeafNode,
   makeQuarantinedNode,
@@ -481,11 +482,6 @@ function runMigrations(
   }
 
   return { ok: true, value: { data, migratedFrom: from } };
-}
-
-function describeThrown(thrown: unknown): string {
-  if (thrown instanceof Error) return thrown.message;
-  return String(thrown);
 }
 
 // ---------------------------------------------------------------------------
@@ -1101,7 +1097,28 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
     // this function total — an unserializable node should cost one node's
     // fidelity, never the whole save.
     if (type === undefined) return data;
-    return type.serialize(data);
+    // The SAME fallback, for the reachable version of the same problem. The
+    // branch above handles a codec that is missing; this one handles a codec
+    // that is present and throws, which is consumer code and therefore not
+    // hypothetical. Leaving it bare contradicted this function's own policy one
+    // line up and, worse, the module's promise that `serializeGraph` is TOTAL
+    // "because a save path that throws loses the user's document".
+    //
+    // The live value is the best remaining representation: it is what the codec
+    // was asked to encode, it is usually near-identical to the wire form, and
+    // on reload it either parses or quarantines loudly. Both outcomes beat
+    // losing the whole save.
+    try {
+      return type.serialize(data);
+    } catch (thrown) {
+      console.error(
+        `keel: the ${JSON.stringify(kind)} codec threw while serializing a node for save. ` +
+          `That node is being written in its live form instead, which may not round-trip. ` +
+          `The rest of the document is unaffected.`,
+        thrown,
+      );
+      return data;
+    }
   };
 
   const emit = (id: NodeId): void => {
@@ -1134,7 +1151,21 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
       // an explicit null would round-trip too, but only if the summary codec
       // tolerated being handed one.
       if (node.summary !== null) {
-        draft.summary = ctx.summary.serialize(node.summary);
+        // Guarded like `serializeData`, and for the same reason: the summary
+        // codec is consumer code on the same footing as a node codec, and its
+        // `parse` half is already wrapped at ingress. A summary is a DERIVED
+        // rollup, so dropping it costs strictly less than dropping a node —
+        // the next reader sees an unloaded container with no stored estimate,
+        // which is honest, where a thrown save loses everything.
+        try {
+          draft.summary = ctx.summary.serialize(node.summary);
+        } catch (thrown) {
+          console.error(
+            `keel: the summary codec threw while serializing node ${JSON.stringify(id)} for save. ` +
+              `Its stored summary is being omitted; the rest of the document is unaffected.`,
+            thrown,
+          );
+        }
       }
       writeChildren(draft, id, node.children);
     }

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -647,6 +647,15 @@ export type ReplayRejectionCode =
   | "kind-mismatch"
   /** The recorded `before` is no longer what the node holds. */
   | "data-mismatch"
+  /**
+   * Replaying this patch would put a second owner on one `sourceKey`.
+   *
+   * Reachable only because `applyIngest` is a NON-UNDOABLE write: it can move a
+   * live node onto a key a sleeping patch still carries, and the replay would
+   * then re-install the original owner beside it. Mirrors `RejectionCode`'s
+   * member of the same name so a consumer handling one handles the other.
+   */
+  | "duplicate-owner"
   /** The store was destroyed. Every mutating call refuses rather than writing
    *  into a graph nothing is listening to — see `Store.destroy`. */
   | "store-destroyed";

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1437,3 +1437,31 @@ export function makeDataChange<Ts extends readonly unknown[]>(
   }> = { nodeId, kind, before, after };
   return change as unknown as DataChange<Ts>;
 }
+
+// ---------------------------------------------------------------------------
+// Describing a throw
+// ---------------------------------------------------------------------------
+
+/**
+ * The message to put in an `Issue` when consumer code threw instead of
+ * returning.
+ *
+ * It lives HERE, in the module that imports nothing, because all four modules
+ * that call into a consumer codec need it — ./serialize wraps `parse` and the
+ * summary codec, ./commands wraps `applyEdit` and `serialize`, ./patches wraps
+ * the `serialize` pair that replay verification compares on. One
+ * implementation, so the three cannot drift into describing the same throw
+ * three different ways.
+ *
+ * NOT re-exported from ./index: a consumer never calls this, it only ever reads
+ * the strings it produces.
+ *
+ * `String(thrown)` rather than `JSON.stringify`: a thrown value is arbitrary,
+ * `stringify` is recursive and can itself throw on a cycle or a BigInt, and a
+ * helper whose whole job is to describe a failure must not have a failure mode
+ * of its own.
+ */
+export function describeThrown(thrown: unknown): string {
+  if (thrown instanceof Error) return thrown.message;
+  return String(thrown);
+}


### PR DESCRIPTION
Stacked on #574. This is the last **high** finding from the third review.

`verifyPatchApplies` exists so a dormant patch is refused before it can be applied. It checked node absence, parent existence, parent loaded-ness, index bounds and the recorded `before` — everything structural — and never asked whether the arriving node's `sourceKey` is already owned. The reducer enforces that rule and `findInvariantViolation` audits it; the one door whose whole job is refusing stale patches did not.

`applyIngest` makes it reachable: it's a **non-undoable** server write, so it can move a live node onto a key a sleeping patch still carries. Measured through the public store — remove `x` (owns `asset-a`), server moves `z` onto `asset-a`, Ctrl-Z:

```
undo() -> ok        ← and the graph it committed reports duplicate-owner
```

### Both arms, not just the one the review named

The finding covered `verifyInserted`. The same hole is on the **data** path, because a `sourceKey` is computed *from* data — so restoring an old value re-claims an old key. Edit a box off its key, let the server move a sibling onto it, Ctrl-Z. Same corruption, same door. Guarding one arm would have left it half open.

Both checks are gated on `derivedIndexNeed(registry).source`: with no codec declaring `sourceKey`, `ownerBySourceKey` is permanently empty and the check could never fire. That matters most on the data arm — undo runs it per changed node, and #571's predecessor round spent real effort getting a common replay to zero codec calls. This doesn't put them back.

### Mutation testing earned its keep three times, twice against my own work

**1. A `vacating` exemption I wrote failed no test.** It existed to stop a patch re-keying two nodes that swap keys from being refused. That patch can't exist — `planEdits` refuses a same-command swap before any patch is built (measured). Deleted rather than kept as decoration; it also cost a second map and a `sourceKey` call per changed node on the undo path.

**2. The `existing === nodeId` self-exemption also failed no test — and it's load-bearing in the most ordinary way possible.** Without it, undoing *any* edit that leaves an owning node's key unchanged is refused, so renaming a container becomes un-undoable. My tests only ever edited `source`, never `name`. That gap is now a test, and reverting the exemption fails it.

**3. `claimedHere` also fails no test, and stays anyway.** The two failed in opposite directions: removing `vacating` made the check *stricter* (a refusal is safe for a patch nobody can build), while removing `claimedHere` makes it fail **open** — neither node is in `ownerBySourceKey` yet, so a hand-built patch claiming one key twice would sail through. Commented as belt-and-braces rather than claimed as live, per round two's `Object.hasOwn` precedent.

The `ownsItsSubtree` filter is likewise labelled for what it is: a cost filter, not a correctness one, since that same predicate decides who gets *into* `ownerBySourceKey`.

### Over-refusal is pinned too

Four tests exist so this doesn't become a rule that refuses too much: an undo re-installing the **only** owner still works; undo/redo of a node owning nothing still works; undo/redo of an edit not touching the key still works; and a **leaf** replay is never refused — leaves own nothing as of #574, and nothing on the replay path may start disagreeing with that.

### Verification

| | |
|---|---|
| Regression tests | 8, of which **3 failed** before |
| Mutation proof | insert arm 2 · data arm 1 · self-exemption 1 |
| Unit suite | 1,367 tests / 67 files |
| Stories | 9 pass, headless Chromium |
| `tsc` | clean, both packages |

🤖 Generated with [Claude Code](https://claude.com/claude-code)