### PR TITLE
Quarantine stops being a one-way door

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -174,6 +174,41 @@ function inDocumentOrder<Ts extends readonly unknown[], S>(
 }
 
 /**
+ * `id -> index` within one parent's children, computed ONCE per parent.
+ *
+ * Both bulk paths — `planMove` and `applyRemoveNodes` — used
+ * `getChildren(graph, parentId).indexOf(id)` once per named node, which is
+ * O(siblings) each and therefore O(K x N) for K nodes out of one strip. That is
+ * the patch-BUILDING half of the same quadratic `spliceOutMany` fixed on the
+ * applying half; fixing one and not the other left select-all-then-Delete at
+ * 62x growth for 10x the siblings when a linear reference moved 15x.
+ *
+ * FIRST occurrence wins, which is what `indexOf` answered. A repeated id in one
+ * children array is an invariant violation the audit reports; this is not the
+ * place to disagree with the old behaviour about it.
+ *
+ * Cached per CALL, never across calls: the map is keyed by parent and read off
+ * a specific graph, and holding it beyond the command would be a stale index
+ * one mutation later.
+ */
+function childSlots<Ts extends readonly unknown[], S>(
+  graph: Graph<Ts, S>,
+  parentId: NodeId,
+  cache: Map<NodeId, ReadonlyMap<NodeId, number>>,
+): ReadonlyMap<NodeId, number> {
+  const hit = cache.get(parentId);
+  if (hit !== undefined) return hit;
+  const slots = new Map<NodeId, number>();
+  const children = getChildren(graph, parentId);
+  for (let index = 0; index < children.length; index += 1) {
+    const id = children[index];
+    if (id !== undefined && !slots.has(id)) slots.set(id, index);
+  }
+  cache.set(parentId, slots);
+  return slots;
+}
+
+/**
  * Drop every id that lives under another id in the same set — a subtree travels
  * with its root, so naming both a folder and a clip inside it must not move (or
  * remove) that clip twice.
@@ -326,6 +361,7 @@ function planMove<Ts extends readonly unknown[], S>(
   const orderedIds = inDocumentOrder(graph, kept);
 
   const originById = new Map<NodeId, Origin>();
+  const slotCache = new Map<NodeId, ReadonlyMap<NodeId, number>>();
   for (const id of orderedIds) {
     const parentId = getParent(graph, id);
     if (parentId === null) {
@@ -335,8 +371,8 @@ function planMove<Ts extends readonly unknown[], S>(
         nodeIds: [id],
       });
     }
-    const index = getChildren(graph, parentId).indexOf(id);
-    if (index < 0) {
+    const index = childSlots(graph, parentId, slotCache).get(id);
+    if (index === undefined) {
       return fail(
         "unknown-node",
         `Node ${JSON.stringify(id)} is not in its parent's children array.`,
@@ -734,6 +770,7 @@ function applyRemoveNodes<Ts extends readonly unknown[], S>(
   const roots = inDocumentOrder(graph, pruneDescendants(graph, unique));
 
   const placements: Placement<Ts, S>[] = [];
+  const slotCache = new Map<NodeId, ReadonlyMap<NodeId, number>>();
   for (const rootId of roots) {
     // `subtreeIds` is pre-order and descends only `loaded` collections, so an
     // unloaded branch contributes exactly its placeholder — which is the whole
@@ -765,8 +802,8 @@ function applyRemoveNodes<Ts extends readonly unknown[], S>(
           nodeIds: [id],
         });
       }
-      const index = getChildren(graph, parentId).indexOf(id);
-      if (index < 0) {
+      const index = childSlots(graph, parentId, slotCache).get(id);
+      if (index === undefined) {
         return fail(
           "unknown-node",
           `Node ${JSON.stringify(id)} is not in its parent's children array.`,

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -316,6 +316,22 @@ export function createEngine<
     const selectionListeners = new Set<() => void>();
 
     let selectedIds: readonly NodeId[] = [];
+    /**
+     * The same selection, as a membership index.
+     *
+     * `has` is the per-card hot path — `useIsSelected` calls it once per mounted
+     * card on every selection change — and it was `selectedIds.includes(id)`,
+     * which is O(selected). One render pass across N cards with M selected was
+     * therefore O(N x M): measured at 0.28ms for 500 cards, 3.7ms for 2,000 and
+     * 63ms for 8,000, which is four dropped frames every time the selection
+     * moves.
+     *
+     * Kept BESIDE the array rather than replacing it, because the array is the
+     * contract: `get()` hands out an ORDERED, identity-stable list that the
+     * React binding memoises on, and a Set has neither property. The two are
+     * only ever written together, in the two places `selectedIds` is assigned.
+     */
+    let selectedSet: ReadonlySet<NodeId> = new Set();
     let anchorId: NodeId | null = null;
     let destroyed = false;
 
