### PR TITLE
Consumers reach the graph through its accessors, and a test says so

### DIFF
--- a/packages/keel-core/review3-consumers-go-through-the-accessors.test.ts
+++ b/packages/keel-core/review3-consumers-go-through-the-accessors.test.ts
@@ -1,0 +1,218 @@
+// KEEL — the accessor contract, enforced rather than described.
+//
+// WHY THIS EXISTS. `Graph` publishes its index maps as public `ReadonlyMap`
+// fields, and every one of them has an accessor beside it that means something
+// slightly different from the raw `.get`:
+//
+//   getSubtreeRev   falls back to `deadRevById`, so a REMOVED id answers with
+//                   the revision it held rather than `undefined`. Raw reads of
+//                   `subtreeRevById` miss that — and `subtreeRevById` is the
+//                   render subscription key, so a subscriber comparing
+//                   revisions across a removal sees nothing change.
+//   getChildren     answers `[]` for anything that is not a loaded collection.
+//   getParent       answers `null` for a root AND for an unknown id.
+//   childrenStateOf is the ONLY honest answer to "loaded, unloaded, reference
+//                   or missing" — the distinction `getChildren` deliberately
+//                   collapses and the raw map only half-encodes.
+//
+// A consumer reading the map directly gets whichever of those the map happens
+// to give, which is right until it is not. This is not hypothetical: the four
+// sites this test was written alongside were the entire consumer surface of
+// KEEL at the time, and two of them were reading `childrenById` raw precisely
+// BECAUSE `getChildren` collapses loaded-and-empty with unloaded — reaching
+// past the accessor to recover a distinction `childrenStateOf` already states.
+//
+// WHY A TEST AND NOT A COMMENT. This package's own review found eight comments
+// describing checks that did not exist, three of which caused the bug beneath
+// them. A note on the field saying "prefer the accessor" is that same shape.
+// This is the check.
+//
+// WHY NOT A TYPE. Narrowing `Graph` so the maps are unreachable would be a
+// mechanical rewrite of the engine's most central type, and it was considered
+// and rejected: every field is already a `ReadonlyMap`, which any persistent
+// map can implement, so hiding them buys nothing for a future change of
+// representation. What is worth protecting is the CONTRACT, and a contract is
+// exactly what a test can hold and a type cannot.
+//
+// SCOPE. Only files that actually import KEEL are checked. `collections-core`,
+// the predecessor engine, uses the identical field names — `nodesById`,
+// `childrenById`, `parentById` — on a type with no accessors and no dead-rev
+// fallback, so a repo-wide textual scan would be almost entirely false
+// positives. Importing KEEL is what makes those names mean KEEL's.
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+/** The `Graph` fields an accessor exists to interpret. */
+const INDEX_FIELDS = [
+  "nodesById",
+  "childrenById",
+  "parentById",
+  "subtreeRevById",
+  "deadRevById",
+  "placementsByContentKey",
+  "ownerBySourceKey",
+] as const;
+
+/**
+ * The accessor to reach for instead — named only where one exists.
+ *
+ * The two derived indexes have NO accessor today. Naming an imaginary one here
+ * would be the exact defect this package's review kept finding: prose asserting
+ * a thing that is not there. If a consumer needs them, the fix is to add the
+ * accessor to `graph.ts`, which is also where the contract would then live.
+ */
+const ACCESSOR_FOR: Readonly<Record<string, string>> = {
+  nodesById: "getNode",
+  childrenById: "getChildren / childrenStateOf",
+  parentById: "getParent",
+  subtreeRevById: "getSubtreeRev",
+  deadRevById: "getSubtreeRev",
+  placementsByContentKey: "an accessor you add to graph.ts — there is none yet",
+  ownerBySourceKey: "an accessor you add to graph.ts — there is none yet",
+};
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".next",
+  ".git",
+  "dist",
+  "build",
+  "coverage",
+  "storybook-static",
+  "playwright-report",
+  "test-results",
+]);
+
+/**
+ * Walk up from the working directory to the workspace root. Vitest runs this
+ * project from `apps/storybook`, not from the package, so neither `cwd` nor a
+ * relative path from here can be assumed — the root is found by looking for the
+ * `package.json` that declares the workspaces.
+ */
+function workspaceRoot(): string {
+  let dir = process.cwd();
+  for (let hops = 0; hops < 10; hops += 1) {
+    const manifest = join(dir, "package.json");
+    try {
+      const raw: unknown = JSON.parse(readFileSync(manifest, "utf8"));
+      if (
+        typeof raw === "object" &&
+        raw !== null &&
+        "workspaces" in raw &&
+        Array.isArray((raw as { workspaces: unknown }).workspaces)
+      ) {
+        return dir;
+      }
+    } catch {
+      // No manifest here, or an unreadable one. Keep climbing.
+    }
+    const parent = join(dir, "..");
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    "keel accessor guard: could not find the workspace root from " +
+      process.cwd(),
+  );
+}
+
+function sourceFilesUnder(dir: string, out: string[]): void {
+  let entries: readonly string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let isDir = false;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (isDir) {
+      sourceFilesUnder(full, out);
+      continue;
+    }
+    if (entry.endsWith(".ts") || entry.endsWith(".tsx")) out.push(full);
+  }
+}
+
+type Violation = Readonly<{ file: string; line: number; field: string; text: string }>;
+
+function scan(): Readonly<{ checked: readonly string[]; violations: readonly Violation[] }> {
+  const root = workspaceRoot();
+  // `packages/keel-core` is the implementation: it MUST read its own maps.
+  const engineDir = join(root, "packages", "keel-core") + sep;
+
+  const files: string[] = [];
+  sourceFilesUnder(join(root, "apps"), files);
+  sourceFilesUnder(join(root, "packages"), files);
+
+  const checked: string[] = [];
+  const violations: Violation[] = [];
+
+  for (const file of files) {
+    if (file.startsWith(engineDir)) continue;
+    let text: string;
+    try {
+      text = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    // Only a file that imports KEEL can be reading KEEL's graph.
+    if (!text.includes("@storyboard/keel-core") && !text.includes("@storyboard/keel-react")) {
+      continue;
+    }
+    checked.push(relative(root, file).split(sep).join("/"));
+
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i] ?? "";
+      // A comment naming the field is describing it, not reading it — and this
+      // file's whole point is that the fields should be discussed by name.
+      const trimmed = line.trim();
+      if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) {
+        continue;
+      }
+      for (const field of INDEX_FIELDS) {
+        if (!line.includes(`.${field}`)) continue;
+        violations.push({
+          file: relative(root, file).split(sep).join("/"),
+          line: i + 1,
+          field,
+          text: trimmed,
+        });
+      }
+    }
+  }
+
+  return { checked, violations };
+}
+
+describe("KEEL consumers reach the graph through its accessors", () => {
+  it("finds the consumer files at all", () => {
+    // A guard that silently checks NOTHING passes forever. The scan has three
+    // ways to go quiet — a moved workspace root, a renamed package, a changed
+    // import specifier — and all three look exactly like success. This asserts
+    // the guard has something to guard.
+    const { checked } = scan();
+    expect(checked.length).toBeGreaterThan(0);
+    expect(checked.some((f) => f.startsWith("packages/keel-react/"))).toBe(true);
+  });
+
+  it("no consumer reads a Graph index map directly", () => {
+    const { violations } = scan();
+    const report = violations
+      .map(
+        (v) =>
+          `${v.file}:${v.line} reads .${v.field} — use ${ACCESSOR_FOR[v.field] ?? "the accessor"}\n` +
+          `    ${v.text}`,
+      )
+      .join("\n");
+    expect(report).toBe("");
+  });
+});

