### PR TITLE
An insert re-indexes what arrived, not the document

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -42,6 +42,7 @@ import {
   tryParseNodeId,
 } from "./types";
 import {
+  dataChangeLeavesDerivedIndexesIntact,
   ownsItsSubtree,
   ancestorChain,
   bumpSubtreeRevs,
@@ -1415,13 +1416,43 @@ export function applyIngestEdits<Ts extends readonly unknown[], S>(
     // chain per node rather than a move's two.
     subtreeRevById: bumpSubtreeRevs(graph.subtreeRevById, graph, editedIds),
   };
-  const nextGraph: Graph<Ts, S> = {
-    ...withNodes,
-    // A `contentKey` or `sourceKey` can move with the data, so both derived
-    // indexes are rebuilt — the same thing `applyPatch` does after a
-    // "data-changed" patch.
-    ...rebuildDerivedIndexes(withNodes, ctx.registry),
-  };
+  // A `contentKey` or `sourceKey` can move with the data, so the indexes may
+  // need rebuilding — but only when a key ACTUALLY moved. This used to rebuild
+  // unconditionally, and the comment that stood here claimed it was doing "the
+  // same thing `applyPatch` does after a 'data-changed' patch". That stopped
+  // being true when `applyPatch`'s data arm gained its guard; the comment had
+  // become a description of the defect rather than of the code.
+  //
+  // MEASURED before this guard, counting `contentKey` on a key-preserving
+  // one-node write: ingest asked 1,000 / 10,000 / 40,000 times at those sizes —
+  // exactly the reachable node count, a whole document-order DFS — while
+  // `edit-nodes` asked 2, flat. Per CALL, not per edit: a batch of twenty still
+  // cost one full walk. This is the path an arriving thumbnail lands on, which
+  // makes it the highest-frequency write in the system.
+  //
+  // The soundness argument is the one ./patches already makes for the same
+  // predicate, and it is STRICTLY STRONGER here: ingest touches only `data`, so
+  // document order cannot change (no bucket's ORDER can move) and no node's
+  // `ownsItsSubtree` can change (no owner can move). Where the patch arm must
+  // also tolerate changes it skipped, `planEdits` refuses a quarantined node
+  // outright — so every plan here really was applied, and the predicate is
+  // evaluated over exactly the nodes that changed.
+  //
+  // On the no-move path both maps carry forward BY IDENTITY, which is what
+  // `walkDerivedIndexes` asks for: a consumer memoising on
+  // `placementsByContentKey` stops churning on every server write.
+  const movesAKey = plans.some(
+    (plan) =>
+      !dataChangeLeavesDerivedIndexesIntact(
+        ctx.registry,
+        plan.kind,
+        plan.before,
+        plan.after,
+      ),
+  );
+  const nextGraph: Graph<Ts, S> = movesAKey
+    ? { ...withNodes, ...rebuildDerivedIndexes(withNodes, ctx.registry) }
+    : withNodes;
 
   const replacements = new Map<NodeId, unknown>(
     plans.map((plan) => [plan.nodeId, plan.after]),

--- a/packages/keel-core/graph.ts
+++ b/packages/keel-core/graph.ts
@@ -1000,6 +1000,144 @@ export function reindexPlacementsAcrossMove<Ts extends readonly unknown[], S>(
 }
 
 /**
+ * `placementsByContentKey` after an INSERT, updated rather than rebuilt.
+ *
+ * The mirror of `reindexPlacementsAcrossMove`, minus its lift-out step: an
+ * arriving node is not in `previous` at all, so there are no survivors to
+ * separate from movers — only arrivals to merge into buckets that are already
+ * in order.
+ *
+ * Sound for the same reason the move case is: an insert cannot REORDER anything
+ * that was already there. Splicing an id into a children array shifts later
+ * siblings within document order but preserves every pre-existing node's order
+ * relative to every other, so each existing bucket stays sorted and the only
+ * new entries are the arrivals' own.
+ *
+ * ONE DIFFERENCE FROM THE MOVE CASE, and it is the only place the two diverge:
+ * an absent bucket here means a brand-new key, which is ordinary and gets set.
+ * There, an absent bucket meant `previous` disagreed with the graph, and the
+ * answer was to decline.
+ *
+ * `null` is "declined", on the same terms as its neighbours — a comparator that
+ * cannot rank two ids, or an arriving id already sitting in the bucket, which
+ * would mean this was not an insert of new nodes.
+ */
+export function placementsAfterInsert<Ts extends readonly unknown[], S>(
+  post: Graph<Ts, S>,
+  registry: NodeTypeRegistry,
+  previous: ReadonlyMap<string, readonly NodeId[]>,
+  arrived: readonly AnyNode<Ts, S>[],
+): ReadonlyMap<string, readonly NodeId[]> | null {
+  // THE ONLY codec calls this function makes: one per ARRIVING node. Every
+  // other node's key is not merely unchanged but irrelevant — `contentKey`
+  // reads `data`, and an insert does not touch anybody else's.
+  const arrivalsByKey = new Map<string, NodeId[]>();
+  for (const node of arrived) {
+    const contentKey = contentKeyOf(registry, node);
+    if (contentKey === null) continue;
+    const bucket = arrivalsByKey.get(contentKey);
+    if (bucket === undefined) arrivalsByKey.set(contentKey, [node.id]);
+    else bucket.push(node.id);
+  }
+  // Nothing arriving carries a key, so the index is exactly what it was. By
+  // reference, which is what `insertLeavesDerivedIndexesIntact` bought before
+  // this function existed and is worth keeping.
+  if (arrivalsByKey.size === 0) return previous;
+
+  const compare = documentOrderComparator(post);
+  const rewritten = new Map<string, readonly NodeId[]>();
+
+  for (const [contentKey, arrivals] of arrivalsByKey) {
+    let declined = false;
+    const ordered = arrivals.slice().sort((a, b) => {
+      const verdict = compare(a, b);
+      if (verdict === null) {
+        declined = true;
+        return 0;
+      }
+      return verdict;
+    });
+    if (declined) return null;
+
+    const bucket = previous.get(contentKey);
+    if (bucket === undefined) {
+      // A key nothing held before. Ordinary for an insert.
+      rewritten.set(contentKey, ordered);
+      continue;
+    }
+
+    const merged: NodeId[] = [];
+    let left = 0;
+    let right = 0;
+    while (left < bucket.length && right < ordered.length) {
+      const incumbent = bucket[left];
+      const arrival = ordered[right];
+      if (incumbent === undefined || arrival === undefined) break;
+      // An arriving id already in the bucket means this was not an insert of
+      // new nodes, and merging would duplicate it.
+      if (incumbent === arrival) return null;
+      const verdict = compare(incumbent, arrival);
+      if (verdict === null) return null;
+      if (verdict <= 0) {
+        merged.push(incumbent);
+        left += 1;
+      } else {
+        merged.push(arrival);
+        right += 1;
+      }
+    }
+    for (; left < bucket.length; left += 1) {
+      const incumbent = bucket[left];
+      if (incumbent === undefined) continue;
+      if (ordered.includes(incumbent)) return null;
+      merged.push(incumbent);
+    }
+    for (; right < ordered.length; right += 1) {
+      const arrival = ordered[right];
+      if (arrival !== undefined) merged.push(arrival);
+    }
+    rewritten.set(contentKey, merged);
+  }
+
+  const next = new Map(previous);
+  for (const [contentKey, bucket] of rewritten) next.set(contentKey, bucket);
+  return next;
+}
+
+/**
+ * `ownerBySourceKey` after an INSERT, updated rather than rebuilt.
+ *
+ * The mirror of `derivedIndexesAfterRemoval`'s owner half. Only a node that
+ * OWNS its subtree can claim a key — the same `ownsItsSubtree` predicate
+ * `walkDerivedIndexes` applies, so the incremental answer and the from-scratch
+ * one cannot disagree about who counts.
+ *
+ * An arrival colliding with an incumbent owner is `duplicate-owner`, which
+ * invariant check 8 refuses AHEAD of check 9's index comparison — the identical
+ * reprieve `rebuildPlacementIndex` and `derivedIndexesAfterRemoval` already
+ * take. So on any graph where carrying the map forward could disagree with a
+ * rebuild, the audit already names the real defect rather than a stale-index
+ * symptom of it.
+ */
+export function ownersAfterInsert<Ts extends readonly unknown[], S>(
+  registry: NodeTypeRegistry,
+  previous: ReadonlyMap<string, NodeId>,
+  arrived: readonly AnyNode<Ts, S>[],
+): ReadonlyMap<string, NodeId> {
+  let next: Map<string, NodeId> | null = null;
+  for (const node of arrived) {
+    if (!ownsItsSubtree<Ts, S>(node)) continue;
+    const sourceKey = sourceKeyOf<Ts, S>(registry, node);
+    if (sourceKey === null) continue;
+    if (previous.has(sourceKey)) continue;
+    if (next === null) next = new Map(previous);
+    if (!next.has(sourceKey)) next.set(sourceKey, node.id);
+  }
+  // Nothing claimed, so the map is what it was — by reference.
+  return next ?? previous;
+}
+
+/**
  * Both indexes after a removal, updated rather than rebuilt.
  *
  * Sound because a removal cannot REORDER anything: dropping ids leaves every

--- a/packages/keel-core/move-cost.test.ts
+++ b/packages/keel-core/move-cost.test.ts
@@ -521,13 +521,61 @@ describe("derived index cost", () => {
     expect(next.ownerBySourceKey.get("src-c0")).toBe(nid("c0"));
   });
 
-  it("looks at only the reordered subtree, not the document", () => {
-    const graph = wideGraph(20, 20); // 400 clips
+  it("asks once per node that TRAVELLED, not once per sibling", () => {
+    // THE BILL IS THE MOVED SUBTREE. Held at three strip widths, because a
+    // per-width bound cannot tell "the moved subtree" apart from "the strip
+    // happened to be 20 wide" — which is exactly what the previous version of
+    // this test asserted, and why it passed while the commonest drag in the
+    // product paid for every sibling beside it.
+    const widths = [5, 20, 50] as const;
+    const counts = widths.map((width) => {
+      const graph = wideGraph(20, width);
+      resetCodecCounters();
+      commit(graph, reorderWithin("c0", "c0-m0", 0, 3));
+      return contentKeyCalls;
+    });
+    // One clip moved, one clip asked, whatever it was standing next to.
+    expect(counts).toEqual([1, 1, 1]);
+  });
+
+  it("charges a reorder the same as a cross-parent move of the same node", () => {
+    // The two gestures move one leaf; only the destination differs. They cost
+    // the same because the SCOPE is the same, and a reorder used to cost the
+    // whole sibling list while the cross-parent move already cost one.
+    const graph = wideGraph(20, 20);
+
     resetCodecCounters();
     commit(graph, reorderWithin("c0", "c0-m0", 0, 5));
-    // Exactly the 20 clips inside `c0`. The from-scratch rebuild this replaced
-    // asked all 400, every drag.
-    expect(contentKeyCalls).toBe(20);
+    const withinCalls = contentKeyCalls;
+
+    resetCodecCounters();
+    commit(graph, moveAcross("c0", "c1", "c0-m0", 0, 0));
+    const acrossCalls = contentKeyCalls;
+
+    expect(withinCalls).toBe(acrossCalls);
+  });
+
+  it("does not charge a COLLECTION reorder for the whole document", () => {
+    // The worst case, and the one no previous test covered: reordering a
+    // collection under the root made the scope root the DOCUMENT root, so the
+    // cheap path was skipped and every node in the graph was asked for its key.
+    const small = wideGraph(10, 20); // 200 clips + 10 folders
+    resetCodecCounters();
+    commit(small, reorderWithin("root", "c0", 0, 5));
+    const smallCalls = contentKeyCalls;
+
+    const large = wideGraph(20, 20); // 400 clips + 20 folders
+    resetCodecCounters();
+    commit(large, reorderWithin("root", "c0", 0, 5));
+    const largeCalls = contentKeyCalls;
+
+    // The moved subtree is one folder and its 20 clips in both graphs, so the
+    // count must not move when the document doubles.
+    expect(smallCalls).toBe(largeCalls);
+    // 20, not 21: only the clip kind defines `contentKey`, so the folder that
+    // actually moved contributes nothing to the index and is never asked. The
+    // bill is the moved subtree's KEYED nodes.
+    expect(largeCalls).toBe(20);
   });
 
   it("keeps placementsByContentKey identical when a reorder cannot move it", () => {

--- a/packages/keel-core/move-cost.test.ts
+++ b/packages/keel-core/move-cost.test.ts
@@ -1015,6 +1015,72 @@ describe("insert / remove / edit commit cost", () => {
     ]);
   });
 
+  it("claims the sourceKey of an inserted OWNING container", () => {
+    // `ownersAfterInsert` is the half of the incremental insert that the fuzz
+    // cannot reach: it inserts clips, and a leaf owns nothing since ownership
+    // became a container-only property. Without this test, deleting the claim
+    // entirely fails NOTHING — which is how it was found.
+    const graph = wideGraph(4, 4);
+    expect(graph.ownerBySourceKey.has("src-fresh")).toBe(false);
+
+    const next = commit(graph, {
+      type: "inserted",
+      placements: [
+        {
+          node: makeCollectionNode<TestTypes, Summary>(
+            nid("fresh"),
+            "folder",
+            { name: "fresh", source: "src-fresh" },
+            { status: "loaded" },
+            null,
+          ),
+          parentId: nid("root"),
+          index: 0,
+        },
+      ],
+    });
+
+    expect(next.ownerBySourceKey.get("src-fresh")).toBe(nid("fresh"));
+    // And it agrees with the authoritative walk, which is the property the
+    // incremental path exists to preserve rather than merely approximate.
+    const fresh = rebuildDerivedIndexes(next, keyedRegistry);
+    expect(next.ownerBySourceKey).toEqual(fresh.ownerBySourceKey);
+  });
+
+  it("leaves an inserted container's key alone when someone already owns it", () => {
+    // A second owner is `duplicate-owner`, which invariant check 8 refuses
+    // AHEAD of check 9's index comparison — so the incremental path must not
+    // quietly reassign the key, and the audit names the real defect either way.
+    const graph = wideGraph(4, 4);
+    const incumbent = graph.ownerBySourceKey.get("src-c0");
+    expect(incumbent).toBe(nid("c0"));
+
+    const next = applyPatch(
+      graph,
+      {
+        type: "inserted",
+        placements: [
+          {
+            node: makeCollectionNode<TestTypes, Summary>(
+              nid("usurper"),
+              "folder",
+              { name: "usurper", source: "src-c0" },
+              { status: "loaded" },
+              null,
+            ),
+            parentId: nid("root"),
+            index: 0,
+          },
+        ],
+      },
+      makeCtx(keyedRegistry),
+    );
+
+    // The incumbent keeps the key. `commit` is not used here because this graph
+    // is deliberately in the state check 8 refuses.
+    expect(next.ownerBySourceKey.get("src-c0")).toBe(nid("c0"));
+  });
+
   it("updates the placement index on removal without touching other buckets", () => {
     const graph = buildGraph([
       {
@@ -1193,6 +1259,7 @@ describe("incremental indexes never diverge from a rebuild", () => {
     let reorders = 0;
     let reparents = 0;
     let removals = 0;
+    let inserts = 0;
     let edits = 0;
 
     for (let step = 0; step < 300; step += 1) {
@@ -1240,7 +1307,7 @@ describe("incremental indexes never diverge from a rebuild", () => {
           ],
         });
         reparents += 1;
-      } else if (roll < 0.9) {
+      } else if (roll < 0.88) {
         // Removal — the filtered-bucket path. Clips are leaves, so one
         // placement is the whole subtree.
         const node = graph.nodesById.get(nodeId);
@@ -1251,6 +1318,31 @@ describe("incremental indexes never diverge from a rebuild", () => {
         });
         assetOfClip.delete(String(nodeId));
         removals += 1;
+      } else if (roll < 0.94) {
+        // INSERT — the arriving-node path. Absent from this fuzz until the
+        // insert arm stopped rebuilding from scratch, which is precisely the
+        // change that made a differential check of it worth having: a
+        // from-scratch rebuild cannot diverge from a from-scratch rebuild, so
+        // there was nothing to catch before.
+        const asset = pick(assetPool);
+        if (asset === undefined) continue;
+        const newId = nid(`ins-${step}`);
+        const index = Math.floor(random() * (from.length + 1));
+        graph = commit(graph, {
+          type: "inserted",
+          placements: [
+            {
+              node: makeLeafNode<TestTypes>(newId, "clip", {
+                title: `ins-${step}`,
+                assetId: asset,
+              }),
+              parentId: nid(fromId),
+              index,
+            },
+          ],
+        });
+        assetOfClip.set(String(newId), asset);
+        inserts += 1;
       } else {
         // Content edit — half of these move the key, half do not.
         const before = assetOfClip.get(String(nodeId));
@@ -1280,6 +1372,9 @@ describe("incremental indexes never diverge from a rebuild", () => {
     expect(reorders).toBeGreaterThan(50);
     expect(reparents).toBeGreaterThan(20);
     expect(removals).toBeGreaterThan(5);
+    // The arm this change added. Asserted like its siblings so a future
+    // reshuffle of the roll ranges cannot silently stop exercising it.
+    expect(inserts).toBeGreaterThan(5);
     expect(edits).toBeGreaterThan(5);
     // A last explicit comparison, so a reader does not have to take check 9 on
     // trust to see what this test proves.

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -55,6 +55,8 @@ import {
 } from "./types";
 import {
   bumpSubtreeRevs,
+  placementsAfterInsert,
+  ownersAfterInsert,
   ownsItsSubtree,
   sourceKeyOf,
   sourceKeyOfKindData,
@@ -582,16 +584,46 @@ function applyInserted<Ts extends readonly unknown[], S>(
   // An insert never reorders what was already there, so when the arriving nodes
   // contribute no key of their own, BOTH indexes are exactly the maps the
   // previous graph published.
+  // UPDATED, NOT REBUILT — the same shape `placementsAfterMove` uses, and the
+  // same argument `derivedIndexesAfterRemoval` makes in the other direction.
+  //
+  // An insert cannot REORDER anything already present: splicing an id into a
+  // children array shifts later siblings within document order but preserves
+  // every pre-existing node's order relative to every other. So each existing
+  // bucket stays sorted, and the only new entries are the arrivals' own.
+  //
+  // This used to fall back to a whole-document rebuild whenever ANY arriving
+  // node carried a key — and `insertLeavesDerivedIndexesIntact` short-circuits
+  // on the first keyed node, so one keyed seed condemned the whole batch.
+  // MEASURED, counting `contentKey`: inserting ONE clip cost 1,002 / 10,002 /
+  // 40,002 calls at those board sizes, while removing one cost 1, because the
+  // removal side has been incremental since it shipped. Undo of a delete
+  // inverts to an `inserted` patch and paid the full 40,001.
+  //
+  // The keyless case still costs nothing and still hands both maps back by
+  // reference — `placementsAfterInsert` returns `previous` by identity when the
+  // arrivals contribute no key, which is exactly what the old gate bought.
   const insertedNodes = placements.map((placement) => placement.node);
-  const derived: DerivedIndexes<Ts, S> = insertLeavesDerivedIndexesIntact(
+  const placementsNext = placementsAfterInsert(
+    grown,
     ctx.registry,
+    graph.placementsByContentKey,
     insertedNodes,
-  )
-    ? {
-        placementsByContentKey: graph.placementsByContentKey,
-        ownerBySourceKey: graph.ownerBySourceKey,
-      }
-    : rebuildDerivedIndexes(grown, ctx.registry);
+  );
+  const derived: DerivedIndexes<Ts, S> =
+    placementsNext === null
+      ? // Declined — the comparator could not rank two ids, or an arriving id
+        // was already in its bucket. Fall back to the authoritative walk rather
+        // than guessing, exactly as the move arm does.
+        rebuildDerivedIndexes(grown, ctx.registry)
+      : {
+          placementsByContentKey: placementsNext,
+          ownerBySourceKey: ownersAfterInsert<Ts, S>(
+            ctx.registry,
+            graph.ownerBySourceKey,
+            insertedNodes,
+          ),
+        };
 
   return { ...grown, ...derived };
 }

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -393,19 +393,21 @@ function placementsAfterMove<Ts extends readonly unknown[], S>(
   // otherwise send the emptiest possible patch down the most expensive path.
   if (moves.length === 0) return previous;
 
-  const scopeRootId = soleReorderParent(moves);
-  if (scopeRootId !== null) {
-    const scoped = reindexPlacementsWithinSubtree(post, registry, previous, scopeRootId);
-    // `null` is "declined", not "invalid" — the incremental path found the
-    // previous index disagreeing with the graph and refused to guess.
-    if (scoped !== null) return scoped;
-  }
-
-  // A cross-parent move — or a scoped reorder that declined. Reposition what
-  // travelled instead of rediscovering what did not: the scope of a move is the
-  // moved subtrees, and every node outside them holds its relative order. See
-  // `reindexPlacementsAcrossMove` for why that is true rather than merely
-  // plausible.
+  // THE MOVED SET FIRST. Reposition what travelled instead of rediscovering
+  // what did not: the scope of a move is the moved subtrees, and every node
+  // outside them holds its relative order. `reindexPlacementsAcrossMove` proves
+  // that rather than assuming it, and its argument — take any two nodes,
+  // neither in a moved subtree — never assumes the parents DIFFER, so it covers
+  // a same-parent reorder unchanged.
+  //
+  // This used to run second, after the scoped path, and the engine therefore
+  // declined to use its own conclusion for exactly the gesture that needs it
+  // most. MEASURED, counting `contentKey`: a clip reorder inside a strip cost
+  // strip-width + 1 (21 for a 20-wide strip, 201 for a 200-wide one) while the
+  // same clip moved to ANOTHER strip cost 1 — the same node, the same distance,
+  // the same work, two orders of magnitude apart. Worse, reordering a
+  // COLLECTION under the root made the scope root the document root, so it
+  // walked the ENTIRE graph: 10,501 calls on a 10,501-node board, every drag.
   const repositioned = reindexPlacementsAcrossMove(
     post,
     registry,
@@ -413,6 +415,20 @@ function placementsAfterMove<Ts extends readonly unknown[], S>(
     moves.map((move) => move.nodeId),
   );
   if (repositioned !== null) return repositioned;
+
+  // The scoped reorder is now the FALLBACK, for a same-parent batch the moved
+  // set declined — which it does when `previous` disagrees with the graph, not
+  // when the move is unusual. Kept rather than deleted because it answers from
+  // a different direction (the subtree that contains the change, rather than
+  // the nodes that moved) and can therefore still succeed where the other
+  // could not.
+  const scopeRootId = soleReorderParent(moves);
+  if (scopeRootId !== null) {
+    const scoped = reindexPlacementsWithinSubtree(post, registry, previous, scopeRootId);
+    // `null` is "declined", not "invalid" — the incremental path found the
+    // previous index disagreeing with the graph and refused to guess.
+    if (scoped !== null) return scoped;
+  }
 
   return rebuildPlacementIndex(post, registry);
 }

--- a/packages/keel-core/performance.test.ts
+++ b/packages/keel-core/performance.test.ts
@@ -1409,6 +1409,68 @@ describe("mutations", () => {
   }, 120_000);
 
   /**
+   * AN INSERT RE-INDEXES WHAT ARRIVED, NOT THE DOCUMENT.
+   *
+   * `applyInserted` fell back to a whole-document `rebuildDerivedIndexes`
+   * whenever ANY arriving node carried a content or source key — the gate
+   * short-circuits on the first keyed node, so one keyed seed condemned the
+   * whole batch. MEASURED, counting `contentKey`:
+   *
+   *   board      insert 1 keyless   insert 1 KEYED   remove 1 keyed
+   *    1,000            0                1,002              1
+   *   10,000            0               10,002              1
+   *   40,000            0               40,002              1
+   *
+   * The removal direction has been incremental since it shipped
+   * (`derivedIndexesAfterRemoval`) and costs ONE. Undo of a delete inverts to an
+   * `inserted` patch and paid the full 40,001.
+   *
+   * The bound below is `arrivals + 1`, not `arrivals`: the `+1` is the gate
+   * itself asking the first arrival for its key before deciding.
+   */
+  it("an insert re-indexes what arrived, not the document", () => {
+    const reindexed = new Map<string, number>();
+
+    for (const fx of wideSizes) {
+      const command: Command<Types, Summary> = {
+        type: "insert-nodes",
+        toParentId: firstFolder(fx),
+        toIndex: 0,
+        seeds: [
+          {
+            kind: "clip",
+            data: { title: "arrival", seconds: 3, assetId: "arriving-asset" },
+          },
+        ],
+      };
+      expect(engine.applyCommand(fx.graph, command).ok).toBe(true);
+
+      const counts = countOnce(() => {
+        engine.applyCommand(fx.graph, command);
+      });
+      reindexed.set(
+        fx.label,
+        noteCount(
+          "insert (one keyed node)",
+          fx.label,
+          fx.nodeCount,
+          "contentKey",
+          counts.contentKey,
+        ),
+      );
+    }
+
+    // INDEPENDENCE at three sizes, because a per-size bound cannot tell a
+    // constant from a number that happens to be small at the size examined.
+    const perInsert = expectIndependentOfGraphSize(
+      reindexed,
+      "insert content-key lookups",
+    );
+    // One arriving node, plus the gate's own look at it.
+    expect(perInsert).toBeLessThanOrEqual(2);
+  }, 120_000);
+
+  /**
    * THE SERVER-WRITE PATH, held to the same bill as the user-intent one.
    *
    * `applyIngestEdits` rebuilt BOTH derived indexes unconditionally, ignoring

--- a/packages/keel-core/performance.test.ts
+++ b/packages/keel-core/performance.test.ts
@@ -46,6 +46,7 @@ import { afterAll, describe, expect, it } from "vitest";
 import { performance } from "node:perf_hooks";
 
 import { createEngine } from "./engine";
+import { createHistory } from "./history";
 import { computeFold, createFoldCache, DEFAULT_FOLD_CACHE_LIMIT } from "./folds";
 import {
   defineNodeType,
@@ -1405,6 +1406,76 @@ describe("mutations", () => {
     expect(perEdit).toBeLessThanOrEqual(2);
 
     expectSubQuadratic(perOp, "content edit");
+  }, 120_000);
+
+  /**
+   * THE SERVER-WRITE PATH, held to the same bill as the user-intent one.
+   *
+   * `applyIngestEdits` rebuilt BOTH derived indexes unconditionally, ignoring
+   * the check `applyPatch`'s data arm has used since it shipped. Its comment
+   * claimed parity with that arm — "the same thing `applyPatch` does after a
+   * 'data-changed' patch" — which stopped being true when the arm gained its
+   * guard, so the comment had become a description of the defect.
+   *
+   * MEASURED before the guard, counting `contentKey` on a key-preserving
+   * one-node write: ingest asked 1,000 / 10,000 / 40,000 times at those three
+   * sizes — exactly the reachable node count, a full document-order DFS — while
+   * `edit-nodes` asked 2, flat. Per CALL, not per edit: a batch of twenty still
+   * cost one whole walk.
+   *
+   * This is the path a thumbnail lands on.
+   */
+  it("a key-preserving ingest re-indexes no more than the equivalent command", () => {
+    const ingestReindexed = new Map<string, number>();
+    const editReindexed = new Map<string, number>();
+
+    for (const fx of wideSizes) {
+      const clips = firstFolderClips(fx);
+      const target = at(clips, 0, "clips");
+      // `seconds` is not what `contentKey` reads, so this write cannot move
+      // either index — the shape of a duration or a thumbnail arriving.
+      const edits = [
+        { nodeId: target, kind: "clip", edit: { seconds: 99 } },
+      ] as const;
+
+      const ingestCounts = countOnce(() => {
+        engine.applyIngest(fx.graph, createHistory<Types, Summary>(), edits);
+      });
+      ingestReindexed.set(
+        fx.label,
+        noteCount(
+          "ingest (key-preserving)",
+          fx.label,
+          fx.nodeCount,
+          "contentKey",
+          ingestCounts.contentKey,
+        ),
+      );
+
+      const editCounts = countOnce(() => {
+        engine.applyCommand(fx.graph, { type: "edit-nodes", edits: [...edits] });
+      });
+      editReindexed.set(fx.label, editCounts.contentKey);
+    }
+
+    // The claim is INDEPENDENCE, asserted at three sizes, because a per-size
+    // bound cannot tell a constant apart from a number that happens to be small
+    // at the size being looked at.
+    const perIngest = expectIndependentOfGraphSize(
+      ingestReindexed,
+      "ingest content-key lookups",
+    );
+    // Two per edited node — its key before and after — which is exactly what
+    // the command path above is already held to.
+    expect(perIngest).toBeLessThanOrEqual(2);
+
+    // And stated as a relationship, not two separate numbers: the IO door must
+    // not cost more than the user-intent door for the same write.
+    for (const fx of wideSizes) {
+      expect(ingestReindexed.get(fx.label)).toBeLessThanOrEqual(
+        editReindexed.get(fx.label) ?? 0,
+      );
+    }
   }, 120_000);
 });
 


