### PR TITLE
The ceilings bound the graph, not whichever door you came in through

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -437,6 +437,29 @@ function isNoOpMove(moves: readonly Move[]): boolean {
   );
 }
 
+/**
+ * The tallest LIVE subtree under `id`, counting `id` itself as 1.
+ *
+ * `subtreeIds` descends only `loaded` collections, which is the right rule
+ * here: an unloaded branch contributes its placeholder and nothing more,
+ * exactly as it does when the ingress door measures the same graph. So a move
+ * is judged on the depth the graph actually holds, and loading that branch
+ * later is bounded by `loadChildrenInto`'s own check rather than pre-refused
+ * here on a guess about what it might contain.
+ */
+function tallestSubtree<Ts extends readonly unknown[], S>(
+  graph: Graph<Ts, S>,
+  id: NodeId,
+): number {
+  const base = ancestorChain(graph, id).length;
+  let tallest = 1;
+  for (const descendantId of subtreeIds(graph, id)) {
+    const depth = ancestorChain(graph, descendantId).length - base + 1;
+    if (depth > tallest) tallest = depth;
+  }
+  return tallest;
+}
+
 function applyMoveNodes<Ts extends readonly unknown[], S>(
   graph: Graph<Ts, S>,
   nodeIds: readonly NodeId[],
@@ -454,6 +477,24 @@ function applyMoveNodes<Ts extends readonly unknown[], S>(
       `toIndex ${toIndex} is outside [0, ${plan.postRemovalChildren.length}] (POST-REMOVAL) for ${JSON.stringify(toParentId)}.`,
       { parentId: toParentId, index: toIndex },
     );
+  }
+
+  // DEPTH, checked against the destination rather than the source: relocating a
+  // deep subtree under a deep parent adds the two together, and only the
+  // ingress doors used to notice.
+  if (ctx.maxDepth !== null) {
+    const parentDepth = depthOf(graph, toParentId);
+    for (const id of plan.orderedIds) {
+      const deepest = parentDepth + tallestSubtree<Ts, S>(graph, id);
+      if (deepest > ctx.maxDepth) {
+        return fail(
+          "would-exceed-max-depth",
+          `Moving ${JSON.stringify(id)} here would nest ${deepest} levels, above the ` +
+            `${ctx.maxDepth} ceiling. Raise or clear EngineConfig.maxDepth if this is legitimate.`,
+          { nodeIds: [id], parentId: toParentId, limit: ctx.maxDepth, actual: deepest },
+        );
+      }
+    }
   }
 
   const built = buildMoves(plan, toParentId, toIndex);
@@ -562,8 +603,36 @@ function applyInsertNodes<Ts extends readonly unknown[], S>(
     );
   }
 
+  // DEPTH first, because it can be answered from the seeds alone and refusing
+  // before `buildSeedPlacements` mints ids keeps a refused command from having
+  // consumed any of the id space.
+  if (ctx.maxDepth !== null) {
+    const deepest = depthOf(graph, toParentId) + tallestSeed<Ts, S>(seeds);
+    if (deepest > ctx.maxDepth) {
+      return fail(
+        "would-exceed-max-depth",
+        `Inserting here would nest ${deepest} levels, above the ${ctx.maxDepth} ceiling. ` +
+          `Raise or clear EngineConfig.maxDepth if this is legitimate.`,
+        { parentId: toParentId, limit: ctx.maxDepth, actual: deepest },
+      );
+    }
+  }
+
   const built = buildSeedPlacements(graph, seeds, toParentId, toIndex, ctx);
   if (!built.ok) return built;
+
+  // COUNTED FROM THE PLACEMENTS, not from `seeds.length`: one seed may carry a
+  // whole subtree, and a per-command check would let three nodes in under a
+  // ceiling with room for one.
+  const total = graph.nodesById.size + built.value.length;
+  if (total > ctx.maxNodes) {
+    return fail(
+      "would-exceed-max-nodes",
+      `Inserting ${built.value.length} node(s) into a graph of ${graph.nodesById.size} would reach ` +
+        `${total}, above the ${ctx.maxNodes} ceiling. Raise EngineConfig.maxNodes if this is legitimate.`,
+      { parentId: toParentId, limit: ctx.maxNodes, actual: total },
+    );
+  }
 
   const patch: Patch<Ts, S> = { type: "inserted", placements: built.value };
   return ok({ graph: applyPatch(graph, patch, ctx), patch });
