### PR TITLE
The fold cache's memory model was wrong, and the warning built on it was short

### DIFF
--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -130,6 +130,19 @@ function defaultMintId(): string {
     .slice(2, 8)}`;
 }
 
+/**
+ * How much room over `folds x nodes` a fold cache needs to stop thrashing.
+ *
+ * The product is the working set's FLOOR. Editing strands `folds x depth`
+ * entries per edit, and those strays are newer than a cold live entry, so a
+ * table sized exactly to the product evicts something live for every one of
+ * them. Measured against the ideal fold-call count per post-edit root read:
+ * 1.90x ideal at 1x the product, 1.27x at 2x, 1.00x at 4x. Two is the knee —
+ * enough to stop the inversion, not so much that the recommendation reads as
+ * absurd for a large board.
+ */
+const FOLD_CACHE_HEADROOM = 2;
+
 const noop = (): void => {};
 
 function sameIds(a: readonly NodeId[], b: readonly NodeId[]): boolean {
@@ -381,15 +394,37 @@ export function createEngine<
       const limit = cache.stats().limit;
       if (limit <= 0) return;
       const nodeCount = candidate.nodesById.size;
-      if (foldCount * nodeCount <= limit) return;
+      // HEADROOM, not the bare product — and the first version of this check
+      // used the bare product, which is why it is spelled out here.
+      //
+      // `folds x nodes` is the FLOOR of the working set, not its resting size:
+      // every edit strands `folds x depth` entries, so occupancy grows with the
+      // session's edit count until the limit reclaims them. Those strays are
+      // not a leak, because a dead-rev entry is never touched again and ages
+      // out first — but they are always NEWER than a cold live entry, so at
+      // exactly `folds x nodes` there is no room and every stray admission
+      // evicts something live.
+      //
+      // MEASURED against the ideal of `folds x depth` fold calls per post-edit
+      // root read: 1.90x ideal at a limit of 1x the product, 1.27x at 2x, and
+      // exactly 1.00x at 4x. Two is the knee, and it is what this gate uses.
+      //
+      // A 16,105-node graph with 8 folds passed the old bare-product check
+      // silently (128,840 <= 131,072) while doing 2.04x the fold work per
+      // rollup after 2,000 edits — at a fixed graph size, driven purely by
+      // churn. That is the exact silent degradation this warning exists for,
+      // and it sat just under the threshold.
+      const want = foldCount * nodeCount * FOLD_CACHE_HEADROOM;
+      if (want <= limit) return;
       warnedAboutCacheSize = true;
-      const servable = Math.floor(limit / foldCount);
+      const servable = Math.floor(limit / (foldCount * FOLD_CACHE_HEADROOM));
       console.error(
         `keel: this graph holds ${nodeCount} nodes and ${foldCount} fold(s) are registered, ` +
-          `but foldCacheLimit (${limit}) covers only ${servable} nodes. Past that the memo ` +
-          `table thrashes and every rollup refolds from scratch — measurably slower than no ` +
-          `cache at all. Raise EngineConfig.foldCacheLimit to at least ${foldCount * nodeCount} ` +
-          `(folds x nodes). EngineConfig.onFoldCacheStats reports evictions if you want to watch it.`,
+          `but foldCacheLimit (${limit}) comfortably covers only ${servable} nodes. Past that ` +
+          `the memo table thrashes and every rollup refolds from scratch — measurably slower ` +
+          `than no cache at all. Raise EngineConfig.foldCacheLimit to at least ${want} ` +
+          `(folds x nodes x ${FOLD_CACHE_HEADROOM} for edit churn). ` +
+          `EngineConfig.onFoldCacheStats reports evictions if you want to watch it.`,
       );
     };
     warnIfCacheCannotCover(initialGraph);

--- a/packages/keel-core/folds.ts
+++ b/packages/keel-core/folds.ts
@@ -199,8 +199,38 @@ export function foldMonoid<Ts extends readonly unknown[], S, A>(
  *
  * `computeFold` commits an entry for EVERY node it walks, so one root-level
  * read of ONE fold over an n-node document occupies n slots, and the k folds a
- * consumer registered all share their store's single cache — k x n at steady
- * state. Below that product the LRU does not degrade gracefully, it INVERTS:
+ * consumer registered all share their store's single cache — k x n.
+ *
+ * THAT IS THE FLOOR, NOT THE STEADY STATE, and an earlier version of this
+ * comment said "at steady state" and was wrong. There is no steady state at
+ * k x n. Every edit bumps the edited node's ancestor chain, so the next root
+ * read mints k x DEPTH new keys and strands k x depth old ones, and occupancy
+ * grows with the session's EDIT COUNT until the limit bites:
+ *
+ *     occupancy  ~=  k x n  +  k x depth x edits
+ *
+ * MEASURED, and the fit is exact rather than approximate — at n=1,111, k=4,
+ * depth=4 the dead entries came to `16E + 384` to the entry at E = 1, 100, 500,
+ * 1,000, 2,000 and 4,000. At E=4,000 that is 15.5x the k x n this comment used
+ * to name as the resting size.
+ *
+ * The stranded entries are NOT a leak, and this is the part that keeps the
+ * design sound: a dead-rev entry is never touched again, so the LRU ages it out
+ * first — GIVEN HEADROOM. Measured against the ideal of k x depth fold calls
+ * per post-edit root read (16 for that fixture):
+ *
+ *     limit 1.0x k x n   ->  30.4 calls   (1.90x ideal)
+ *     limit 1.25x        ->  23.2
+ *     limit 2.0x         ->  20.3         (1.27x)
+ *     limit 4.0x         ->  16.0         (1.00x, with 131,052 evictions costing nothing)
+ *
+ * So the cliff is not at k x n, it is just below it. A dead entry is always
+ * NEWER than a cold live one — a leaf is only re-touched when a sibling is
+ * edited — so at exactly k x n there is no room and every dead admission evicts
+ * a live one. Size the table with headroom over the product, not to it;
+ * `createStore` warns using the same multiple.
+ *
+ * Below the product the LRU does not degrade gracefully, it INVERTS:
  * fold k's walk evicts fold 1's entries, fold 1's next read misses at the root,
  * and every mounted card refolds its whole subtree from scratch. That is
  * precisely the un-memoized behaviour this table exists to beat, so the cap

--- a/packages/keel-core/review3-the-two-default-ceilings-agree.test.ts
+++ b/packages/keel-core/review3-the-two-default-ceilings-agree.test.ts
@@ -175,14 +175,19 @@ describe("the store says so when the memo table cannot cover its graph", () => {
     engine.createStore(graph);
     expect(spy).toHaveBeenCalled();
     const message = String(spy.mock.calls[0]?.[0] ?? "");
-    // The number a consumer acts on is the size it stops covering, so the
-    // message has to carry it rather than just saying "too small".
-    expect(message).toContain("16384");
+    // The number a consumer acts on is the size it comfortably covers, so the
+    // message has to carry it rather than just saying "too small". 8,192, not
+    // 16,384: the gate now allows headroom over `folds x nodes` because the
+    // product is the working set's FLOOR and editing strands entries above it.
+    expect(message).toContain("8192");
     expect(message).toContain("foldCacheLimit");
   });
 
-  it("stays silent when the table covers the graph", () => {
-    const { engine, graph } = storeOf(8, 16_000);
+  it("stays silent when the table covers the graph WITH headroom", () => {
+    // 8 folds x 8,000 nodes x 2 = 128,000, inside the 131,072 default. At
+    // 16,000 it would fit the bare product and still thrash, which is the
+    // whole reason the multiple exists.
+    const { engine, graph } = storeOf(8, 8_000);
     const spy = captureErrors();
     engine.createStore(graph);
     expect(spy).not.toHaveBeenCalled();
@@ -243,9 +248,10 @@ describe("the store says so when the memo table cannot cover its graph", () => {
 
   it("warns when a graph GROWS past what the table covers", () => {
     // Under the default table at load, over it after a few inserts — the case
-    // a load-time-only check would miss entirely. 8 folds makes the default
-    // cover 16,384 nodes, so this sits just under it and then crosses.
-    const { engine, graph } = storeOf(8, 16_380);
+    // a load-time-only check would miss entirely. 8 folds and the headroom
+    // multiple make the default comfortably cover 8,192 nodes, so this sits
+    // just under it and then crosses.
+    const { engine, graph } = storeOf(8, 8_190);
     const spy = captureErrors();
     const store = engine.createStore(graph);
     expect(spy).not.toHaveBeenCalled();
@@ -268,6 +274,10 @@ describe("the store says so when the memo table cannot cover its graph", () => {
       DEFAULT_FOLD_CACHE_LIMIT,
     );
     expect(Math.floor(DEFAULT_FOLD_CACHE_LIMIT / realisticFolds)).toBe(16_384);
+    // And the size it comfortably covers, once churn headroom is allowed for,
+    // is half that. The gap between these two numbers is where a graph passes
+    // the bare-product check and thrashes anyway.
+    expect(Math.floor(DEFAULT_FOLD_CACHE_LIMIT / (realisticFolds * 2))).toBe(8_192);
   });
 });
 


### PR DESCRIPTION
Two edits. The first corrects a comment; the second corrects code I shipped in #579 on the strength of it.

## The model

`folds.ts` described the memo table's resting size as *"k x n at steady state"*. **There is no steady state at k × n.** Every edit bumps the edited node's ancestor chain, so the next root read mints `k × depth` new keys and strands `k × depth` old ones:

```
occupancy  ≈  k × n  +  k × depth × edits
```

The fit is exact, not approximate: at n=1,111, k=4, depth=4 the dead entries came to `16E + 384` **to the entry** at E = 1, 100, 500, 1,000, 2,000 and 4,000. At E=4,000 that's **15.5×** the number the comment named as the resting size.

The strays are **not a leak**, and that deserves saying as loudly as the correction — a dead-rev entry is never touched again, so the LRU ages it out first. Measured against the ideal of `k × depth` fold calls per post-edit root read (16 for that fixture):

| limit | calls | vs ideal |
|---|---|---|
| 1.0× k×n | 30.4 | 1.90× |
| 1.25× | 23.2 | |
| 2.0× | 20.3 | 1.27× |
| 4.0× | 16.0 | **1.00×** |

At 4× eviction runs hard and costs exactly nothing. So the cliff isn't *at* `k × n` — it's just below it, and for a specific reason: a stray is always **newer** than a cold live entry, because a leaf is only re-touched when a sibling is edited. Sized exactly to the product there's no room, and every stray admission evicts something live.

## The warning — the half with teeth

The cache-coverage diagnostic I added in #579 gated on the bare product, `foldCount * nodeCount <= limit`. Per the numbers above **that is precisely the thrashing point**, so the check passed at exactly the size it exists to catch.

Measured: a **16,105-node graph with 8 folds passes silently** (128,840 ≤ 131,072) and does **2.04× the fold work** per rollup read after 2,000 edits — at a fixed graph size, driven purely by churn.

`FOLD_CACHE_HEADROOM = 2`, the measured knee, now multiplies both the gate and the recommendation. Everything that made the diagnostic quiet enough to keep is unchanged: still gated on `config.foldCacheLimit === undefined`, so a consumer who named a number isn't second-guessed, and still measured against the actual graph rather than `maxNodes`.

**Diagnostic output across the whole suite remains 0 lines.**

## On the updated gates

Three of #579's own gates failed on this change, correctly — they encoded the old boundary. Updated rather than relaxed, and the constant they assert is now **8,192** (what the default comfortably covers) beside **16,384** (what it covers on paper). The gap between those two numbers is the region where a graph passes the check and thrashes anyway, which is the entire finding.

## Verification

| | |
|---|---|
| Mutation proof | multiple back to 1 → 2 gates fail |
| Unit suite | 1,406 tests / 70 files |
| Diagnostic false positives | **0** |
| Stories | 9 pass, headless Chromium |
| `tsc` | clean, both packages |

🤖 Generated with [Claude Code](https://claude.com/claude-code)