--- a/packages/keel-react/keel.stories.tsx
+++ b/packages/keel-react/keel.stories.tsx
@@ -18,11 +18,14 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, within } from "storybook/test";
 
 import {
+  childrenStateOf,
   createEngine,
   defineNodeType,
   folded,
   foldedExact,
   foldMonoid,
+  getChildren,
+  getParent,
   parseNodeId,
   summaryFrom,
   weakestCertainty,
@@ -564,11 +567,17 @@ function useMoveWithinParent(): (id: NodeId, direction: -1 | 1) => void {
       // Read the graph AT CLICK TIME, not at render time. `store` is stable for
       // its lifetime, so this closure can never go stale.
       const graph = store.getGraph();
-      const parentId = graph.parentById.get(id);
-      if (parentId === undefined || parentId === null) return;
+      // `getParent`, not `graph.parentById.get` — the map answers `undefined`
+      // for an unknown id and `null` for a root, and this caller wants the same
+      // thing in both cases. The accessor already collapses them.
+      const parentId = getParent(graph, id);
+      if (parentId === null) return;
 
-      const siblings = graph.childrenById.get(parentId);
-      if (siblings === undefined) return;
+      // `getChildren` answers `[]` for anything that is not a loaded
+      // collection, and `[]` fails the `indexOf` below exactly as `undefined`
+      // did — so the load state is not load-bearing HERE. Where it is, this
+      // file uses `childrenStateOf`; see the drop handler below.
+      const siblings = getChildren(graph, parentId);
 
       const from = siblings.indexOf(id);
       if (from < 0) return;
@@ -597,12 +606,19 @@ function useMoveToCollection(): (id: NodeId, toParentId: NodeId) => void {
   return useCallback(
     (id, toParentId) => {
       const graph = store.getGraph();
-      // No `childrenById` entry means the target is not a LOADED collection,
-      // and the engine would refuse the drop with `target-not-loaded` anyway: a
-      // post-removal index into children you have never seen has no honest
-      // value.
-      const target = graph.childrenById.get(toParentId);
-      if (target === undefined) return;
+      // The target must be a LOADED collection — the engine would refuse the
+      // drop with `target-not-loaded` anyway, because a post-removal index into
+      // children you have never seen has no honest value.
+      //
+      // `childrenStateOf` is what answers that. `getChildren` cannot: it
+      // returns `[]` for a loaded-and-empty collection AND for an unloaded one,
+      // and collapsing those two is the exact ambiguity this engine exists to
+      // remove. Reading `graph.childrenById` raw would also distinguish them,
+      // which is why this line used to — but that spelling reaches past the
+      // accessor that states the contract, and the contract is what survives a
+      // change to how the graph stores its indexes.
+      if (childrenStateOf(graph, toParentId)?.status !== "loaded") return;
+      const target = getChildren(graph, toParentId);
 
       const command = store.resolveDrop({
         type: "move",
@@ -1509,8 +1525,12 @@ function AddNoteButton() {
       <Button
         testId="add-note"
         onClick={() => {
-          const children = store.getGraph().childrenById.get(IDS.actOne);
-          if (children === undefined) return;
+          const graph = store.getGraph();
+          // Loaded-or-nothing, for the same reason as the drop handler above:
+          // appending at `children.length` is only honest when the children
+          // are ones this client has actually seen.
+          if (childrenStateOf(graph, IDS.actOne)?.status !== "loaded") return;
+          const children = getChildren(graph, IDS.actOne);
           store.dispatch({
             type: "insert-nodes",
             // A SEED carries a VALUE and never an id — the engine mints the id,


### PR DESCRIPTION
`Graph` publishes its index maps as public `ReadonlyMap` fields, and every
one has an accessor beside it that means something slightly different from
the raw `.get`:

  getSubtreeRev    falls back to `deadRevById`, so a REMOVED id answers with
                   the revision it held rather than `undefined`
  getChildren      answers `[]` for anything not a loaded collection
  getParent        answers `null` for a root AND for an unknown id
  childrenStateOf  the only honest loaded/unloaded/reference/missing answer

KEEL's entire consumer surface was four call sites in `keel.stories.tsx`,
and all four read the maps raw. Two of them were not careless: they read
`childrenById` directly BECAUSE `getChildren` collapses loaded-and-empty
with unloaded, and appending at `children.length` is only honest for
children the client has actually seen. They were recovering a distinction
`childrenStateOf` already states — reaching past the accessor to get back
what the accessor above it deliberately throws away.

  :567  parentById.get   -> getParent            (caller already treated
                                                  undefined and null alike)
  :570  childrenById.get -> getChildren          ([] fails the indexOf
                                                  below exactly as undefined did)
  :604  childrenById.get -> childrenStateOf + getChildren
  :1512 childrenById.get -> childrenStateOf + getChildren

The `subtreeRevById` case is the one that would have hurt. It is the render
subscription key, and the raw map answers `undefined` for a removed id
where `getSubtreeRev` answers with the dead revision — so a subscriber
comparing revisions across a removal sees nothing change. No consumer read
it yet. The guard is what keeps that true.

WHAT THIS IS NOT. It is not a step toward structural sharing. That was the
argument that started this, and it does not hold: every field is already a
`ReadonlyMap`, which any persistent map can implement, so hiding the fields
buys nothing for a future change of representation. #580 stays open on its
own merits. What is worth protecting is the contract, and a contract is
what a test can hold and a type cannot.

WHY A TEST, NOT A COMMENT. This package's review found eight comments
describing checks that did not exist, three of which caused the bug beneath
them. A note on the field reading "prefer the accessor" is that same shape.

The guard scans only files that IMPORT keel — `collections-core`, the
predecessor engine, uses the identical field names on a type with no
accessors and no dead-rev fallback, so a repo-wide textual scan would be
almost entirely false positives.

MUTATION-PROVEN, both directions:

  reintroduce one raw `.childrenById.get` in the stories
    -> FAILS, naming file:line, the field, and the accessor to use
  point the import filter at a package that does not exist
    -> the "finds the consumer files at all" test FAILS with 0 checked

That second test exists because the scan has three silent ways to check
nothing — a moved workspace root, a renamed package, a changed import
specifier — and all three look exactly like success.

1,411 unit tests pass, 9 keel stories pass in headless Chromium, tsc clean
on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)