### PR TITLE
Tombstones move out of the map every commit copies

### DIFF
--- a/packages/keel-core/commands.test.ts
+++ b/packages/keel-core/commands.test.ts
@@ -264,6 +264,7 @@ function buildGraph(engineId: symbol, roots: readonly Spec[]): Graph<Types, Summ
     parentById: parents,
     rootIds,
     subtreeRevById: revs,
+    deadRevById: new Map(),
     placementsByContentKey: new Map(),
     ownerBySourceKey: new Map(),
   };

--- a/packages/keel-core/folds.test.ts
+++ b/packages/keel-core/folds.test.ts
@@ -196,6 +196,7 @@ function buildGraph(roots: readonly Spec[]): TestGraph {
     parentById,
     rootIds,
     subtreeRevById,
+    deadRevById: new Map(),
     placementsByContentKey: new Map(),
     ownerBySourceKey: new Map(),
   };
@@ -689,6 +690,7 @@ describe("computeFold dispatch", () => {
       parentById,
       rootIds: [childId],
       subtreeRevById,
+    deadRevById: new Map(),
       placementsByContentKey: new Map(),
       ownerBySourceKey: new Map(),
     };
@@ -726,6 +728,7 @@ describe("computeFold dispatch", () => {
     const graph: TestGraph = {
       engineId: ENGINE_ID,
       nodesById,
+      deadRevById: new Map(),
       childrenById: new Map<NodeId, readonly NodeId[]>([
         [a, [b]],
         [b, [a]],

--- a/packages/keel-core/graph.ts
+++ b/packages/keel-core/graph.ts
@@ -48,6 +48,9 @@ import type {
 const NO_IDS: readonly NodeId[] = Object.freeze([]);
 const NO_PLACEMENTS: ReadonlyMap<string, readonly NodeId[]> = new Map();
 const NO_OWNERS: ReadonlyMap<string, NodeId> = new Map();
+/** Shared empty tombstone store. A graph that has never removed anything holds
+ *  this one, by reference. */
+export const NO_DEAD_REVS: ReadonlyMap<NodeId, number> = new Map();
 
 // ---------------------------------------------------------------------------
 // Registry
@@ -92,6 +95,7 @@ export function emptyGraph<Ts extends readonly unknown[], S>(
     parentById: new Map(),
     rootIds: NO_IDS,
     subtreeRevById: new Map(),
+    deadRevById: NO_DEAD_REVS,
     placementsByContentKey: NO_PLACEMENTS,
     ownerBySourceKey: NO_OWNERS,
   };
@@ -122,6 +126,9 @@ export function buildGraph<Ts extends readonly unknown[], S>(
     rootIds: readonly NodeId[];
     registry: NodeTypeRegistry;
     subtreeRevs?: ReadonlyMap<NodeId, number>;
+    /** Carried forward when a graph is rebuilt around existing nodes, so a
+     *  rebuild does not forget what has been removed. */
+    deadRevs?: ReadonlyMap<NodeId, number>;
   }>,
 ): Graph<Ts, S> {
   const parentById = new Map<NodeId, NodeId | null>();
@@ -145,6 +152,8 @@ export function buildGraph<Ts extends readonly unknown[], S>(
     parentById,
     rootIds: args.rootIds,
     subtreeRevById,
+    // Ingress builds a graph from a node set; nothing has been removed from it.
+    deadRevById: args.deadRevs ?? NO_DEAD_REVS,
     placementsByContentKey: NO_PLACEMENTS,
     ownerBySourceKey: NO_OWNERS,
   };
@@ -194,7 +203,12 @@ export function getSubtreeRev<Ts extends readonly unknown[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): number {
-  return graph.subtreeRevById.get(id) ?? 0;
+  // LIVE FIRST. The two maps are disjoint, so the order is not what makes this
+  // correct — it is what makes it cheap, since the live map is the one every
+  // read of a present node hits. A dead id answers with the revision it held
+  // when it was removed, which is what keeps a re-inserted id from landing back
+  // on a revision its previous lifetime already cached.
+  return graph.subtreeRevById.get(id) ?? graph.deadRevById.get(id) ?? 0;
 }
 
 /** `null` for a leaf, an unknown node, or a QUARANTINED leaf — the three cases

--- a/packages/keel-core/move-cost.test.ts
+++ b/packages/keel-core/move-cost.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   bumpSubtreeRevs,
+  getSubtreeRev,
   bumpSubtreeRevsInto,
   findInvariantViolation,
   rebuildDerivedIndexes,
@@ -243,6 +244,7 @@ function buildGraph(
     parentById,
     rootIds,
     subtreeRevById,
+    deadRevById: new Map(),
     placementsByContentKey: new Map(),
     ownerBySourceKey: new Map(),
   };
@@ -1221,6 +1223,99 @@ describe("insert / remove / edit commit cost", () => {
 // ---------------------------------------------------------------------------
 // The differential guard
 // ---------------------------------------------------------------------------
+
+describe("the tombstone store is out of the per-commit copy", () => {
+  /**
+   * The property, stated as reference identity rather than as a clock reading:
+   * a commit that removes nothing does not touch `deadRevById` at all.
+   *
+   * That is what takes tombstones out of the cost curve. They used to live in
+   * `subtreeRevById`, which every commit copies, so per-commit cost tracked the
+   * number of nodes a session had EVER DELETED rather than the number it held.
+   * MEASURED on one `edit-nodes` before the split: 40us at zero tombstones,
+   * 1.7ms at 20,000, 29.4ms at 200,400 — and confirmed to be the copy, since a
+   * bare `new Map` on the same map tracked it at ratio ~1.0.
+   */
+  it("shares deadRevById by reference across every commit that removes nothing", () => {
+    const graph = wideGraph(4, 4);
+
+    const edited = commit(graph, {
+      type: "data-changed",
+      changes: [
+        {
+          nodeId: nid("c0-m0"),
+          kind: "clip",
+          before: { title: "c0-m0", assetId: "asset-c0-m0" },
+          after: { title: "renamed", assetId: "asset-c0-m0" },
+        },
+      ],
+    });
+    expect(edited.deadRevById).toBe(graph.deadRevById);
+
+    const moved = commit(graph, reorderWithin("c0", "c0-m0", 0, 3));
+    expect(moved.deadRevById).toBe(graph.deadRevById);
+
+    const inserted = commit(graph, {
+      type: "inserted",
+      placements: [
+        {
+          node: makeLeafNode<TestTypes>(nid("arrival"), "clip", {
+            title: "arrival",
+            assetId: "asset-arrival",
+          }),
+          parentId: nid("c0"),
+          index: 0,
+        },
+      ],
+    });
+    expect(inserted.deadRevById).toBe(graph.deadRevById);
+  });
+
+  it("keeps subtreeRevById exactly total over nodesById", () => {
+    // The contract the type has always documented, and which the tombstone
+    // silently broke by making the map a SUPERSET. Restored by the split, and
+    // asserted here because invariant check 6 can only say every live node HAS
+    // an entry — it cannot say no dead one does.
+    const graph = wideGraph(4, 4);
+    expect(graph.subtreeRevById.size).toBe(graph.nodesById.size);
+
+    const node = graph.nodesById.get(nid("c0-m0"));
+    if (node === undefined) throw new Error("fixture");
+    const next = commit(graph, {
+      type: "removed",
+      placements: [{ node, parentId: nid("c0"), index: 0 }],
+    });
+
+    expect(next.subtreeRevById.size).toBe(next.nodesById.size);
+    expect(next.subtreeRevById.has(nid("c0-m0"))).toBe(false);
+    // And the number itself is preserved, one higher, at its new address.
+    expect(next.deadRevById.get(nid("c0-m0"))).toBe(
+      (graph.subtreeRevById.get(nid("c0-m0")) ?? 0) + 1,
+    );
+  });
+
+  it("still resumes a re-inserted id above everything its last life cached", () => {
+    // The P1 this whole mechanism exists to prevent, checked through the new
+    // address. `review-f1.test.ts` covers it end to end through the store; this
+    // is the arithmetic, isolated.
+    const graph = wideGraph(4, 4);
+    const node = graph.nodesById.get(nid("c0-m0"));
+    if (node === undefined) throw new Error("fixture");
+
+    const removed = commit(graph, {
+      type: "removed",
+      placements: [{ node, parentId: nid("c0"), index: 0 }],
+    });
+    const tombstone = removed.deadRevById.get(nid("c0-m0")) ?? 0;
+
+    const back = commit(removed, {
+      type: "inserted",
+      placements: [{ node, parentId: nid("c0"), index: 0 }],
+    });
+
+    expect(getSubtreeRev(back, nid("c0-m0"))).toBeGreaterThan(tombstone);
+  });
+});
 
 describe("incremental indexes never diverge from a rebuild", () => {
   /** Deterministic LCG. A seeded generator, never `Math.random`: a fuzz that

--- a/packages/keel-core/patches.test.ts
+++ b/packages/keel-core/patches.test.ts
@@ -9,7 +9,11 @@ import {
   scrubPatchForIngest,
   verifyPatchApplies,
 } from "./patches";
-import { findInvariantViolation, rebuildDerivedIndexes } from "./graph";
+import {
+  findInvariantViolation,
+  getSubtreeRev,
+  rebuildDerivedIndexes,
+} from "./graph";
 import {
   defineNodeType,
   makeCollectionNode,
@@ -254,6 +258,7 @@ function buildGraph(
     parentById,
     rootIds,
     subtreeRevById,
+    deadRevById: new Map(),
     placementsByContentKey: new Map(),
     ownerBySourceKey: new Map(),
   };
@@ -794,7 +799,18 @@ describe("applyPatch: removed", () => {
       // invalidation mechanism, and dropping it let a re-inserted id restart
       // low enough to reach the dead lineage's cached values. See the
       // tombstone comment in `applyRemoved`.
-      expect(next.subtreeRevById.has(nid(gone))).toBe(true);
+      //
+      // It now survives in `deadRevById` rather than in `subtreeRevById`, which
+      // is a change of ADDRESS and not of contract: the number is the same, the
+      // high-water rule is the same, and `getSubtreeRev` still answers with it.
+      // What changed is that it is no longer inside the map every commit
+      // copies. Both halves are asserted, because "the tombstone moved" and
+      // "the tombstone was dropped" must not look alike to this test.
+      expect(next.subtreeRevById.has(nid(gone))).toBe(false);
+      expect(next.deadRevById.has(nid(gone))).toBe(true);
+      expect(getSubtreeRev(next, nid(gone))).toBeGreaterThan(
+        getSubtreeRev(graph, nid(gone)),
+      );
     }
     // The surviving placement of asset-1 is `a`; `c` left with the subtree.
     expect(

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -552,7 +552,12 @@ function applyInserted<Ts extends readonly unknown[], S>(
     }
     // `subtreeRevById` is TOTAL over `nodesById`. Seeding before the bump means
     // this holds regardless of how `bumpSubtreeRevs` treats an absent id.
-    if (!revs.has(node.id)) revs.set(node.id, 0);
+    // The floor comes from the TOMBSTONE STORE now, not from this map: a
+    // removed id's revision moved there, so `revs.has` can no longer answer
+    // "has this id lived here before". The rule is unchanged — a returning id
+    // resumes strictly above every revision its previous lifetime could have
+    // cached — and the bump below carries it the final step.
+    if (!revs.has(node.id)) revs.set(node.id, graph.deadRevById.get(node.id) ?? 0);
   }
 
   const grown: Graph<Ts, S> = {
@@ -649,6 +654,13 @@ function applyRemoved<Ts extends readonly unknown[], S>(
     placements.map((placement) => placement.parentId),
   );
 
+  // THE ONE WRITER of the tombstone store, and the only place a graph's
+  // `deadRevById` is ever a fresh map. Every other commit shares the previous
+  // graph's by reference, which is the whole point of the split: the map that
+  // grows with a session's total deletions is no longer inside the map every
+  // commit copies.
+  const deadRevs = new Map<NodeId, number>(graph.deadRevById);
+
   const removedIds: NodeId[] = [];
   // BACKWARD walk: children leave before parents, and a later sibling's splice
   // cannot invalidate an earlier one's recorded index.
@@ -703,7 +715,8 @@ function applyRemoved<Ts extends readonly unknown[], S>(
     // tombstone now sits strictly above every rev the dead lineage could have
     // cached, which is exactly the property `applyInserted`'s re-insertion bump
     // relies on.
-    revs.set(id, (revs.get(id) ?? 0) + 1);
+    deadRevs.set(id, (revs.get(id) ?? 0) + 1);
+    revs.delete(id);
   }
 
   // ONE rewrite per affected parent, after the loop rather than inside it. The
@@ -731,6 +744,7 @@ function applyRemoved<Ts extends readonly unknown[], S>(
     childrenById: children,
     parentById: parents,
     subtreeRevById: revs,
+    deadRevById: deadRevs,
     ...derived,
   };
 }

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -59,6 +59,7 @@ import {
 } from "./types";
 
 import {
+  NO_DEAD_REVS,
   ancestorChain,
   ownsItsSubtree,
   bumpSubtreeRevs,
@@ -1076,6 +1077,8 @@ export function deserializeDocument<Ts extends readonly unknown[], S>(
     parentById: doc.parentById,
     rootIds: doc.rootIds,
     subtreeRevById,
+    // A freshly deserialized document has removed nothing.
+    deadRevById: NO_DEAD_REVS,
     placementsByContentKey: new Map(),
     ownerBySourceKey: new Map(),
   };
@@ -1391,13 +1394,26 @@ export function loadChildrenInto<Ts extends readonly unknown[], S>(
   // every ancestor rollup, and it did not self-heal — each later edit landed on
   // the next already-poisoned rev.
   for (const incomingId of payload.order) {
-    const tombstone = graph.subtreeRevById.get(incomingId);
+    // The tombstone now lives in its own store, so this reads there rather than
+    // in the live map — but the RULE is unchanged: an id that has lived here
+    // before resumes strictly above every revision its previous lifetime could
+    // have cached.
+    //
+    // The dead entry is NOT removed as the id returns. `applyRemoved` is the
+    // only writer of that store, and leaving it alone is what keeps that true —
+    // a returning id simply has a live entry that `getSubtreeRev` reads first,
+    // and the stale dead number can only ever be overwritten upward by a later
+    // removal of the same id.
+    const tombstone = graph.deadRevById.get(incomingId);
     subtreeRevById.set(incomingId, tombstone === undefined ? 0 : tombstone + 1);
   }
 
   const base: Graph<Ts, S> = {
     engineId: graph.engineId,
     nodesById,
+    // Shared by reference: a load removes nothing, so the tombstone store is
+    // exactly the one the previous graph published.
+    deadRevById: graph.deadRevById,
     childrenById,
     parentById,
     rootIds: graph.rootIds,

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -386,9 +386,42 @@ export type Graph<Ts extends readonly unknown[], S> = Readonly<{
    * rollup — move a node at depth 5 and no ancestor's children array changes
    * identity, so no ancestor rollup ever re-renders.
    *
-   * Total over `nodesById`: every node has an entry.
+   * TOTAL OVER `nodesById` AND NOTHING MORE: every live node has an entry, and
+   * no id without a node does. A removed id's revision moves to `deadRevById`
+   * rather than staying here — see there for why it is kept at all, and why
+   * keeping it HERE cost a long session real time.
    */
   subtreeRevById: ReadonlyMap<NodeId, number>;
+  /**
+   * The revision each REMOVED id last held. A tombstone store.
+   *
+   * WHY THESE ARE KEPT. `subtreeRevById` is the fold cache's only invalidation
+   * mechanism: an entry keyed (foldKey, nodeId, rev) is meant to become
+   * unreachable once the rev moves past it, which is why nothing ever evicts
+   * for correctness. Forgetting a removed id's revision restarts a re-inserted
+   * id at 0, and the store then serves the DEAD lineage's cached values — a
+   * wrong AGGREGATE at the root that does not self-heal. That shipped twice.
+   *
+   * WHY THEY LIVE HERE RATHER THAN BESIDE THE LIVE ONES. They used to sit in
+   * `subtreeRevById`, which made it a superset of `nodesById` and — the part
+   * that cost — put them inside the map every commit copies. Growth is exactly
+   * one entry per ever-removed id, for the life of the store, so per-commit
+   * cost tracked the number of nodes a session had ever DELETED rather than the
+   * number it currently holds. MEASURED on one `edit-nodes`: 40us at zero
+   * tombstones, 1.7ms at 20,000, 29.4ms at 200,400 — and confirmed to be the
+   * copy, since a bare `new Map` on the same map tracked it at ratio ~1.0.
+   *
+   * Split out, the semantics are byte-for-byte what they were — same numbers,
+   * same high-water rule, no eviction and no threshold — and the copy every
+   * commit makes is proportional to LIVE nodes again. This map has exactly one
+   * writer (`applyRemoved`) and is shared by reference by every commit that
+   * removes nothing, which is nearly all of them.
+   *
+   * DISJOINT from `subtreeRevById` by construction: an id is live or dead,
+   * never both. `getSubtreeRev` reads live first regardless, and invariant
+   * check 6 asserts the disjointness rather than trusting it.
+   */
+  deadRevById: ReadonlyMap<NodeId, number>;
   /** Derived from `contentKey`. Values are in document order. */
   placementsByContentKey: ReadonlyMap<string, readonly NodeId[]>;
   /** Derived from `sourceKey`. At most one non-`reference` placement per key. */


### PR DESCRIPTION
A removed node's revision has to be remembered — it's the fold cache's only invalidation mechanism, and forgetting it lets a re-inserted id restart low enough to serve the **dead lineage's** cached values. That shipped twice and is guarded by `review-f1`.

It was remembered in `subtreeRevById`, which every commit copies. So per-commit cost tracked the number of nodes a session had **ever deleted**, not the number it held:

| tombstones | one `edit-nodes` | bare `new Map` on the same map |
|---|---|---|
| 0 | 40–52 µs | 17–28 µs |
| 5,000 | 356–380 µs | 343 µs |
| 20,000 | 1.67 ms | 1.58 ms |
| 50,000 | 4.4–5.2 ms | 4.23 ms |
| 200,400 | **29.4 ms** | 23.4 ms |

Ratio ~1.0 throughout — the commit *was* the copy. `move-nodes`, which `performance.test.ts` calls the commonest gesture in the product, degrades the same way: 32× at 50,000.

## After

`Graph` gains `deadRevById`. `subtreeRevById` keeps its type and returns to meaning exactly what its doc comment always claimed — *"total over `nodesById`"* — which the tombstone had quietly made false by making it a superset.

| tombstones | 0 | 5,000 | 20,000 | 50,000 |
|---|---|---|---|---|
| `edit-nodes` | ~40 µs | **38.1 µs** | **38.3 µs** | **41.4 µs** |

Flat. The curve isn't bounded, it's **gone**.

## No correctness argument was spent

That's why this shape won over the two obvious alternatives. It isn't a semantic change — it's a partition of one map by a predicate the code already maintains (`id in nodesById`). Same numbers, same high-water rule, no eviction, no threshold, no new question about when a cached value is safe to reach.

Both rejected designs bought a bounded map with a *new* correctness argument:

- **Periodic compaction** (prune + `cache.clear()`) is safe, but its trigger is disqualifying: `dead >= max(live, 1024)` fires exactly when a commit removes half the document — a bulk delete, which is the fastest way to make tombstones and the worst case for the amortisation it needs. Each fire also discards live memoisation (87.5 ms cold refold at 8,000 nodes).
- **Teaching the cache `hasNode()`** is the only option that *weakens* the guarantee. Today a stale key is unreachable **structurally**, because a revision cannot come back down. Behind a refcount it would be unreachable **by bookkeeping** — and a refcount that drifts low fails **open**, into exactly the non-self-healing corruption class of F1.

**The rule that keeps it simple:** `deadRevById` has exactly one writer (`applyRemoved`) and nothing is ever deleted from it. Every other commit shares the previous graph's map by reference — asserted by identity, not by comment.

## On the blast radius

Only **four** production sites failed to compile, because most spread the previous graph. That's fewer than the compiler *should* have caught, so every read of `subtreeRevById` was audited by hand instead: twelve code sites, and the only one that ever needed the combined view is `getSubtreeRev`. Every `new Map(graph.subtreeRevById)` now copies live entries and is correct unchanged — which is the win, arriving at each site for free.

## Verification

| | |
|---|---|
| Mutation proof | tombstone move → **4 fail incl. review-f1's dead-lineage tests** · insert floor → 3 incl. the stale-aggregate test · `getSubtreeRev` read-through → 4 incl. #570's removal-notification tests |
| New gates | 3, structural (reference identity, not wall clock) |
| Unit suite | 1,409 tests / 70 files |
| Stories | 9 pass, headless Chromium |
| `tsc` | clean, both packages |

The mutation results are the part worth reading: breaking this re-fails the P1 tests from two review rounds ago, so the net that caught the original corruption is demonstrably still live over the new arrangement.

**This does not close [#580](https://github.com/josulliv101/storyboard-flow/issues/580).** The live half of the copy is untouched, and at zero tombstones a 501-node commit still spends a quarter of its time there. What this removes is the part that grew without bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)