@@ -390,6 +406,7 @@ export function createEngine<
         anchorId !== null && getNode(graph, anchorId) === undefined;
       if (kept.length === selectedIds.length && !anchorGone) return false;
       selectedIds = kept;
+      selectedSet = new Set(kept);
       if (anchorGone) anchorId = null;
       return true;
     };
@@ -473,18 +490,21 @@ export function createEngine<
 
       if (resolvedAnchor === anchorId && sameIds(deduped, selectedIds)) return;
       selectedIds = deduped;
+      // `seen` was already built to dedupe, and it holds exactly the ids that
+      // survived into `deduped` — so the membership index costs nothing extra.
+      selectedSet = seen;
       anchorId = resolvedAnchor;
       notifyAll("selection", selectionListeners);
     };
 
     const selection: SelectionSlice = {
       get: () => selectedIds,
-      has: (id) => selectedIds.includes(id),
+      has: (id) => selectedSet.has(id),
       set: (ids) => {
         setSelection(ids, ids.at(-1) ?? null);
       },
       toggle: (id) => {
-        if (!selectedIds.includes(id)) {
+        if (!selectedSet.has(id)) {
           setSelection([...selectedIds, id], id);
           return;
         }

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -284,6 +284,56 @@ function spliceOut(
   children.set(parentId, next);
 }
 
+/**
+ * The same copy-on-write removal, for MANY ids at once — ONE pass per parent
+ * instead of one per removed node.
+ *
+ * `spliceOut` is three O(siblings) passes (`indexOf`, `slice`, `splice`) and
+ * allocates a fresh array each time, so calling it per removed node made
+ * removing K of N siblings cost O(K x N). The constant is a memcpy, which is
+ * why it stayed invisible: free below a thousand siblings, and 5.2 SECONDS
+ * measured for select-all-then-Delete on a 40,000-item strip. Both arms that
+ * remove in bulk — `applyRemoved` and `applyMoved` — now go through here.
+ *
+ * `remaining.delete(id)` rather than `ids.has(id)` is deliberate and preserves
+ * `spliceOut`'s exact semantics: `splice(at, 1)` removes AT MOST ONE occurrence
+ * of an id, and a `has` filter would remove every copy. That can only differ on
+ * a graph already violating "one id in two children arrays", and a bulk removal
+ * is not the place to start quietly repairing a corruption the audit exists to
+ * report.
+ */
+function spliceOutMany(
+  children: Map<NodeId, readonly NodeId[]>,
+  byParent: ReadonlyMap<NodeId, ReadonlySet<NodeId>>,
+): void {
+  for (const [parentId, ids] of byParent) {
+    const current = children.get(parentId);
+    // Absent when the parent is itself being removed in this same patch — its
+    // whole entry is gone, so there is no array left to maintain.
+    if (current === undefined) continue;
+    const remaining = new Set<NodeId>(ids);
+    const next: NodeId[] = [];
+    for (const id of current) {
+      if (remaining.delete(id)) continue;
+      next.push(id);
+    }
+    if (next.length !== current.length) children.set(parentId, next);
+  }
+}
+
+/** Group ids by the parent they are leaving, so each parent is rewritten once. */
+function groupByParent(
+  entries: readonly Readonly<{ parentId: NodeId; nodeId: NodeId }>[],
+): ReadonlyMap<NodeId, ReadonlySet<NodeId>> {
+  const byParent = new Map<NodeId, Set<NodeId>>();
+  for (const { parentId, nodeId } of entries) {
+    const bucket = byParent.get(parentId);
+    if (bucket === undefined) byParent.set(parentId, new Set([nodeId]));
+    else bucket.add(nodeId);
+  }
+  return byParent;
+}
+
 // ---------------------------------------------------------------------------
 // The commit cost rules, stated once because all four arms obey them
 // ---------------------------------------------------------------------------
@@ -394,7 +444,14 @@ function applyMoved<Ts extends readonly unknown[], S>(
 
   // Remove ALL, then insert ALL. `toIndex` is a POST-REMOVAL index, so the two
   // phases cannot be interleaved.
-  for (const move of moves) spliceOut(children, move.fromParentId, move.nodeId);
+  // One pass per SOURCE parent. A multi-select drag out of one strip was the
+  // same O(K x N) as the delete above.
+  spliceOutMany(
+    children,
+    groupByParent(
+      moves.map((move) => ({ parentId: move.fromParentId, nodeId: move.nodeId })),
+    ),
+  );
   for (const move of moves) {
     spliceIn(children, move.toParentId, move.toIndex, move.nodeId);
     // Only write when the link actually changes. In the shared-map case there
@@ -554,7 +611,6 @@ function applyRemoved<Ts extends readonly unknown[], S>(
     if (placement === undefined) continue;
     const id = placement.node.id;
     removedIds.push(id);
-    spliceOut(children, placement.parentId, id);
     nodes.delete(id);
     parents.delete(id);
     children.delete(id);
@@ -601,6 +657,20 @@ function applyRemoved<Ts extends readonly unknown[], S>(
     // relies on.
     revs.set(id, (revs.get(id) ?? 0) + 1);
   }
+
+  // ONE rewrite per affected parent, after the loop rather than inside it. The
+  // loop's backward walk is still what makes children leave before parents;
+  // removal by identity is order-independent, so hoisting the splice out of it
+  // changes nothing except how many times each array is copied.
+  spliceOutMany(
+    children,
+    groupByParent(
+      placements.map((placement) => ({
+        parentId: placement.parentId,
+        nodeId: placement.node.id,
+      })),
+    ),
+  );
 
   // Updated, not rebuilt: a removal cannot REORDER a survivor, so each affected
   // bucket only needs its dead ids filtered out. Read against the PRE-state

--- a/packages/keel-core/performance.test.ts
+++ b/packages/keel-core/performance.test.ts
@@ -932,7 +932,20 @@ function growth(perOp: ReadonlyMap<string, number>): number {
  * the same data got 19x slower" is.
  */
 function expectSubQuadratic(perOp: ReadonlyMap<string, number>, what: string): void {
-  const ratio = growth(perOp);
+  expectSubQuadraticRatio(growth(perOp), what);
+}
+
+/**
+ * The same gate, for a measurement whose two samples are NOT the wide 1k/10k
+ * fixtures.
+ *
+ * `growth` reads those two labels specifically, which is right for everything
+ * that scales with NODE COUNT. A multi-select delete does not: its cost is
+ * driven by how many SIBLINGS one parent holds, and the wide fixture caps that
+ * at `WIDE_FANOUT`. Split out rather than duplicated so both callers share one
+ * calibration and one failure message.
+ */
+function expectSubQuadraticRatio(ratio: number, what: string): void {
   // Sampled HERE, immediately after the operation above, so a slow stretch of
   // wall clock inflates both or neither.
   const reference = measureLinearReferenceGrowth();
@@ -959,6 +972,32 @@ function expectSubQuadratic(perOp: ReadonlyMap<string, number>, what: string): v
     ratio,
     `${what}: 10x the nodes made it ${ratio.toFixed(1)}x slower. ` +
       `A linear reference on the same fixtures, timed immediately afterwards, ` +
+      `moved ${reference.toFixed(1)}x, so the ceiling was ${ceiling.toFixed(1)}x.`,
+  ).toBeLessThan(ceiling);
+}
+
+/**
+ * A STRONGER time claim than sub-quadratic: this cost does not track the size at
+ * all.
+ *
+ * `expectSubQuadraticRatio` is the right gate for work that IS linear and must
+ * not become quadratic. It is the wrong gate for work that should be constant —
+ * a regression from O(1) to O(n) lands around the linear reference (~15x), sails
+ * under a ceiling of 40, and ships. This one sits a third of the way up the
+ * reference instead: far above the noise a genuinely constant operation
+ * produces (~1x), far below what linear would.
+ *
+ * Floored at 4 so a machine whose reference measures unusually low cannot make
+ * the gate tighter than measurement noise.
+ */
+function expectConstantTime(ratio: number, what: string): void {
+  const reference = measureLinearReferenceGrowth();
+  observedReferences.push(reference);
+  const ceiling = Math.max(4, reference / 3);
+  expect(
+    ratio,
+    `${what}: 10x the size made it ${ratio.toFixed(1)}x slower, and it should ` +
+      `not have moved at all. A linear reference, timed immediately afterwards, ` +
       `moved ${reference.toFixed(1)}x, so the ceiling was ${ceiling.toFixed(1)}x.`,
   ).toBeLessThan(ceiling);
 }
@@ -1173,6 +1212,137 @@ describe("mutations", () => {
     expect(perMove).toBeLessThanOrEqual(CROSS_PARENT_MOVED_SUBTREE);
 
     expectSubQuadratic(perOp, "cross-parent move");
+  }, 120_000);
+
+  /**
+   * MULTI-SELECT DELETE, which is select-all-then-Delete on a strip.
+   *
+   * `applyRemoved` called `spliceOut` once per removed placement, and
+   * `spliceOut` is three O(siblings) passes — `indexOf`, `slice`, `splice` —
+   * with a fresh array allocated each time. Removing K of N siblings therefore
+   * cost O(K x N). The constant is a memcpy, which is exactly what let it hide:
+   * invisible below a thousand siblings, and 5.2 SECONDS measured at 40,000.
+   *
+   * ITS OWN FIXTURE, because the wide one cannot see this. The cost is driven
+   * by how many siblings ONE parent holds, and `makeWideFixture` caps that at
+   * `WIDE_FANOUT` (20) no matter how large the document gets — the first
+   * version of this test used it, passed on the unfixed engine, and proved
+   * nothing. A flat parent is the shape the gesture actually happens on.
+   */
+  it("a multi-select delete is linear in the siblings it removes", () => {
+    const flatSizes = [1_000, 10_000] as const;
+    const ratioSamples: number[] = [];
+
+    for (const siblings of flatSizes) {
+      const childIds: string[] = [];
+      const nodes: SerializedNode[] = [];
+      for (let i = 0; i < siblings; i += 1) childIds.push(`flat-${i}`);
+      nodes.push({
+        id: "root",
+        kind: "folder",
+        data: { name: "root" },
+        children: childIds,
+      });
+      for (const id of childIds) {
+        nodes.push({ id, kind: "clip", data: { title: id, seconds: 1 } });
+      }
+      const loaded = engine.deserialize({
+        formatVersion: 1,
+        schemaVersions: { folder: 1, clip: 1 },
+        rootIds: ["root"],
+        nodes,
+      });
+      expect(loaded.ok).toBe(true);
+      if (!loaded.ok) return;
+      const graph = loaded.value.graph;
+
+      const command: Command<Types, Summary> = {
+        type: "remove-nodes",
+        nodeIds: childIds.map((id) => parseNodeId(id)),
+      };
+      // The op must actually succeed, or this times a rejection path.
+      expect(engine.applyCommand(graph, command).ok).toBe(true);
+
+      ratioSamples.push(
+        measure(
+          "multi-select delete",
+          `flat${siblings}`,
+          siblings + 1,
+          () => {
+            engine.applyCommand(graph, command);
+          },
+        ),
+      );
+    }
+
+    const small = ratioSamples[0];
+    const large = ratioSamples[1];
+    expect(small !== undefined && large !== undefined && small > 0).toBe(true);
+    if (small === undefined || large === undefined || small <= 0) return;
+    expectSubQuadraticRatio(large / small, "multi-select delete");
+  }, 120_000);
+
+  /**
+   * SELECTION MEMBERSHIP, which `useIsSelected` calls once per mounted card
+   * every time the selection changes.
+   *
+   * It was `selectedIds.includes(id)` — O(selected) — so one render pass across
+   * N cards with M selected was O(N x M). Measured before the fix: 0.28ms for
+   * 500 cards all selected, 3.7ms for 2,000, and 63ms for 8,000. Four dropped
+   * frames on every selection change, on a board the engine is explicitly built
+   * to handle.
+   *
+   * Gated as CONSTANT rather than sub-quadratic on purpose: the regression this
+   * guards against is a return to a linear scan, which a sub-quadratic ceiling
+   * would happily let through.
+   */
+  it("selection membership does not depend on how much is selected", () => {
+    const samples: number[] = [];
+
+    for (const size of [1_000, 10_000] as const) {
+      const childIds: string[] = [];
+      const nodes: SerializedNode[] = [];
+      for (let i = 0; i < size; i += 1) childIds.push(`sel-${i}`);
+      nodes.push({
+        id: "root",
+        kind: "folder",
+        data: { name: "root" },
+        children: childIds,
+      });
+      for (const id of childIds) {
+        nodes.push({ id, kind: "clip", data: { title: id, seconds: 1 } });
+      }
+      const loaded = engine.deserialize({
+        formatVersion: 1,
+        schemaVersions: { folder: 1, clip: 1 },
+        rootIds: ["root"],
+        nodes,
+      });
+      expect(loaded.ok).toBe(true);
+      if (!loaded.ok) return;
+
+      const store = engine.createStore(loaded.value.graph);
+      const ids = childIds.map((id) => parseNodeId(id));
+      store.selection.set(ids);
+      expect(store.selection.get().length).toBe(size);
+
+      // The LAST id, which is where a linear scan costs the most — a probe near
+      // the front would hide the very regression this is written to catch.
+      const probe = at(ids, size - 1, "selection probe");
+      expect(store.selection.has(probe)).toBe(true);
+
+      samples.push(
+        measure("selection.has", `sel${size}`, size + 1, () => {
+          store.selection.has(probe);
+        }),
+      );
+    }
+
+    const small = samples[0];
+    const large = samples[1];
+    expect(small !== undefined && large !== undefined && small > 0).toBe(true);
+    if (small === undefined || large === undefined || small <= 0) return;
+    expectConstantTime(large / small, "selection.has");
   }, 120_000);
 
   it("a content edit consults exactly one codec, whatever the graph size", () => {

--- a/packages/keel-core/review3-a-quarantined-node-stays-repairable.test.ts
+++ b/packages/keel-core/review3-a-quarantined-node-stays-repairable.test.ts
@@ -1,0 +1,240 @@
+// Third review round — saving a quarantined node destroyed the one fact needed
+// to repair it.
+//
+// QUARANTINE'S WHOLE PROMISE is that a node whose content this build cannot
+// understand keeps its id, its position, its children and its RAW BYTES, so a
+// later build can read it correctly. The module header states it: "A document
+// that will not load is a document the user cannot repair."
+//
+// `serializeGraph` wrote the REGISTRY's current version for every registered
+// kind, up front, and the quarantined branch only filled in a version for kinds
+// the registry did not know. So a node quarantined at v1 — because the v2
+// migration was missing or threw — was re-emitted labelled v2. On the next load
+// `runMigrations` sees `from >= to`, runs nothing, and hands v1 bytes to a v2
+// `parse`. The node quarantines again, forever, and the mechanism that existed
+// to preserve it is what destroyed it.
+//
+// The user gesture is completely ordinary: a build ships a bad migration, one
+// node quarantines, the user keeps working (which is the POINT of quarantine)
+// and saves. That save is the expected outcome, not an edge case.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+/** v1 wire shape: `{ title, secs }`. v2 wire shape: `{ title, seconds }`. */
+type Clip = Readonly<{ title: string; seconds: number }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+/** Flipped to simulate the build that ships the FIXED migration. */
+let migrationThrows = true;
+
+function makeClipV2() {
+  return defineNodeType<Clip, ClipEdit>()({
+    kind: "clip",
+    container: false,
+    schemaVersion: 2,
+    migrations: {
+      2: (raw: unknown): unknown => {
+        if (migrationThrows) {
+          throw new TypeError("clip migration to v2 is broken in this build");
+        }
+        const record: Record<string, unknown> = { ...(raw as object) };
+        return { title: record["title"], seconds: record["secs"] };
+      },
+    },
+    parse(raw): Result<Clip, readonly Issue[]> {
+      if (typeof raw !== "object" || raw === null) {
+        return { ok: false, error: [{ path: "$", message: "not an object" }] };
+      }
+      const record: Record<string, unknown> = { ...raw };
+      const title = record["title"];
+      const seconds = record["seconds"];
+      if (typeof title !== "string") {
+        return { ok: false, error: [{ path: "$.title", message: "title" }] };
+      }
+      // A v1 payload has `secs`, not `seconds`, so it fails here unless the
+      // migration ran — which is exactly the signal this test turns on.
+      if (typeof seconds !== "number") {
+        return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+      }
+      return { ok: true, value: { title, seconds } };
+    },
+    serialize(data): unknown {
+      return { title: data.title, seconds: data.seconds };
+    },
+    applyEdit(data, edit) {
+      return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+    },
+  });
+}
+
+type Folder = Readonly<{ name: string }>;
+const folderType = defineNodeType<Folder, Readonly<{ name?: string }>>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+type Summary = Readonly<{ n: number }>;
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const n = record["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+function makeEngineV2() {
+  const types = [makeClipV2(), folderType] as const;
+  return createEngine<typeof types, Summary, {}>({ types, summary, folds: {} });
+}
+
+/** The document as an older build wrote it: clip at schema version 1. */
+const v1Document = {
+  formatVersion: 1 as const,
+  schemaVersions: { clip: 1, folder: 1 },
+  rootIds: ["root"],
+  nodes: [
+    {
+      id: "root",
+      kind: "folder",
+      data: { name: "Root" },
+      children: ["a", "b"],
+    },
+    { id: "a", kind: "clip", data: { title: "A", secs: 4 } },
+    { id: "b", kind: "clip", data: { title: "B", secs: 9 } },
+  ],
+};
+
+const clipAId = parseNodeId("a");
+
+describe("a quarantined node survives a save-and-reload well enough to be repaired", () => {
+  it("quarantines when the migration is broken, which is the setup, not the bug", () => {
+    migrationThrows = true;
+    const engine = makeEngineV2();
+    const loaded = engine.deserialize(v1Document);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.value.report.quarantined.length).toBe(2);
+  });
+
+  it("re-emits the version its bytes were actually written at", () => {
+    migrationThrows = true;
+    const engine = makeEngineV2();
+    const loaded = engine.deserialize(v1Document);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const saved = engine.serialize(loaded.value.graph);
+    const clip = saved.nodes.find((node) => node.id === "a");
+    expect(clip).toBeDefined();
+
+    // The claim: whatever the document-level map says, this node carries the
+    // version its raw bytes belong to. Without that, the v1 bytes are labelled
+    // v2 and no migration can ever reach them again.
+    expect(clip?.schemaVersion).toBe(1);
+    // And the bytes themselves are untouched — quarantine's byte-exact re-emit.
+    expect(clip?.data).toEqual({ title: "A", secs: 4 });
+  });
+
+  it("REPAIRS on the next build, which is the whole point of quarantine", () => {
+    migrationThrows = true;
+    const brokenBuild = makeEngineV2();
+    const loadedBroken = brokenBuild.deserialize(v1Document);
+    expect(loadedBroken.ok).toBe(true);
+    if (!loadedBroken.ok) return;
+    expect(loadedBroken.value.report.quarantined.length).toBe(2);
+
+    // The user kept working and saved — the expected outcome, since quarantine
+    // exists precisely so one bad node does not make the document unwritable.
+    const saved = brokenBuild.serialize(loadedBroken.value.graph);
+
+    // A later build ships the fixed migration.
+    migrationThrows = false;
+    const fixedBuild = makeEngineV2();
+    const reloaded = fixedBuild.deserialize(saved);
+    expect(reloaded.ok).toBe(true);
+    if (!reloaded.ok) return;
+
+    // Nothing quarantined this time: the migration ran because the node still
+    // declared v1.
+    expect(reloaded.value.report.quarantined.length).toBe(0);
+
+    const node = reloaded.value.graph.nodesById.get(clipAId);
+    expect(node?.quarantined).toBe(false);
+    if (node === undefined || node.quarantined) return;
+    expect(node.data).toEqual({ title: "A", seconds: 4 });
+  });
+
+  it("still round-trips a HEALTHY document without inventing per-node versions", () => {
+    migrationThrows = false;
+    const engine = makeEngineV2();
+    const loaded = engine.deserialize(v1Document);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.value.report.quarantined.length).toBe(0);
+
+    const saved = engine.serialize(loaded.value.graph);
+    // A node that parsed cleanly holds CURRENT data, so it needs no per-node
+    // escape hatch — writing one on every node would bloat every document to
+    // carry a fact the document-level map already states.
+    for (const node of saved.nodes) {
+      expect(node.schemaVersion).toBeUndefined();
+    }
+    expect(saved.schemaVersions).toEqual({ clip: 2, folder: 1 });
+
+    const again = engine.deserialize(saved);
+    expect(again.ok).toBe(true);
+    if (!again.ok) return;
+    expect(again.value.report.quarantined.length).toBe(0);
+  });
+
+  it("refuses a per-node version that is not a finite number", () => {
+    migrationThrows = false;
+    const engine = makeEngineV2();
+    const hostile = {
+      ...v1Document,
+      nodes: [
+        v1Document.nodes[0],
+        { id: "a", kind: "clip", data: { title: "A", secs: 4 }, schemaVersion: "2" },
+        v1Document.nodes[2],
+      ],
+    };
+    const loaded = engine.deserialize(hostile);
+    // It comes off the wire, so it is validated like everything else there.
+    expect(loaded.ok).toBe(false);
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -89,6 +89,8 @@ type NodeDraft = {
   children?: readonly string[];
   childrenState?: WireChildrenState;
   missingReason?: string;
+  /** Written only for a quarantined node — see `SerializedNode.schemaVersion`. */
+  schemaVersion?: number;
   summary?: unknown;
   data: unknown;
 };
@@ -305,6 +307,17 @@ function parseSerializedNode(
       });
     }
     draft.childrenState = raw.childrenState;
+  }
+
+  // Off the wire, so validated like everything else there. A non-finite or
+  // non-numeric version would flow straight into `runMigrations`' bounds.
+  if (raw.schemaVersion !== undefined) {
+    if (typeof raw.schemaVersion !== "number" || !Number.isFinite(raw.schemaVersion)) {
+      return malformed(
+        `node ${JSON.stringify(raw.id)}: schemaVersion must be a finite number`,
+      );
+    }
+    draft.schemaVersion = raw.schemaVersion;
   }
 
   if (raw.missingReason !== undefined) {
@@ -801,6 +814,11 @@ function buildDocument<Ts extends readonly unknown[], S>(
     // QUARANTINES — loud, byte-exact, and repairable. Between a silent
     // corruption and a loud refusal, take the refusal.
     const declaredVersion =
+      // THE NODE'S OWN VERSION WINS. Present only on a node re-emitted from
+      // quarantine, where the document-level entry describes the registry
+      // rather than these bytes. Absent everywhere else, so the map below stays
+      // the answer for every healthy node.
+      wire.schemaVersion ??
       // BELT AND BRACES, and unreachable today — verified by mutation: with the
       // null-prototype initializer in `parseSerializedDocument` in place,
       // reverting this guard fails nothing, because every `doc` reaching here
@@ -1137,6 +1155,16 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
       if (!Object.hasOwn(schemaVersions, node.kind)) {
         schemaVersions[node.kind] = node.schemaVersion;
       }
+      // AND on the node itself, unconditionally, because the document-level
+      // entry above is only reachable for an UNREGISTERED kind — a registered
+      // one had the registry's current version written before any node was
+      // examined, and it wins. That is precisely the case that made quarantine
+      // a one-way door: a node quarantined at v1 because the v2 migration threw
+      // was re-emitted labelled v2, so the fixed build's `runMigrations` saw
+      // `from >= to`, ran nothing, and handed v1 bytes to a v2 `parse`. The
+      // node quarantined again, forever, and the mechanism that existed to
+      // preserve it is what destroyed it.
+      draft.schemaVersion = node.schemaVersion;
       if (node.summary !== undefined) draft.summary = node.summary;
       writeChildren(draft, id, node.children);
       nodes.push(draft);

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -789,6 +789,25 @@ export type SerializedNode = Readonly<{
   childrenState?: "unloaded" | "reference" | "missing";
   /** Only meaningful with `childrenState: "missing"`. */
   missingReason?: string;
+  /**
+   * The version THIS node's `data` was written at, overriding the document's
+   * `schemaVersions` entry for its kind.
+   *
+   * Absent on every healthy node, and that is the point: a node that parsed
+   * cleanly holds current data, so the document-level map already describes it
+   * and writing a per-node copy on every node would bloat every document to
+   * restate a fact it already carries.
+   *
+   * It exists for QUARANTINE. A node quarantined because its migration was
+   * missing or threw still holds bytes from the version it was written at,
+   * while `schemaVersions[kind]` says what the REGISTRY is at now. Re-emitting
+   * those bytes under the registry's number is what made a quarantined node
+   * permanently unrepairable: the next build's `runMigrations` sees
+   * `from >= to`, runs nothing, and hands old bytes to a new `parse`. This is
+   * the escape hatch that keeps quarantine's promise — raw bytes AND the
+   * version they belong to.
+   */
+  schemaVersion?: number;
   summary?: unknown;
   data: unknown;
 }>;


### PR DESCRIPTION
Stacked on #576.

**Quarantine's whole promise** is that a node this build cannot understand keeps its id, its position, its children and its **raw bytes**, so a later build can read it correctly. The module header states the stake: *"A document that will not load is a document the user cannot repair."*

Saving one destroyed the single fact needed to repair it.

`serializeGraph` writes the **registry's** current version for every registered kind before any node is examined, and the quarantined branch only filled in a version for kinds the registry didn't know. So a node quarantined at v1 — because the v2 migration was missing or threw — was re-emitted labelled **v2**. On the next load `runMigrations` sees `from >= to`, runs nothing, and hands v1 bytes to a v2 `parse`. It quarantines again, on every build, forever, because the version that would let a migration reach it is gone.

The gesture needs no hostile input: a build ships a bad migration, one node quarantines, the user keeps working — which is the *point* of quarantine — and saves. **Six of the nine review lenses found this independently.**

### The fix

`SerializedNode` gains an optional `schemaVersion`, written **only** on a quarantined node and preferred over the document-level map on load.

Absent on every healthy node, deliberately: a node that parsed cleanly holds current data, so `schemaVersions[kind]` already describes it, and a per-node copy everywhere would bloat every document to restate a fact it already carries. A test pins that absence so this can't quietly become a field on everything.

Additive, so `formatVersion` stays **1** — an older reader ignores the key, and a document without it reads exactly as today. The value is validated at ingress like everything else off the wire; a non-finite version would otherwise flow straight into `runMigrations`' loop bounds.

### The test is the repair journey, not a field assertion

Because the journey is what was broken:

1. Load a v1 document under a build whose migration throws → **2 nodes quarantine**
2. Save (the expected outcome — quarantine exists so one bad node doesn't make the document unwritable)
3. Ship the fixed migration
4. Reload → expect **zero** quarantined, data correctly migrated

Before this change, step 4 returns 2. Forever.

### Verification

| | |
|---|---|
| Regression tests | 5, of which **3 failed** before |
| Mutation proof | emit 2 · load preference 1 · wire validation 1 |
| Unit suite | 1,374 tests / 68 files |
| Stories | 9 pass, headless Chromium |
| `tsc` | clean, both packages |

### Correction

I reported after #576 that all eight high-severity findings were fixed. **They were not** — this was one of two still open, and it was the one the most lenses agreed on. The remaining high is `commands.ts:658`: the `duplicate-owner` rejection prescribes inserting a `reference` placement, and no `Seed` can express one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)