### PR TITLE
Two write paths stop re-indexing the whole document

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -42,6 +42,7 @@ import {
   tryParseNodeId,
 } from "./types";
 import {
+  dataChangeLeavesDerivedIndexesIntact,
   ownsItsSubtree,
   ancestorChain,
   bumpSubtreeRevs,
@@ -1415,13 +1416,43 @@ export function applyIngestEdits<Ts extends readonly unknown[], S>(
     // chain per node rather than a move's two.
     subtreeRevById: bumpSubtreeRevs(graph.subtreeRevById, graph, editedIds),
   };
-  const nextGraph: Graph<Ts, S> = {
-    ...withNodes,
-    // A `contentKey` or `sourceKey` can move with the data, so both derived
-    // indexes are rebuilt — the same thing `applyPatch` does after a
-    // "data-changed" patch.
-    ...rebuildDerivedIndexes(withNodes, ctx.registry),
-  };
+  // A `contentKey` or `sourceKey` can move with the data, so the indexes may
+  // need rebuilding — but only when a key ACTUALLY moved. This used to rebuild
+  // unconditionally, and the comment that stood here claimed it was doing "the
+  // same thing `applyPatch` does after a 'data-changed' patch". That stopped
+  // being true when `applyPatch`'s data arm gained its guard; the comment had
+  // become a description of the defect rather than of the code.
+  //
+  // MEASURED before this guard, counting `contentKey` on a key-preserving
+  // one-node write: ingest asked 1,000 / 10,000 / 40,000 times at those sizes —
+  // exactly the reachable node count, a whole document-order DFS — while
+  // `edit-nodes` asked 2, flat. Per CALL, not per edit: a batch of twenty still
+  // cost one full walk. This is the path an arriving thumbnail lands on, which
+  // makes it the highest-frequency write in the system.
+  //
+  // The soundness argument is the one ./patches already makes for the same
+  // predicate, and it is STRICTLY STRONGER here: ingest touches only `data`, so
+  // document order cannot change (no bucket's ORDER can move) and no node's
+  // `ownsItsSubtree` can change (no owner can move). Where the patch arm must
+  // also tolerate changes it skipped, `planEdits` refuses a quarantined node
+  // outright — so every plan here really was applied, and the predicate is
+  // evaluated over exactly the nodes that changed.
+  //
+  // On the no-move path both maps carry forward BY IDENTITY, which is what
+  // `walkDerivedIndexes` asks for: a consumer memoising on
+  // `placementsByContentKey` stops churning on every server write.
+  const movesAKey = plans.some(
+    (plan) =>
+      !dataChangeLeavesDerivedIndexesIntact(
+        ctx.registry,
+        plan.kind,
+        plan.before,
+        plan.after,
+      ),
+  );
+  const nextGraph: Graph<Ts, S> = movesAKey
+    ? { ...withNodes, ...rebuildDerivedIndexes(withNodes, ctx.registry) }
+    : withNodes;
 
   const replacements = new Map<NodeId, unknown>(
     plans.map((plan) => [plan.nodeId, plan.after]),

--- a/packages/keel-core/move-cost.test.ts
+++ b/packages/keel-core/move-cost.test.ts
@@ -521,13 +521,61 @@ describe("derived index cost", () => {
     expect(next.ownerBySourceKey.get("src-c0")).toBe(nid("c0"));
   });
 
-  it("looks at only the reordered subtree, not the document", () => {
-    const graph = wideGraph(20, 20); // 400 clips
+  it("asks once per node that TRAVELLED, not once per sibling", () => {
+    // THE BILL IS THE MOVED SUBTREE. Held at three strip widths, because a
+    // per-width bound cannot tell "the moved subtree" apart from "the strip
+    // happened to be 20 wide" — which is exactly what the previous version of
+    // this test asserted, and why it passed while the commonest drag in the
+    // product paid for every sibling beside it.
+    const widths = [5, 20, 50] as const;
+    const counts = widths.map((width) => {
+      const graph = wideGraph(20, width);
+      resetCodecCounters();
+      commit(graph, reorderWithin("c0", "c0-m0", 0, 3));
+      return contentKeyCalls;
+    });
+    // One clip moved, one clip asked, whatever it was standing next to.
+    expect(counts).toEqual([1, 1, 1]);
+  });
+
+  it("charges a reorder the same as a cross-parent move of the same node", () => {
+    // The two gestures move one leaf; only the destination differs. They cost
+    // the same because the SCOPE is the same, and a reorder used to cost the
+    // whole sibling list while the cross-parent move already cost one.
+    const graph = wideGraph(20, 20);
+
     resetCodecCounters();
     commit(graph, reorderWithin("c0", "c0-m0", 0, 5));
-    // Exactly the 20 clips inside `c0`. The from-scratch rebuild this replaced
-    // asked all 400, every drag.
-    expect(contentKeyCalls).toBe(20);
+    const withinCalls = contentKeyCalls;
+
+    resetCodecCounters();
+    commit(graph, moveAcross("c0", "c1", "c0-m0", 0, 0));
+    const acrossCalls = contentKeyCalls;
+
+    expect(withinCalls).toBe(acrossCalls);
+  });
+
+  it("does not charge a COLLECTION reorder for the whole document", () => {
+    // The worst case, and the one no previous test covered: reordering a
+    // collection under the root made the scope root the DOCUMENT root, so the
+    // cheap path was skipped and every node in the graph was asked for its key.
+    const small = wideGraph(10, 20); // 200 clips + 10 folders
+    resetCodecCounters();
+    commit(small, reorderWithin("root", "c0", 0, 5));
+    const smallCalls = contentKeyCalls;
+
+    const large = wideGraph(20, 20); // 400 clips + 20 folders
+    resetCodecCounters();
+    commit(large, reorderWithin("root", "c0", 0, 5));
+    const largeCalls = contentKeyCalls;
+
+    // The moved subtree is one folder and its 20 clips in both graphs, so the
+    // count must not move when the document doubles.
+    expect(smallCalls).toBe(largeCalls);
+    // 20, not 21: only the clip kind defines `contentKey`, so the folder that
+    // actually moved contributes nothing to the index and is never asked. The
+    // bill is the moved subtree's KEYED nodes.
+    expect(largeCalls).toBe(20);
   });
 
   it("keeps placementsByContentKey identical when a reorder cannot move it", () => {

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -393,19 +393,21 @@ function placementsAfterMove<Ts extends readonly unknown[], S>(
   // otherwise send the emptiest possible patch down the most expensive path.
   if (moves.length === 0) return previous;
 
-  const scopeRootId = soleReorderParent(moves);
-  if (scopeRootId !== null) {
-    const scoped = reindexPlacementsWithinSubtree(post, registry, previous, scopeRootId);
-    // `null` is "declined", not "invalid" — the incremental path found the
-    // previous index disagreeing with the graph and refused to guess.
-    if (scoped !== null) return scoped;
-  }
-
-  // A cross-parent move — or a scoped reorder that declined. Reposition what
-  // travelled instead of rediscovering what did not: the scope of a move is the
-  // moved subtrees, and every node outside them holds its relative order. See
-  // `reindexPlacementsAcrossMove` for why that is true rather than merely
-  // plausible.
+  // THE MOVED SET FIRST. Reposition what travelled instead of rediscovering
+  // what did not: the scope of a move is the moved subtrees, and every node
+  // outside them holds its relative order. `reindexPlacementsAcrossMove` proves
+  // that rather than assuming it, and its argument — take any two nodes,
+  // neither in a moved subtree — never assumes the parents DIFFER, so it covers
+  // a same-parent reorder unchanged.
+  //
+  // This used to run second, after the scoped path, and the engine therefore
+  // declined to use its own conclusion for exactly the gesture that needs it
+  // most. MEASURED, counting `contentKey`: a clip reorder inside a strip cost
+  // strip-width + 1 (21 for a 20-wide strip, 201 for a 200-wide one) while the
+  // same clip moved to ANOTHER strip cost 1 — the same node, the same distance,
+  // the same work, two orders of magnitude apart. Worse, reordering a
+  // COLLECTION under the root made the scope root the document root, so it
+  // walked the ENTIRE graph: 10,501 calls on a 10,501-node board, every drag.
   const repositioned = reindexPlacementsAcrossMove(
     post,
     registry,
@@ -413,6 +415,20 @@ function placementsAfterMove<Ts extends readonly unknown[], S>(
     moves.map((move) => move.nodeId),
   );
   if (repositioned !== null) return repositioned;
+
+  // The scoped reorder is now the FALLBACK, for a same-parent batch the moved
+  // set declined — which it does when `previous` disagrees with the graph, not
+  // when the move is unusual. Kept rather than deleted because it answers from
+  // a different direction (the subtree that contains the change, rather than
+  // the nodes that moved) and can therefore still succeed where the other
+  // could not.
+  const scopeRootId = soleReorderParent(moves);
+  if (scopeRootId !== null) {
+    const scoped = reindexPlacementsWithinSubtree(post, registry, previous, scopeRootId);
+    // `null` is "declined", not "invalid" — the incremental path found the
+    // previous index disagreeing with the graph and refused to guess.
+    if (scoped !== null) return scoped;
+  }
 
   return rebuildPlacementIndex(post, registry);
 }

--- a/packages/keel-core/performance.test.ts
+++ b/packages/keel-core/performance.test.ts
@@ -46,6 +46,7 @@ import { afterAll, describe, expect, it } from "vitest";
 import { performance } from "node:perf_hooks";
 
 import { createEngine } from "./engine";
+import { createHistory } from "./history";
 import { computeFold, createFoldCache, DEFAULT_FOLD_CACHE_LIMIT } from "./folds";
 import {
   defineNodeType,
@@ -1405,6 +1406,76 @@ describe("mutations", () => {
     expect(perEdit).toBeLessThanOrEqual(2);
 
     expectSubQuadratic(perOp, "content edit");
+  }, 120_000);
+
+  /**
+   * THE SERVER-WRITE PATH, held to the same bill as the user-intent one.
+   *
+   * `applyIngestEdits` rebuilt BOTH derived indexes unconditionally, ignoring
+   * the check `applyPatch`'s data arm has used since it shipped. Its comment
+   * claimed parity with that arm — "the same thing `applyPatch` does after a
+   * 'data-changed' patch" — which stopped being true when the arm gained its
+   * guard, so the comment had become a description of the defect.
+   *
+   * MEASURED before the guard, counting `contentKey` on a key-preserving
+   * one-node write: ingest asked 1,000 / 10,000 / 40,000 times at those three
+   * sizes — exactly the reachable node count, a full document-order DFS — while
+   * `edit-nodes` asked 2, flat. Per CALL, not per edit: a batch of twenty still
+   * cost one whole walk.
+   *
+   * This is the path a thumbnail lands on.
+   */
+  it("a key-preserving ingest re-indexes no more than the equivalent command", () => {
+    const ingestReindexed = new Map<string, number>();
+    const editReindexed = new Map<string, number>();
+
+    for (const fx of wideSizes) {
+      const clips = firstFolderClips(fx);
+      const target = at(clips, 0, "clips");
+      // `seconds` is not what `contentKey` reads, so this write cannot move
+      // either index — the shape of a duration or a thumbnail arriving.
+      const edits = [
+        { nodeId: target, kind: "clip", edit: { seconds: 99 } },
+      ] as const;
+
+      const ingestCounts = countOnce(() => {
+        engine.applyIngest(fx.graph, createHistory<Types, Summary>(), edits);
+      });
+      ingestReindexed.set(
+        fx.label,
+        noteCount(
+          "ingest (key-preserving)",
+          fx.label,
+          fx.nodeCount,
+          "contentKey",
+          ingestCounts.contentKey,
+        ),
+      );
+
+      const editCounts = countOnce(() => {
+        engine.applyCommand(fx.graph, { type: "edit-nodes", edits: [...edits] });
+      });
+      editReindexed.set(fx.label, editCounts.contentKey);
+    }
+
+    // The claim is INDEPENDENCE, asserted at three sizes, because a per-size
+    // bound cannot tell a constant apart from a number that happens to be small
+    // at the size being looked at.
+    const perIngest = expectIndependentOfGraphSize(
+      ingestReindexed,
+      "ingest content-key lookups",
+    );
+    // Two per edited node — its key before and after — which is exactly what
+    // the command path above is already held to.
+    expect(perIngest).toBeLessThanOrEqual(2);
+
+    // And stated as a relationship, not two separate numbers: the IO door must
+    // not cost more than the user-intent door for the same write.
+    for (const fx of wideSizes) {
+      expect(ingestReindexed.get(fx.label)).toBeLessThanOrEqual(
+        editReindexed.get(fx.label) ?? 0,
+      );
+    }
   }, 120_000);
 });
 


### PR DESCRIPTION
Both are the same mistake in different places: rediscovering what didn't move. Both measured by **codec-call count** — exact and machine-independent — rather than by clock.

## 1. A reorder paid for every sibling it stood next to

`placementsAfterMove` tried the O(scope) path before the O(moved) one, so a same-parent reorder was re-indexed against the whole subtree containing it, while the same node moved to *another* parent cost one call.

| gesture | `contentKey` calls |
|---|---|
| clip reorder, 20-wide strip | 21 |
| clip reorder, 200-wide strip | 201 |
| same clip moved to another strip | **1** |
| **collection reorder under the root** | **the entire document** (10,501 on a 10,501-node board) |

That last row is the one that matters and the one no test covered: a collection's scope root *is* the document root, so dragging a folder walked everything, every drag.

The fix is a **pure reordering of three existing calls** — no helper changed. The argument was already written in this file and in `graph.ts`: *"a move's scope is what MOVED"*, and `reindexPlacementsAcrossMove`'s proof never assumes the parents differ, so it covers a same-parent reorder unchanged. The engine was declining to use its own conclusion for exactly the gesture that needs it most.

**The old gate is why this survived.** It asserted `contentKeyCalls === 20` on a 20-wide strip — which cannot tell "the moved subtree" apart from "the strip happened to be 20 wide". It now runs at three widths and asserts the count doesn't move, plus a test tying a reorder to the cross-parent move of the same node: same work, same bill.

## 2. The server-write path rebuilt both indexes on every call

`applyIngestEdits` ignored the check `applyPatch`'s data arm has used since it shipped.

| nodes | `ingest` | `edit-nodes` |
|---|---|---|
| 1,000 | 1,000 | 2 |
| 10,000 | 10,000 | 2 |
| 40,000 | **40,000** | 2 |

Exactly the reachable node count — a whole document-order DFS — and **per call, not per edit**: a batch of twenty still cost one full walk. This is the path an arriving thumbnail lands on.

**The comment that stood there described the defect rather than the code.** It claimed both indexes are rebuilt *"the same thing `applyPatch` does after a 'data-changed' patch"* — true when written, false from the moment that arm gained its guard. That's this codebase's signature failure mode, and it's now six for six this review round.

Soundness is the argument `patches.ts` already makes for the same predicate, and it's *stronger* here: ingest touches only `data`, so document order can't change and no node's `ownsItsSubtree` can change. Where the patch arm must tolerate changes it skipped, `planEdits` refuses a quarantined node outright.

Side benefit the index's own doc comment asks for: on the no-move path both maps carry forward **by identity**, so a consumer memoising on `placementsByContentKey` stops churning on every server write.

## Honest about the shape

The raw ratios oversell this. **It's a constant factor, not an asymptotic change.** `edit-nodes` already tracks a linear reference almost exactly, because every write copies `nodesById` and `subtreeRevById`. The rebuild roughly *doubled* a write that was already linear (2.0–2.2× measured on the store path); it did not turn a constant into a linear.

The asymptotic question is the map copies — [#580](https://github.com/josulliv101/storyboard-flow/issues/580), untouched here.

A registry defining neither key pays nothing either way, since `walkDerivedIndexes` early-returns the shared empties. This only bites a consumer who opted into a key, which the product's registry does.

## Verification

| | |
|---|---|
| Mutation proof | move reordering → 5 fail (3 new + 2 existing cross-parent gates) · ingest guard → 1 |
| Unit suite | 1,403 tests / 70 files |
| Stories | 9 pass, headless Chromium |
| `tsc` | clean, both packages |

Still to come from the same measurement round: `applyInserted` rebuilding on any keyed node (40,002 calls to insert one clip into 40k), and tombstone pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)