### PR DESCRIPTION
Stacked on #582 — merge that first.

`applyInserted` fell back to a whole-document `rebuildDerivedIndexes` whenever **any** arriving node carried a content or source key — and `insertLeavesDerivedIndexesIntact` short-circuits on the first keyed node, so one keyed seed condemned the entire batch.

| board | insert 1 keyless | insert 1 **keyed** | remove 1 keyed |
|---|---|---|---|
| 1,000 | 0 | 1,002 | 1 |
| 10,000 | 0 | 10,002 | 1 |
| 40,000 | 0 | **40,002** | **1** |

Removal has been incremental since it shipped and costs **one**. Undo of a delete inverts to an `inserted` patch and paid the full 40,001 — so deleting a clip and pressing Ctrl-Z walked the whole board.

## The fix mirrors the move side, which was already built and argued

`placementsAfterInsert` is `reindexPlacementsAcrossMove`'s body *minus* its lift-out step: arriving ids aren't in `previous` at all, so there are no survivors to separate from movers — only arrivals to merge into buckets that are already sorted. `ownersAfterInsert` parallels the owner half of `derivedIndexesAfterRemoval`, claiming a key only for a node that `ownsItsSubtree` — the same predicate `walkDerivedIndexes` applies, so the incremental answer and the from-scratch one can't disagree about who counts.