@@ -605,6 +674,46 @@ function checkInsertTarget<Ts extends readonly unknown[], S>(
  *
  * EXPLICIT STACK, never recursion — seed depth is consumer input.
  */
+/**
+ * How deep `id` sits, counting the roots as level 1.
+ *
+ * `ancestorChain` excludes `id` itself, so its length plus one IS the depth —
+ * the same arithmetic `loadChildrenInto` uses to tell `buildDocument` where a
+ * lazy payload is being attached. Stated once here so the reducer and the
+ * ingress door cannot drift about what "depth" counts.
+ */
+function depthOf<Ts extends readonly unknown[], S>(
+  graph: Graph<Ts, S>,
+  id: NodeId,
+): number {
+  return ancestorChain(graph, id).length + 1;
+}
+
+/**
+ * The tallest subtree in a seed batch, counting the seed itself as 1.
+ *
+ * Walked with an explicit stack for the same reason every other walk in this
+ * package is: a seed's children are consumer-supplied and their nesting is not
+ * this module's to trust.
+ */
+function tallestSeed<Ts extends readonly unknown[], S>(
+  seeds: readonly Seed<Ts, S>[],
+): number {
+  let tallest = 0;
+  const stack: Readonly<{ seed: Seed<Ts, S>; depth: number }>[] = seeds.map(
+    (seed) => ({ seed, depth: 1 }),
+  );
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (frame === undefined) break;
+    if (frame.depth > tallest) tallest = frame.depth;
+    const kids = frame.seed.children;
+    if (kids === undefined) continue;
+    for (const kid of kids) stack.push({ seed: kid, depth: frame.depth + 1 });
+  }
+  return tallest;
+}
+
 function buildSeedPlacements<Ts extends readonly unknown[], S>(
   graph: Graph<Ts, S>,
   seeds: readonly Seed<Ts, S>[],

--- a/packages/keel-core/review3-the-ceilings-bound-the-graph-not-one-payload.test.ts
+++ b/packages/keel-core/review3-the-ceilings-bound-the-graph-not-one-payload.test.ts
@@ -1,0 +1,448 @@
+// Third review round — three holes with one shape: a bound this package
+// DOCUMENTS and then does not enforce at every door that can reach the state.
+//
+//   1. `parseSerializedDocument` composed two refusals with
+//      `JSON.stringify(<untrusted value>)`. `JSON.parse` is ITERATIVE in V8 and
+//      `JSON.stringify` is RECURSIVE, so a payload that parses fine blows the
+//      stack while the engine builds the message that rejects it — a throw out
+//      of a function whose whole contract is
+//      `Result<SerializedDocument, StructuralError>`. It does not need an
+//      exotic payload: ~6,000 levels is a 12 KB request body.
+//
+//   2. `EngineConfig.maxDepth` was enforced PER PAYLOAD, counted from each
+//      payload's own roots, ignoring how deep the target already sat. So
+//      repeated `store.load` calls walked past the ceiling without limit —
+//      the identical hole `maxNodes` already closes a few lines away via
+//      `existingNodeCount`.
+//
+//   3. The REDUCER enforced neither ceiling. Both lived only on the ingress
+//      doors, so ordinary gestures grew a graph past either one, after which
+//      `engine.serialize` emitted a document `engine.deserialize` refuses —
+//      the engine producing documents it cannot read back.
+//
+// The theme is worth naming because it is the same one that produced three
+// comments describing checks that did not exist: a rule enforced at one door is
+// not a rule, it is a habit.
+import { describe, expect, it } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { parseSerializedDocument } from "./serialize";
+import { createEngine } from "./engine";
+
+type Clip = Readonly<{ title: string }>;
+const clipType = defineNodeType<Clip, Readonly<{ title?: string }>>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+const folderType = defineNodeType<Folder, Readonly<{ name?: string }>>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const n = record["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+function makeEngine(config?: Readonly<{ maxNodes?: number; maxDepth?: number }>) {
+  return createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    ...(config?.maxNodes === undefined ? {} : { maxNodes: config.maxNodes }),
+    ...(config?.maxDepth === undefined ? {} : { maxDepth: config.maxDepth }),
+  });
+}
+
+/** A value that `JSON.parse` builds happily and `JSON.stringify` cannot walk. */
+function deeplyNested(levels: number): unknown {
+  return JSON.parse("[".repeat(levels) + "1" + "]".repeat(levels));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Composing the refusal must not throw
+// ---------------------------------------------------------------------------
+
+describe("a refusal is composed without walking the value it refuses", () => {
+  it("parses the hostile payload in the first place, which is the premise", () => {
+    // If this ever throws, the rest of this block is testing nothing — V8's
+    // JSON parser being iterative is the whole reason the defect exists.
+    expect(() => deeplyNested(100_000)).not.toThrow();
+  });
+
+  it("returns a Result for a deeply nested formatVersion", () => {
+    const raw = { formatVersion: deeplyNested(100_000), rootIds: [], nodes: [] };
+    let thrown: unknown = null;
+    let out: ReturnType<typeof parseSerializedDocument> | null = null;
+    try {
+      out = parseSerializedDocument(raw);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeNull();
+    expect(out?.ok).toBe(false);
+    if (out && !out.ok) expect(out.error.code).toBe("unsupported-format-version");
+  });
+
+  it("returns a Result for a deeply nested childrenState", () => {
+    const raw = {
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "R" },
+          childrenState: deeplyNested(100_000),
+        },
+      ],
+    };
+    let thrown: unknown = null;
+    try {
+      const out = parseSerializedDocument(raw);
+      expect(out.ok).toBe(false);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeNull();
+  });
+
+  it("holds at 6,000 levels, which is a 12 KB request body and not an exotic one", () => {
+    const raw = { formatVersion: deeplyNested(6_000), rootIds: [], nodes: [] };
+    expect(() => parseSerializedDocument(raw)).not.toThrow();
+  });
+
+  it("reaches the same guard through the sanctioned ingress door", () => {
+    const engine = makeEngine();
+    expect(() =>
+      engine.deserialize({
+        formatVersion: deeplyNested(100_000),
+        rootIds: [],
+        nodes: [],
+      }),
+    ).not.toThrow();
+  });
+
+  it("still names an ordinary bad value usefully, and does not echo a huge one", () => {
+    const bad = parseSerializedDocument({ formatVersion: 2, rootIds: [], nodes: [] });
+    expect(bad.ok).toBe(false);
+    if (bad.ok) return;
+    expect(bad.error.message).toContain("2");
+
+    const huge = parseSerializedDocument({
+      formatVersion: "x".repeat(5_000_000),
+      rootIds: [],
+      nodes: [],
+    });
+    expect(huge.ok).toBe(false);
+    if (huge.ok) return;
+    // A refusal a consumer will log must not carry a 5 MB payload into the log.
+    expect(huge.error.message.length).toBeLessThan(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. maxDepth bounds the GRAPH, not one payload
+// ---------------------------------------------------------------------------
+
+describe("maxDepth survives repeated lazy loads", () => {
+  /** A one-node payload whose root is an unloaded folder. */
+  function unloadedPayload(id: string) {
+    return {
+      formatVersion: 1 as const,
+      schemaVersions: { folder: 1, clip: 1 },
+      rootIds: [id],
+      nodes: [
+        {
+          id,
+          kind: "folder",
+          data: { name: id },
+          childrenState: "unloaded" as const,
+          summary: { n: 0 },
+        },
+      ],
+    };
+  }
+
+  it("refuses the eager door past the ceiling, which proves the ceiling is live", () => {
+    const engine = makeEngine({ maxDepth: 3 });
+    const tooDeep = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1, clip: 1 },
+      rootIds: ["r"],
+      nodes: [
+        { id: "r", kind: "folder", data: { name: "r" }, children: ["l2"] },
+        { id: "l2", kind: "folder", data: { name: "l2" }, children: ["l3"] },
+        { id: "l3", kind: "folder", data: { name: "l3" }, children: ["l4"] },
+        { id: "l4", kind: "clip", data: { title: "l4" } },
+      ],
+    });
+    expect(tooDeep.ok).toBe(false);
+    if (tooDeep.ok) return;
+    expect(tooDeep.error.code).toBe("document-too-deep");
+  });
+
+  it("refuses the LAZY door at the same ceiling", () => {
+    const engine = makeEngine({ maxDepth: 3 });
+    const loaded = engine.deserialize(unloadedPayload("f0"));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    // f0 is depth 1. Loading into it puts f1 at depth 2, f2 at 3 — both legal.
+    expect(store.load(parseNodeId("f0"), unloadedPayload("f1")).ok).toBe(true);
+    expect(store.load(parseNodeId("f1"), unloadedPayload("f2")).ok).toBe(true);
+
+    // f3 would be depth 4. The eager door refuses that shape; so must this one.
+    const past = store.load(parseNodeId("f2"), unloadedPayload("f3"));
+    expect(past.ok).toBe(false);
+    if (past.ok) return;
+    expect(past.error.code).toBe("malformed-document");
+    expect(past.error.cause?.code).toBe("document-too-deep");
+  });
+
+  it("does not refuse a legal lazy load, which is the over-refusal guard", () => {
+    const engine = makeEngine({ maxDepth: 10 });
+    const loaded = engine.deserialize(unloadedPayload("f0"));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+    for (let i = 1; i < 9; i += 1) {
+      const result = store.load(parseNodeId(`f${i - 1}`), unloadedPayload(`f${i}`));
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it("is unbounded by default, so this changes nothing for a consumer who set no ceiling", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize(unloadedPayload("f0"));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+    for (let i = 1; i < 40; i += 1) {
+      expect(store.load(parseNodeId(`f${i - 1}`), unloadedPayload(`f${i}`)).ok).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The reducer obeys the same ceilings the ingress doors do
+// ---------------------------------------------------------------------------
+
+describe("the reducer cannot grow a graph the engine could not read back", () => {
+  function twoNodeStore(config: Readonly<{ maxNodes?: number; maxDepth?: number }>) {
+    const engine = makeEngine(config);
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1, clip: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: ["a"] },
+        { id: "a", kind: "clip", data: { title: "A" } },
+      ],
+    });
+    if (!loaded.ok) throw new Error("fixture failed to deserialize");
+    return { engine, store: engine.createStore(loaded.value.graph) };
+  }
+
+  it("refuses an insert that would exceed maxNodes", () => {
+    const { engine, store } = twoNodeStore({ maxNodes: 4 });
+    const rootId = parseNodeId("root");
+
+    // 2 nodes present; two more are legal, the third is not.
+    for (let i = 0; i < 2; i += 1) {
+      const ok = store.dispatch({
+        type: "insert-nodes",
+        toParentId: rootId,
+        toIndex: 0,
+        seeds: [{ kind: "clip", data: { title: `n${i}` } }],
+      });
+      expect(ok.ok).toBe(true);
+    }
+
+    const past = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "clip", data: { title: "over" } }],
+    });
+    expect(past.ok).toBe(false);
+    if (past.ok) return;
+    expect(past.error.code).toBe("would-exceed-max-nodes");
+
+    // The point of the ceiling: what the engine emits, it can read back.
+    const round = engine.deserialize(engine.serialize(store.getGraph()));
+    expect(round.ok).toBe(true);
+  });
+
+  it("counts a whole seed subtree, not one node per command", () => {
+    const { store } = twoNodeStore({ maxNodes: 4 });
+    const past = store.dispatch({
+      type: "insert-nodes",
+      toParentId: parseNodeId("root"),
+      toIndex: 0,
+      seeds: [
+        {
+          kind: "folder",
+          data: { name: "F" },
+          children: [
+            { kind: "clip", data: { title: "x" } },
+            { kind: "clip", data: { title: "y" } },
+          ],
+        },
+      ],
+    });
+    // 2 present + 3 arriving = 5, above 4. A per-node check would have let the
+    // command through and then blown the ceiling.
+    expect(past.ok).toBe(false);
+    if (past.ok) return;
+    expect(past.error.code).toBe("would-exceed-max-nodes");
+  });
+
+  it("refuses an insert that would exceed maxDepth", () => {
+    const { engine, store } = twoNodeStore({ maxDepth: 3 });
+    const rootId = parseNodeId("root");
+
+    // root(1) -> folder(2) -> clip(3) is legal.
+    const legal = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [
+        { kind: "folder", data: { name: "F" }, children: [{ kind: "clip", data: { title: "x" } }] },
+      ],
+    });
+    expect(legal.ok).toBe(true);
+
+    // One level further is not.
+    const past = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [
+        {
+          kind: "folder",
+          data: { name: "G" },
+          children: [
+            {
+              kind: "folder",
+              data: { name: "H" },
+              children: [{ kind: "clip", data: { title: "deep" } }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(past.ok).toBe(false);
+    if (past.ok) return;
+    expect(past.error.code).toBe("would-exceed-max-depth");
+
+    const round = engine.deserialize(engine.serialize(store.getGraph()));
+    expect(round.ok).toBe(true);
+  });
+
+  it("refuses a MOVE that would push a subtree past maxDepth", () => {
+    const engine = makeEngine({ maxDepth: 3 });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1, clip: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: ["deep", "sub"] },
+        // A two-level subtree sitting at depth 2.
+        { id: "deep", kind: "folder", data: { name: "D" }, children: ["leaf"] },
+        { id: "leaf", kind: "clip", data: { title: "L" } },
+        // Another container at depth 2. Moving `deep` under it puts `leaf` at 4.
+        { id: "sub", kind: "folder", data: { name: "S" }, children: [] },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const past = store.dispatch({
+      type: "move-nodes",
+      nodeIds: [parseNodeId("deep")],
+      toParentId: parseNodeId("sub"),
+      toIndex: 0,
+    });
+    expect(past.ok).toBe(false);
+    if (past.ok) return;
+    expect(past.error.code).toBe("would-exceed-max-depth");
+  });
+
+  it("leaves an unbounded engine exactly as it was", () => {
+    const { store } = twoNodeStore({});
+    for (let i = 0; i < 40; i += 1) {
+      const ok = store.dispatch({
+        type: "insert-nodes",
+        toParentId: parseNodeId("root"),
+        toIndex: 0,
+        seeds: [{ kind: "clip", data: { title: `n${i}` } }],
+      });
+      expect(ok.ok).toBe(true);
+    }
+    expect(store.getGraph().nodesById.size).toBe(42);
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -35,6 +35,7 @@
 
 import {
   describeThrown,
+  describeValue,
   makeCollectionNode,
   makeLeafNode,
   makeQuarantinedNode,
@@ -58,6 +59,7 @@ import {
 } from "./types";
 
 import {
+  ancestorChain,
   ownsItsSubtree,
   bumpSubtreeRevs,
   childrenStateOf,
@@ -167,7 +169,7 @@ export function parseSerializedDocument(
   if (raw.formatVersion !== 1) {
     return fail({
       code: "unsupported-format-version",
-      message: `Unsupported formatVersion ${JSON.stringify(raw.formatVersion)} (this engine reads 1)`,
+      message: `Unsupported formatVersion ${describeValue(raw.formatVersion)} (this engine reads 1)`,
     });
   }
 
@@ -302,7 +304,7 @@ function parseSerializedNode(
     if (!isWireChildrenState(raw.childrenState)) {
       return fail({
         code: "invalid-children-state",
-        message: `node ${JSON.stringify(raw.id)}: childrenState must be "unloaded", "reference" or "missing", received ${JSON.stringify(raw.childrenState)}`,
+        message: `node ${JSON.stringify(raw.id)}: childrenState must be "unloaded", "reference" or "missing", received ${describeValue(raw.childrenState)}`,
         rawId: raw.id,
       });
     }
@@ -544,6 +546,20 @@ function buildDocument<Ts extends readonly unknown[], S>(
      * ever the one that is too big.
      */
     existingNodeCount?: number;
+    /**
+     * How deep the payload's own roots already sit in the HOST graph.
+     *
+     * The exact companion to `existingNodeCount`, and it was missing for the
+     * same reason that one was needed: `maxDepth` counted from each payload's
+     * own roots and ignored where they were being attached, so the lazy door
+     * walked straight past the ceiling. MEASURED before this existed: a
+     * `maxDepth` of 3, then twelve successive one-node `store.load` calls each
+     * attaching to the last, produced a graph 13 levels deep. Every one of
+     * those payloads was legally 1 level deep on its own.
+     *
+     * 1 for the eager door, where the roots ARE the graph's roots.
+     */
+    existingDepth?: number;
   }>,
 ): Result<BuiltDocument<Ts, S>, StructuralError> {
   const parsed = parseSerializedDocument(raw, {
@@ -740,7 +756,7 @@ function buildDocument<Ts extends readonly unknown[], S>(
     const root = rootIds[i];
     if (root !== undefined) {
       stack.push(root);
-      depths.push(1);
+      depths.push(options.existingDepth ?? 1);
     }
   }
   while (stack.length > 0) {
@@ -1295,6 +1311,10 @@ export function loadChildrenInto<Ts extends readonly unknown[], S>(
   const built = buildDocument<Ts, S>(doc, ctx, {
     rootsMustBeContainers: false,
     existingNodeCount: graph.nodesById.size,
+    // The payload's roots become THIS target's children, so they land one level
+    // below it. `ancestorChain` excludes `id` itself, hence the +2: one for the
+    // target, one for the children about to hang off it.
+    existingDepth: ancestorChain(graph, id).length + 2,
   });
   if (!built.ok) {
     return loadRejection({

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -601,6 +601,20 @@ export type RejectionCode =
   /** A seed's data failed its own `parse`. See `issues`. */
   | "parse-failed"
   | "leaf-seed-with-children"
+  /**
+   * A gesture that would push the graph past `EngineConfig.maxNodes` or
+   * `maxDepth`.
+   *
+   * Named to mirror `would-create-cycle` rather than the ingress pair
+   * `document-too-large` / `document-too-deep`, because the subject is
+   * different: those describe a DOCUMENT that is already too big, this
+   * describes a COMMAND that has not happened. The ceilings used to live only
+   * on the ingress doors, so the reducer could grow a graph that
+   * `engine.serialize` then emitted and `engine.deserialize` refused — the
+   * engine producing documents it cannot read back.
+   */
+  | "would-exceed-max-nodes"
+  | "would-exceed-max-depth"
   /** The consumer's PRE-commit `commandPolicy` vetoed it. */
   | "policy-rejected";
 
@@ -617,6 +631,12 @@ export type Rejection = Readonly<{
   issues?: readonly Issue[];
   /** The codec's verbatim complaint, on `"edit-rejected"`. */
   editRejection?: EditRejection;
+  /** The ceiling that was hit, on the two `would-exceed-*` codes. Named the
+   *  same as `StructuralError`'s pair so a consumer reporting a limit to the
+   *  user reads it the same way whichever door refused. */
+  limit?: number;
+  /** What the graph WOULD have reached. */
+  actual?: number;
 }>;
 
 /**
@@ -1489,6 +1509,51 @@ export function makeDataChange<Ts extends readonly unknown[]>(
  * helper whose whole job is to describe a failure must not have a failure mode
  * of its own.
  */
+/**
+ * `describeThrown`'s sibling, for an untrusted VALUE rather than a thrown one.
+ *
+ * `JSON.parse` is ITERATIVE in V8 and `JSON.stringify` is RECURSIVE, so a
+ * payload that parsed perfectly well can still blow the stack while the engine
+ * composes the refusal that rejects it — a throw out of a function whose whole
+ * contract is a `Result`. It does not take an exotic input: ~6,000 levels is a
+ * 12 KB request body, and the failure lands on the trust boundary where every
+ * hostile document arrives.
+ *
+ * Also CLAMPED, which is a second and smaller problem the same edit closes: an
+ * unclamped describer echoes a 5 MB string straight into a message a consumer
+ * will log.
+ *
+ * NOT re-exported from ./index — a consumer reads the strings it produces and
+ * never calls it.
+ */
+export function describeValue(value: unknown): string {
+  if (value === null) return "null";
+  // Primitives cannot nest, so they need no walk. `String` is safe on a symbol
+  // where a template literal is not, and a function's source can be long, so
+  // everything here still goes through the same clamp.
+  if (typeof value !== "object" && typeof value !== "string") {
+    return clamp(String(value));
+  }
+  try {
+    const text = JSON.stringify(value);
+    // `stringify` answers `undefined` for a function or a bare symbol.
+    if (text === undefined) return typeof value;
+    return clamp(text);
+  } catch {
+    // Stack exhaustion, or a cycle. Either way the shape is all that can be
+    // said safely, and the stack is fully usable again once the frame unwinds.
+    return Array.isArray(value) ? "[deeply nested array]" : "[deeply nested object]";
+  }
+}
+
+const DESCRIBE_LIMIT = 120;
+
+function clamp(text: string): string {
+  return text.length > DESCRIBE_LIMIT
+    ? `${text.slice(0, DESCRIBE_LIMIT - 3)}...`
+    : text;
+}
+
 export function describeThrown(thrown: unknown): string {
   if (thrown instanceof Error) return thrown.message;
   return String(thrown);


### PR DESCRIPTION
Three defects with one shape: a bound this package **documents** and then does not enforce at every door that can reach the state.

All three were re-confirmed **by execution against the current tree** — six PRs have landed since the review, so none of the original line numbers or premises were taken on trust.

## 1. Composing a refusal could throw

`parseSerializedDocument` built two error messages with `JSON.stringify(<untrusted value>)`. `JSON.parse` is **iterative** in V8; `JSON.stringify` is **recursive**. So a payload that parses perfectly well blows the stack while the engine composes the refusal that rejects it — a `RangeError` out of a function whose entire contract is a `Result`, on the trust boundary where every hostile document arrives.

It needs nothing exotic: **~6,000 levels is a 12 KB request body**, measured here at that size as well as at 100,000.

`describeValue` joins `describeThrown` in `./types` — that helper exists precisely because "a thrown value is arbitrary" and must not be stringified blindly, and this is the same argument one step earlier. It also **clamps**, closing a smaller second problem in the same edit: an unclamped describer echoes a 5 MB string into a message a consumer will log.

## 2. `maxDepth` was enforced per payload

Depth counted from each payload's own roots and ignored where they were being attached, so the lazy door walked past the ceiling without limit.

**Measured:** `maxDepth: 3`, then twelve successive one-node `store.load` calls each attaching to the last → a graph **13 levels deep**. Every payload was legally 1 level deep on its own.

The fix mirrors `existingNodeCount`, which sits a few lines away and exists for the identical reason — its own doc comment says *"bounding each payload on its own left the ceiling trivially walkable."*

## 3. The reducer enforced neither ceiling

Both lived only on the ingress doors, so ordinary gestures grew a graph past either one — after which `engine.serialize` emitted a document `engine.deserialize` refuses. **The engine could produce documents it cannot read back.**

`insert-nodes` now checks both; `move-nodes` checks depth, since relocating a deep subtree under a deep parent adds the two together. Two new `RejectionCode` members named to mirror `would-create-cycle` rather than the ingress pair: those describe a *document* that is already too big, these describe a *command* that hasn't happened.

The node count comes from the built **placements**, not `seeds.length` — one seed may carry a whole subtree, and a per-command check would let three nodes in under a ceiling with room for one. Pinned by its own test.

Depth on a move is measured against the **live** subtree, which descends only `loaded` collections — matching what the ingress door measures on the same graph. An unloaded branch contributes its placeholder, and loading it later is bounded by `loadChildrenInto`'s own check rather than pre-refused here on a guess.

## Over-refusal guards

Five, because a ceiling that refuses too much is worse than one that refuses too little: a legal lazy load still works, an engine with no ceiling set is unaffected in both directions, an ordinary bad `formatVersion` is still named usefully, and the eager door still refuses the shape it always did.

## Verification

| | |
|---|---|
| Regression tests | 15, of which **10 failed** before |
| Mutation proof | describeValue@formatVersion 4 · @childrenState 1 · depth base 1 · reducer maxNodes 2 · maxDepth insert 1 · maxDepth move 1 |
| Unit suite | 1,389 tests / 69 files |
| Stories | 9 pass, headless Chromium |
| `tsc` | clean, both packages |

### One note on that proof

My first mutation of the insert-depth guard reported the **move** test failing instead of the insert one — so the insert guard looked proven when it wasn't. The four-space anchor I used is a substring of the six-space one inside `applyMoveNodes`, which appears earlier in the file, so both mutations edited the same line. Re-run against a unique anchor, it fails its own test as it should.

A mutation that hits the wrong line is indistinguishable from a guard that works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)