### PR TITLE
The two default ceilings disagreed, and the comment said they could not

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -1362,7 +1362,8 @@ function resolveInsertDrop<Ts extends readonly unknown[], S>(
  *
  * The user loses undo of their own edit to that one node — correct, the server
  * has since overwritten it — and keeps everything else. Cost is
- * O(historyLimit x changes), bounded.
+ * O(historyLimit x changes) — bounded only when a consumer SET a
+ * `historyLimit`, which is not the default. See `EngineConfig.historyLimit`.
  */
 export function applyIngestEdits<Ts extends readonly unknown[], S>(
   graph: Graph<Ts, S>,

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -58,7 +58,7 @@ import {
   applyIngestEdits,
   resolveDrop as resolveDropIn,
 } from "./commands";
-import { computeFold, createFoldCache } from "./folds";
+import { computeFold, createFoldCache, DEFAULT_FOLD_CACHE_LIMIT } from "./folds";
 import {
   DEFAULT_MAX_NODES,
   deserializeDocument,
@@ -208,6 +208,30 @@ export function createEngine<
     foldKeyOwners.set(fold.key, entryKey);
   }
 
+  // `historyLimit` REFUSED rather than reinterpreted, and this is the one place
+  // that can. ./history's `effectiveLimit` maps anything that is not a positive
+  // integer — `0`, a negative, a fraction, `NaN` — to unbounded, and argues for
+  // it on the grounds that `historyLimit: 2.5` is a typo and silently choosing
+  // 2 or 3 would hide it. True, and choosing INFINITY hides it too, in the one
+  // direction that is unsafe: the consumer asked to bound memory and got no
+  // bound. MEASURED: `historyLimit: 2.5` retained 200 entries.
+  //
+  // Throws, like the duplicate kind and the duplicate fold key above, for the
+  // same reason — a programmer error at module init, before any data has been
+  // read. Omitting the field is still how a consumer asks for unbounded, and
+  // that stays silent.
+  const historyLimit = config.historyLimit;
+  if (
+    historyLimit !== undefined &&
+    (!Number.isInteger(historyLimit) || historyLimit <= 0)
+  ) {
+    throw new Error(
+      `keel: historyLimit must be a positive integer, received ${String(historyLimit)}. ` +
+        `Omit it entirely for unbounded history — a fractional or non-positive value ` +
+        `would silently mean unbounded, which is the opposite of what naming a limit asks for.`,
+    );
+  }
+
   // A fresh symbol per call is the whole cross-instance guard: `NodeId` is
   // branded globally, so an id from another engine typechecks here, and this is
   // the only thing standing between that and a graph quietly holding another
@@ -304,6 +328,71 @@ export function createEngine<
      * product gets a table that thrashes without saying so.
      */
     const cache = createFoldCache(config.foldCacheLimit);
+
+    /**
+     * THE TWO CEILINGS, compared against the graph that actually exists.
+     *
+     * `maxNodes` says how large a document may be; `foldCacheLimit` says how
+     * many (fold, node, rev) entries the memo table holds. They are
+     * independent numbers describing one graph, and at the DEFAULTS they
+     * disagree: a registry of 8 folds — the size ./folds itself calls
+     * realistic — makes the table cover 16,384 nodes while the node ceiling
+     * admits 100,000.
+     *
+     * Past that point the LRU does not degrade, it INVERTS: fold k's walk
+     * evicts fold 1's entries, fold 1's next read misses at the root, and every
+     * mounted card refolds its whole subtree. MEASURED at 20,001 nodes with 8
+     * folds — five times under the node ceiling, and accepted by `deserialize`:
+     * 188,944 evictions, ZERO hits on an identical repeat, 5,542 ms against
+     * 0.017 ms with the table sized to fit. Worse than no cache at all, because
+     * every `set` also runs the eviction loop.
+     *
+     * CHECKED AGAINST `nodesById.size`, NOT AGAINST `maxNodes`, and that
+     * distinction is the whole difference between a diagnostic and noise. The
+     * first version of this compared the two CEILINGS at `createEngine`, which
+     * is where both numbers are in hand — and it fired for twelve of this
+     * package's own fixtures, including one that sets `foldCacheLimit: 4`
+     * deliberately to exercise eviction. A consumer who sized a small cache on
+     * purpose is not making a mistake, and a consumer whose documents are 500
+     * nodes does not care that a ceiling they will never reach exceeds a table
+     * they will never fill. The real condition is "this table cannot cover THIS
+     * graph", and only a store knows that.
+     *
+     * ONCE per store, latched, and re-checked on commit because a graph grows.
+     * The cost is an integer compare behind a boolean that flips at most once.
+     */
+    let warnedAboutCacheSize = false;
+    const warnIfCacheCannotCover = (candidate: Graph<Ts, S>): void => {
+      if (warnedAboutCacheSize) return;
+      // ONLY WHEN THE LIMIT IS THE DEFAULT. A consumer who wrote a number chose
+      // it; the failure this exists to catch belongs to the consumer who wrote
+      // none and does not know the default stops covering at 16,384 nodes. This
+      // is the same rule `maxNodes` states a few lines up — "a consumer who
+      // names a ceiling has named THE ceiling" — applied to the other one.
+      //
+      // It is also what makes the diagnostic quiet enough to keep: checking
+      // every store took out four of this package's own capacity tests, which
+      // set tiny limits deliberately to exercise eviction. Those stores really
+      // will thrash, so the warning was true — and useless, because thrashing
+      // was the point.
+      if (config.foldCacheLimit !== undefined) return;
+      const foldCount = Object.keys(config.folds).length;
+      if (foldCount === 0) return;
+      const limit = cache.stats().limit;
+      if (limit <= 0) return;
+      const nodeCount = candidate.nodesById.size;
+      if (foldCount * nodeCount <= limit) return;
+      warnedAboutCacheSize = true;
+      const servable = Math.floor(limit / foldCount);
+      console.error(
+        `keel: this graph holds ${nodeCount} nodes and ${foldCount} fold(s) are registered, ` +
+          `but foldCacheLimit (${limit}) covers only ${servable} nodes. Past that the memo ` +
+          `table thrashes and every rollup refolds from scratch — measurably slower than no ` +
+          `cache at all. Raise EngineConfig.foldCacheLimit to at least ${foldCount * nodeCount} ` +
+          `(folds x nodes). EngineConfig.onFoldCacheStats reports evictions if you want to watch it.`,
+      );
+    };
+    warnIfCacheCannotCover(initialGraph);
 
     // Handed out here, before the store exists and before any fold can run, so
     // a consumer that wants the counters has them from the first `aggregate`
@@ -428,6 +517,9 @@ export function createEngine<
 
       graph = next;
       auditIfDev(label, next);
+      // A graph grows; the table does not. Latched, so this is one integer
+      // compare behind a boolean after the first crossing.
+      warnIfCacheCannotCover(next);
 
       const selectionChanged = pruneSelection();
 

--- a/packages/keel-core/history.ts
+++ b/packages/keel-core/history.ts
@@ -312,7 +312,9 @@ export function coalesceEntries<Ts extends readonly unknown[], S>(
  * their own edit to the one overwritten node — correct, the server has since
  * overwritten it — and keeps every other entry, in order, fully invertible.
  *
- * Cost is O(entries x changes), bounded by `historyLimit`.
+ * Cost is O(entries x changes). `historyLimit` bounds `entries` only when a
+ * consumer SET one — it defaults to unbounded, so by default the bound named
+ * here is the one that does not exist.
  */
 export function scrubHistoryForIngest<Ts extends readonly unknown[], S>(
   history: History<Ts, S>,

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -1352,7 +1352,8 @@ export function isEmptyPatch<Ts extends readonly unknown[], S>(
  *
  * The alternative shipped in a predecessor design — a version stamp that
  * invalidates the whole entry — means every remote write destroys undo from
- * that entry down. This costs O(historyLimit x changes) and destroys one node's
+ * that entry down. This costs O(entries x changes), where `historyLimit` bounds `entries` only
+ * when a consumer set one, and destroys one node's
  * worth.
  *
  * Returns null when the patch is left empty, and the caller drops the entry.

--- a/packages/keel-core/review3-the-two-default-ceilings-agree.test.ts
+++ b/packages/keel-core/review3-the-two-default-ceilings-agree.test.ts
@@ -1,0 +1,301 @@
+// Third review round, bounds sweep — two defaults that contradict each other,
+// and a comment that claims they cannot.
+//
+// `DEFAULT_MAX_NODES` is 100,000. Its doc comment argues that number is safe
+// partly because it sits "above the 16,384 the fold cache is sized to hold, so
+// the two ceilings cannot contradict each other: no document that loads is one
+// the memo table then silently refuses to serve."
+//
+// The premise IS the contradiction. The table holds `foldCacheLimit / folds`
+// NODES, not 16,384 nodes unconditionally. `DEFAULT_FOLD_CACHE_LIMIT` is
+// 8 x 16,384 = 131,072 ENTRIES, and ./folds names an 8-fold registry as
+// realistic — so 16,384 nodes IS the default table's node capacity, and the
+// node ceiling admits 6.1x that.
+//
+// MEASURED through the public surface, 8 folds, one root with N clip children,
+// eight root `aggregate` reads performed twice:
+//
+//   16,000 nodes   evictions 0        second pass 8/8 hits     0.118 ms
+//   20,001 nodes   evictions 188,944  second pass 0/8 hits     5,542 ms
+//   20,001 nodes, cache sized to fit   evictions 0   8/8 hits  0.017 ms
+//
+// 20,001 nodes is FIVE TIMES UNDER the node ceiling and `deserialize` accepts
+// it. The repeat costs 5.5 seconds instead of 17 microseconds, and it is worse
+// than having no cache at all, because every `set` also runs the eviction loop.
+// That is exactly the "LRU INVERTS" failure ./folds describes as the thing its
+// sizing exists to prevent, on a document the engine's own default permits.
+//
+// The fix is a DIAGNOSTIC, not a new ceiling. `createEngine` is the one place
+// both numbers are in hand — it already walks `config.folds` for the
+// duplicate-key check — and raising either default would trade a silent stall
+// for a silent memory cost. `stats()` exists because this failure has no other
+// symptom; this makes it audible at construction instead of at 20,000 nodes.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { foldMonoid, DEFAULT_FOLD_CACHE_LIMIT } from "./folds";
+import { DEFAULT_MAX_NODES } from "./serialize";
+import { createEngine } from "./engine";
+
+type Clip = Readonly<{ title: string; seconds: number }>;
+const clipType = defineNodeType<Clip, Readonly<{ title?: string }>>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const seconds = record["seconds"];
+    if (typeof title !== "string" || typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$", message: "shape" }] };
+    }
+    return { ok: true, value: { title, seconds } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, seconds: data.seconds };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+const folderType = defineNodeType<Folder, Readonly<{ name?: string }>>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const n = record["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+function foldsNamed(count: number) {
+  const folds: Record<string, ReturnType<typeof foldMonoid<Types, Summary, number>>> = {};
+  for (let i = 0; i < count; i += 1) {
+    folds[`f${i}`] = foldMonoid<Types, Summary, number>({
+      key: `f${i}`,
+      empty: 0,
+      leaf(node) {
+        return node.kind === "clip" ? node.data.seconds : 0;
+      },
+      concat(a, b) {
+        return a + b;
+      },
+    });
+  }
+  return folds;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function captureErrors() {
+  return vi.spyOn(console, "error").mockImplementation(() => undefined);
+}
+
+function docOf(n: number) {
+  const children: string[] = [];
+  const nodes: unknown[] = [];
+  for (let i = 0; i < n; i += 1) children.push(`c${i}`);
+  nodes.push({ id: "root", kind: "folder", data: { name: "R" }, children });
+  for (const id of children) {
+    nodes.push({ id, kind: "clip", data: { title: id, seconds: 1 } });
+  }
+  return { formatVersion: 1, schemaVersions: { clip: 1, folder: 1 }, rootIds: ["root"], nodes };
+}
+
+function storeOf(
+  foldCount: number,
+  nodes: number,
+  config?: Readonly<{ foldCacheLimit?: number }>,
+) {
+  const folds = foldsNamed(foldCount);
+  const engine = createEngine<Types, Summary, typeof folds>({
+    types,
+    summary,
+    folds,
+    ...(config?.foldCacheLimit === undefined
+      ? {}
+      : { foldCacheLimit: config.foldCacheLimit }),
+  });
+  const loaded = engine.deserialize(docOf(nodes - 1));
+  if (!loaded.ok) throw new Error("fixture failed to deserialize");
+  return { engine, graph: loaded.value.graph };
+}
+
+describe("the store says so when the memo table cannot cover its graph", () => {
+  it("warns when folds x nodes exceeds the table", () => {
+    const { engine, graph } = storeOf(8, 20_001);
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).toHaveBeenCalled();
+    const message = String(spy.mock.calls[0]?.[0] ?? "");
+    // The number a consumer acts on is the size it stops covering, so the
+    // message has to carry it rather than just saying "too small".
+    expect(message).toContain("16384");
+    expect(message).toContain("foldCacheLimit");
+  });
+
+  it("stays silent when the table covers the graph", () => {
+    const { engine, graph } = storeOf(8, 16_000);
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent for a small graph, whatever the CEILINGS say", () => {
+    // The condition that produced twelve false positives: comparing maxNodes
+    // against the table rather than the graph. A 200-node document with 8
+    // folds is fine and must not be scolded, even though 8 x maxNodes is far
+    // above the default table.
+    const { engine, graph } = storeOf(8, 200);
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent whenever the consumer named the limit themselves", () => {
+    // ./fold-cache-capacity.test.ts sets tiny limits on purpose to exercise
+    // eviction. Those stores really do thrash — the warning would be TRUE and
+    // useless, because thrashing is the point. A named number is a choice.
+    const { engine, graph } = storeOf(8, 20_001, { foldCacheLimit: 4 });
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when caching is deliberately disabled", () => {
+    const { engine, graph } = storeOf(8, 20_001, { foldCacheLimit: 0 });
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent for a registry with no folds at all", () => {
+    const engine = createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+    const loaded = engine.deserialize(docOf(20_000));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const spy = captureErrors();
+    engine.createStore(loaded.value.graph);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("warns at most ONCE, however far the graph grows", () => {
+    const { engine, graph } = storeOf(8, 20_001);
+    const spy = captureErrors();
+    const store = engine.createStore(graph);
+    for (let i = 0; i < 3; i += 1) {
+      store.dispatch({
+        type: "insert-nodes",
+        toParentId: parseNodeId("root"),
+        toIndex: 0,
+        seeds: [{ kind: "clip", data: { title: `x${i}`, seconds: 1 } }],
+      });
+    }
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns when a graph GROWS past what the table covers", () => {
+    // Under the default table at load, over it after a few inserts — the case
+    // a load-time-only check would miss entirely. 8 folds makes the default
+    // cover 16,384 nodes, so this sits just under it and then crosses.
+    const { engine, graph } = storeOf(8, 16_380);
+    const spy = captureErrors();
+    const store = engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+    for (let i = 0; i < 8; i += 1) {
+      store.dispatch({
+        type: "insert-nodes",
+        toParentId: parseNodeId("root"),
+        toIndex: 0,
+        seeds: [{ kind: "clip", data: { title: `g${i}`, seconds: 1 } }],
+      });
+    }
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("the two package defaults do disagree at a realistic fold count", () => {
+    // Stated as an executable fact rather than left in a comment, because the
+    // comment that used to describe this relationship was wrong.
+    const realisticFolds = 8;
+    expect(realisticFolds * DEFAULT_MAX_NODES).toBeGreaterThan(
+      DEFAULT_FOLD_CACHE_LIMIT,
+    );
+    expect(Math.floor(DEFAULT_FOLD_CACHE_LIMIT / realisticFolds)).toBe(16_384);
+  });
+});
+
+describe("historyLimit says what it does", () => {
+  it("refuses a limit that is not a positive integer", () => {
+    for (const bad of [0, -1, 2.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() =>
+        createEngine<Types, Summary, {}>({
+          types,
+          summary,
+          folds: {},
+          historyLimit: bad,
+        }),
+      ).toThrow(/historyLimit/);
+    }
+  });
+
+  it("accepts a positive integer, and omission still means unbounded", () => {
+    expect(() =>
+      createEngine<Types, Summary, {}>({
+        types,
+        summary,
+        folds: {},
+        historyLimit: 3,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      createEngine<Types, Summary, {}>({ types, summary, folds: {} }),
+    ).not.toThrow();
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -117,9 +117,25 @@ function isWireChildrenState(value: unknown): value is WireChildrenState {
  * (9.57 ms for 10,000), so 100,000 is where one document crosses ~100 ms of
  * blocking parse and becomes a visible hitch rather than a load. That is an
  * order of magnitude above the 10,000-node document those fixtures treat as
- * realistic, and above the 16,384 the fold cache is sized to hold, so the two
- * ceilings cannot contradict each other: no document that loads is one the
- * memo table then silently refuses to serve.
+ * realistic.
+ *
+ * THIS NUMBER AND `DEFAULT_FOLD_CACHE_LIMIT` DO NOT AGREE, and an earlier
+ * version of this comment claimed the opposite — that 100,000 sits "above the
+ * 16,384 the fold cache is sized to hold, so the two ceilings cannot
+ * contradict each other". The premise was the contradiction. That table holds
+ * `foldCacheLimit / folds` NODES, not 16,384 unconditionally: the default is
+ * 8 x 16,384 ENTRIES, and ./folds names an 8-fold registry as realistic, so
+ * 16,384 nodes IS the default table's capacity and this ceiling admits 6.1x
+ * it. MEASURED at 20,001 nodes with 8 folds — five times under this number,
+ * and accepted by `deserialize`: 188,944 evictions, zero cache hits on an
+ * identical repeat, 5,542 ms against 0.017 ms with the table sized to fit.
+ *
+ * The two are INDEPENDENT numbers describing one graph, and that is fine as
+ * long as somebody notices when they disagree. `createEngine` compares them
+ * and says so — see the diagnostic there. They are deliberately not derived
+ * from one another: sizing the table from this ceiling would cost ~186 MB by
+ * default, and lowering this ceiling to the table's capacity would refuse
+ * documents that load today.
  *
  * A ceiling, not a target. It exists so that an unbounded payload cannot
  * decide this process's memory, and it should never fire on real data — a


### PR DESCRIPTION
Found by a sweep for the **class** the three ceiling defects in #578 share — a bound this package documents and doesn't enforce everywhere. This one is worse than unenforced: it was documented as *impossible*.

`DEFAULT_MAX_NODES` is 100,000, and its comment argued that's safe partly because it sits *"above the 16,384 the fold cache is sized to hold, so the two ceilings cannot contradict each other."*

**The premise is the contradiction.** The table holds `foldCacheLimit / folds` **nodes**, not 16,384 unconditionally. The default is 8 × 16,384 **entries**, and `folds.ts` names an 8-fold registry as realistic — so 16,384 nodes *is* the default table's capacity, and the node ceiling admits **6.1× it**.

Measured through the public surface, 8 folds, eight root rollup reads repeated:

| nodes | evictions | 2nd-pass hits | time |
|---|---|---|---|
| 16,000 | 0 | 8/8 | 0.118 ms |
| **20,001** | 188,944 | **0/8** | **5,542 ms** |
| 20,001, table sized to fit | 0 | 8/8 | 0.017 ms |

20,001 is **5× under the node ceiling** and `deserialize` accepts it. Worse than no cache at all, because every `set` also runs the eviction loop — precisely the "LRU INVERTS" failure `folds.ts` says its sizing exists to prevent.

A **diagnostic**, not a new ceiling: deriving the table from `maxNodes` would size it at ~186 MB by default, and lowering `maxNodes` would refuse documents that load today.

## Two corrections to where the check lives

Both from running it rather than reasoning about it.

**It started at `createEngine`, comparing the two ceilings** — where both numbers are in hand, and what I proposed. It fired for **twelve** of this package's own fixtures. A consumer whose documents are 500 nodes doesn't care that a ceiling they'll never reach exceeds a table they'll never fill. The real condition is "this table cannot cover *this* graph", and only a store knows that — so it moved to `createStore`, and to `commitGraph` latched, because a graph grows and a load-time-only check misses that.

**That still left four**, all from `fold-cache-capacity.test.ts`, which sets tiny limits deliberately to exercise eviction. Those stores really do thrash, so the warning was **true and useless** — thrashing was the point. It now fires only when `foldCacheLimit` was *not* set, which is the rule `maxNodes` already states a few lines away: *a consumer who names a ceiling has named THE ceiling.* Noise is now **zero**.

## Also from the same sweep

`historyLimit` mapped `0`, negatives, fractions and `NaN` to **Infinity**. The comment argues against hiding a typo — true — but Infinity hides it too, in the one direction that's unsafe: the consumer asked to bound memory and got no bound. Measured: `historyLimit: 2.5` retained **200** entries. `createEngine` now throws, like the duplicate kind and duplicate fold key beside it. Omission still means unbounded.

Three comments described the ingest scrub as "bounded by `historyLimit`" when that defaults to unbounded — so the bound named was the one that doesn't exist. Corrected in `commands.ts`, `history.ts`, `patches.ts`.

## Verification

| | |
|---|---|
| Regression tests | 11, of which **2 failed** against the original code |
| Mutation proof | coverage warning 3 · commit re-check 1 · named-limit exemption 1 · historyLimit 1 |
| Unit suite | 1,400 tests / 70 files |
| Diagnostic output across the whole suite | **0 lines** |
| Stories | 9 pass, headless Chromium |
| `tsc` | clean, both packages |

Six of the eleven tests are over-refusal guards, because a diagnostic that cries wolf gets muted — and then the real one isn't heard either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)