Sound because an insert cannot **reorder** anything already present: splicing an id into a children array shifts later siblings within document order but preserves every pre-existing node's order relative to every other.

**One place the two diverge**, and it's the whole difference: an absent bucket here means a brand-new key — ordinary, gets set. On the move side an absent bucket meant `previous` disagreed with the graph, and the answer was to decline.

The keyless case still costs nothing and still hands both maps back **by identity**, which is exactly what the old gate bought.

## Proven differentially, not argued

The package's 300-commit divergence fuzz covered reorders, reparents, removals and edits — and **never inserted**. That was reasonable while the insert arm rebuilt from scratch: a from-scratch rebuild cannot diverge from a from-scratch rebuild, so there was nothing to catch. It can now, so the fuzz gained an insert arm. `commit` asserts `findInvariantViolation` after every step, and check 9 compares **both** indexes against a fresh rebuild — 300 commits, entry by entry, in order.

## Mutation testing found a hole in my own change, again

Deleting the `ownersAfterInsert` claim entirely failed **nothing**. The fuzz inserts clips, and a leaf owns nothing since #574 made ownership container-only — so no test anywhere inserted an *owner*. Two tests now cover it: an inserted owning container claims its key and agrees with the authoritative walk, and an inserted container whose key is already owned does not usurp the incumbent. Reverting the claim now fails the first.

That's the fourth false green this discipline has caught in my own work this session.

## Verification

| | |
|---|---|
| Mutation proof | merge order → 2 (incl. the fuzz) · incremental path → 2 · owner claim → 1 |
| Unit suite | 1,406 tests / 70 files |
| Stories | 9 pass, headless Chromium |
| `tsc` | clean, both packages |

Remaining from this measurement round: tombstone pruning (the one that feeds back into #580) and the fold-cache memory-model comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)