### PR TITLE
A commit costs what the document costs, and now the engine says so

### DIFF
--- a/packages/keel-core/commit-cost-budget.test.ts
+++ b/packages/keel-core/commit-cost-budget.test.ts
@@ -1,0 +1,281 @@
+// KEEL — the second thing a graph outgrows.
+//
+// `fold-cache-capacity.test.ts` and `review3-the-two-default-ceilings-agree.ts`
+// cover the memo table going past what it can hold. This covers the other
+// silent size failure, which has no table and no eviction counter: a commit
+// copies whole maps, so its cost is set by how many nodes the DOCUMENT holds
+// and not at all by how small the edit was.
+//
+// MEASURED, one `edit-nodes` and one `insert-nodes`, best-of-25:
+//
+//    10,025 nodes   edit  1.21 ms   insert  2.33 ms   0.120 us/node
+//    25,025 nodes   edit  3.26 ms   insert  6.28 ms   0.130 us/node
+//    50,025 nodes   edit  7.59 ms   insert 14.92 ms   0.152 us/node
+//   100,025 nodes   edit 17.06 ms   insert 33.89 ms   0.171 us/node
+//
+// `DEFAULT_MAX_NODES` is 100,000, the last row — where one keystroke is a whole
+// 60Hz frame inside the reducer before React is asked to render anything. The
+// engine's own default admits documents it cannot serve interactively, which is
+// the same two-numbers-that-do-not-know-about-each-other shape the fold-cache
+// round found, in a different pair.
+//
+// This file asserts the DIAGNOSTIC, never a duration. Wall-clock assertions
+// pass on the author's laptop, fail on a loaded CI box, and earn a `.skip`
+// within a month; the numbers above belong in a comment, and what is tested is
+// that the engine says something when a graph crosses the line.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type Issue,
+  type Result,
+  type SummaryCodec,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { DEFAULT_MAX_NODES } from "./serialize";
+import { createEngine, DEFAULT_INTERACTIVE_NODE_BUDGET } from "./engine";
+
+type Clip = Readonly<{ title: string; seconds: number }>;
+const clipType = defineNodeType<Clip, Readonly<{ title?: string }>>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const seconds = record["seconds"];
+    if (typeof title !== "string" || typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$", message: "shape" }] };
+    }
+    return { ok: true, value: { title, seconds } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, seconds: data.seconds };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+const folderType = defineNodeType<Folder, Readonly<{ name?: string }>>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const n = record["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function captureErrors() {
+  return vi.spyOn(console, "error").mockImplementation(() => undefined);
+}
+
+/** A root with `total - 1` clip children, so `nodesById.size === total`. */
+function docOf(total: number) {
+  const children: string[] = [];
+  const nodes: unknown[] = [];
+  for (let i = 0; i < total - 1; i += 1) children.push(`c${i}`);
+  nodes.push({ id: "root", kind: "folder", data: { name: "R" }, children });
+  for (const id of children) {
+    nodes.push({ id, kind: "clip", data: { title: id, seconds: 1 } });
+  }
+  return { formatVersion: 1, schemaVersions: { clip: 1, folder: 1 }, rootIds: ["root"], nodes };
+}
+
+type Options = Readonly<{ interactiveNodeBudget?: number; maxNodes?: number }>;
+
+function storeOf(nodes: number, options: Options = {}) {
+  const engine = createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    ...(options.interactiveNodeBudget === undefined
+      ? {}
+      : { interactiveNodeBudget: options.interactiveNodeBudget }),
+    ...(options.maxNodes === undefined ? {} : { maxNodes: options.maxNodes }),
+  });
+  const loaded = engine.deserialize(docOf(nodes));
+  if (!loaded.ok) throw new Error(`fixture failed to load: ${loaded.error.message}`);
+  if (loaded.value.graph.nodesById.size !== nodes) {
+    throw new Error(
+      `fixture is ${loaded.value.graph.nodesById.size} nodes, wanted ${nodes}`,
+    );
+  }
+  return { engine, graph: loaded.value.graph };
+}
+
+describe("a store says so when its commits stop fitting a frame", () => {
+  it("warns for a graph past the budget", () => {
+    const { engine, graph } = storeOf(201, { interactiveNodeBudget: 200 });
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).toHaveBeenCalled();
+    const message = String(spy.mock.calls[0]?.[0] ?? "");
+    // The two numbers a consumer acts on: how big this graph actually is, and
+    // the knob that silences the message once they have priced it.
+    expect(message).toContain("201");
+    expect(message).toContain("interactiveNodeBudget");
+  });
+
+  it("stays silent AT the budget, not just under it", () => {
+    // Off-by-one in the comparison is the likeliest way this check goes wrong,
+    // and it goes wrong quietly in both directions.
+    const { engine, graph } = storeOf(200, { interactiveNodeBudget: 200 });
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent for a small graph", () => {
+    const { engine, graph } = storeOf(50, { interactiveNodeBudget: 200 });
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when the consumer set the budget to zero", () => {
+    const { engine, graph } = storeOf(5_000, { interactiveNodeBudget: 0 });
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("warns at most ONCE, however many commits follow", () => {
+    const { engine, graph } = storeOf(201, { interactiveNodeBudget: 200 });
+    const spy = captureErrors();
+    const store = engine.createStore(graph);
+    for (let i = 0; i < 3; i += 1) {
+      store.dispatch({
+        type: "insert-nodes",
+        toParentId: parseNodeId("root"),
+        toIndex: 0,
+        seeds: [{ kind: "clip", data: { title: `x${i}`, seconds: 1 } }],
+      });
+    }
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns when a graph GROWS past the budget", () => {
+    // The case a load-time-only check cannot see, and the reason this is
+    // re-checked on commit: a document that loads comfortably and is edited
+    // past the line one insert at a time.
+    const { engine, graph } = storeOf(198, { interactiveNodeBudget: 200 });
+    const spy = captureErrors();
+    const store = engine.createStore(graph);
+    expect(spy).not.toHaveBeenCalled();
+    for (let i = 0; i < 5; i += 1) {
+      store.dispatch({
+        type: "insert-nodes",
+        toParentId: parseNodeId("root"),
+        toIndex: 0,
+        seeds: [{ kind: "clip", data: { title: `g${i}`, seconds: 1 } }],
+      });
+    }
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("is NOT silenced by a consumer who named maxNodes", () => {
+    // The one place this departs from the fold-cache warning, which does go
+    // quiet when `foldCacheLimit` is named. `foldCacheLimit` and the table it
+    // sizes answer the same question, so naming one IS choosing. `maxNodes`
+    // does not: it is a trust boundary against hostile payloads, and a
+    // consumer who bounded allocation at 50,000 has said nothing at all about
+    // what they will accept per keystroke. Reading their security number as a
+    // performance opinion would silence exactly the deployment most likely to
+    // need this.
+    const { engine, graph } = storeOf(201, {
+      interactiveNodeBudget: 200,
+      maxNodes: 500,
+    });
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("uses the measured default when the consumer names no budget", () => {
+    // The expensive test, and the only one that proves the DEFAULT is wired
+    // rather than the parameter. A budget that defaults to `undefined` and
+    // compares as `NaN` would pass every test above and warn for nothing, ever.
+    const { engine, graph } = storeOf(DEFAULT_INTERACTIVE_NODE_BUDGET + 1);
+    const spy = captureErrors();
+    engine.createStore(graph);
+    expect(spy).toHaveBeenCalled();
+    expect(String(spy.mock.calls[0]?.[0] ?? "")).toContain(
+      String(DEFAULT_INTERACTIVE_NODE_BUDGET),
+    );
+  });
+});
+
+describe("the two size defaults disagree, and that is the point", () => {
+  it("maxNodes admits documents past the interactive budget", () => {
+    // Executable rather than prose, because the comment that used to describe
+    // the relationship between `maxNodes` and the fold table was wrong, and
+    // this is the same claim about a different pair.
+    expect(DEFAULT_MAX_NODES).toBeGreaterThan(DEFAULT_INTERACTIVE_NODE_BUDGET);
+    // 4x. A document at the node ceiling costs about four times per keystroke
+    // what one at the budget does — worse than 4x in fact, because the measured
+    // per-node cost rises with size.
+    expect(DEFAULT_MAX_NODES / DEFAULT_INTERACTIVE_NODE_BUDGET).toBe(4);
+  });
+
+  it("the interactive budget is a diagnostic, not a ceiling", () => {
+    // A graph well past the budget still LOADS and still COMMITS. If this ever
+    // starts throwing or rejecting, the diagnostic has become a gate and the
+    // trust boundary has quietly moved.
+    const { engine, graph } = storeOf(2_000, { interactiveNodeBudget: 200 });
+    const spy = captureErrors();
+    const store = engine.createStore(graph);
+    const result = store.dispatch({
+      type: "insert-nodes",
+      toParentId: parseNodeId("root"),
+      toIndex: 0,
+      seeds: [{ kind: "clip", data: { title: "still works", seconds: 1 } }],
+    });
+    expect(result.ok).toBe(true);
+    expect(store.getGraph().nodesById.size).toBe(2_001);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -143,6 +143,46 @@ function defaultMintId(): string {
  */
 const FOLD_CACHE_HEADROOM = 2;
 
+/**
+ * Live-node count past which ONE commit stops fitting an interactive frame.
+ *
+ * WHY THERE IS A NUMBER HERE AT ALL. A commit copies whole maps: every
+ * mutation copies `subtreeRevById` (in `bumpSubtreeRevs`), a data change also
+ * copies `nodesById` (in `applyDataChanged`), and an insert or a removal copies
+ * four maps rather than two. So commit cost is proportional to how many nodes
+ * the document HOLDS and not at all to how small the edit was — one keystroke
+ * on one title pays for the whole graph.
+ *
+ * MEASURED, one `edit-nodes` and one `insert-nodes`, best-of-25, product-shaped
+ * fixture (root -> folders of 20 clips):
+ *
+ *    10,025 nodes   edit  1.21 ms   insert  2.33 ms   0.120 us/node
+ *    25,025 nodes   edit  3.26 ms   insert  6.28 ms   0.130 us/node
+ *    50,025 nodes   edit  7.59 ms   insert 14.92 ms   0.152 us/node
+ *   100,025 nodes   edit 17.06 ms   insert 33.89 ms   0.171 us/node
+ *
+ * Two things in that table decide this number. The per-node cost RISES with
+ * size — 42% worse at 100,000 than at 10,000, as allocation and GC stop being
+ * free — so extrapolating the small sizes linearly UNDERSTATES what a large
+ * document costs. And `DEFAULT_MAX_NODES` is 100,000, where a single keystroke
+ * costs 17 ms: a whole 60Hz frame inside the reducer, before React is asked to
+ * render anything. The engine's own default admits documents it cannot serve
+ * interactively.
+ *
+ * 25,000 is where the worst common gesture — an insert, which copies four maps
+ * — still costs 6.3 ms, about a third of a frame, leaving the rest for render.
+ * Above it the curve bends the wrong way.
+ *
+ * A DIAGNOSTIC, NOT A GATE, and deliberately not a lowered `maxNodes`. That
+ * ceiling is a TRUST boundary: it exists so a hostile payload cannot decide how
+ * much memory this process allocates, and lowering it to serve a performance
+ * argument would refuse honest documents for the wrong reason. The two numbers
+ * answer different questions and both should be sayable — which is the same
+ * mistake, in the other direction, that #585 found between `maxNodes` and
+ * `foldCacheLimit`. This one is audible instead of enforced.
+ */
+export const DEFAULT_INTERACTIVE_NODE_BUDGET = 25_000;
+
 const noop = (): void => {};
 
 function sameIds(a: readonly NodeId[], b: readonly NodeId[]): boolean {
@@ -429,6 +469,51 @@ export function createEngine<
     };
     warnIfCacheCannotCover(initialGraph);
 
+    /**
+     * The OTHER thing a graph outgrows, and it outgrows it silently.
+     *
+     * A commit copies whole maps — see `DEFAULT_INTERACTIVE_NODE_BUDGET` for
+     * which ones and what they cost — so the price of a keystroke is set by how
+     * many nodes the document holds, not by how small the edit was. There is no
+     * symptom short of a laggy app: nothing throws, nothing is dropped, every
+     * result is correct, and the frame is simply gone.
+     *
+     * SAME SHAPE AS THE CACHE WARNING ABOVE, and for the same reasons. Checked
+     * against `nodesById.size` rather than a ceiling, because the ceiling is a
+     * number about payloads and this is a question about THIS graph. Latched,
+     * so it is one integer compare behind a boolean after the first crossing.
+     * Re-checked on commit, because the case a load-time check cannot see is
+     * the document that loads small and grows.
+     *
+     * NOT GATED ON `maxNodes`, and that is the one place it departs from the
+     * cache warning. `foldCacheLimit` and the table it sizes answer the same
+     * question, so naming one is choosing. `maxNodes` does not: it is a trust
+     * boundary against hostile payloads, and a consumer who set it to 50,000 to
+     * bound allocation has said nothing whatever about what they will accept
+     * per keystroke. Reading their security number as a performance opinion
+     * would silence exactly the deployment most likely to need this.
+     */
+    let warnedAboutCommitCost = false;
+    const warnIfCommitCostIsPastInteractive = (candidate: Graph<Ts, S>): void => {
+      if (warnedAboutCommitCost) return;
+      const budget = config.interactiveNodeBudget ?? DEFAULT_INTERACTIVE_NODE_BUDGET;
+      // A named budget is a choice, and `0` is how that choice says "never".
+      if (budget <= 0) return;
+      const nodeCount = candidate.nodesById.size;
+      if (nodeCount <= budget) return;
+      warnedAboutCommitCost = true;
+      console.error(
+        `keel: this graph holds ${nodeCount} live nodes, past the ${budget} this engine ` +
+          `treats as interactive. A commit copies whole maps — every mutation copies ` +
+          `subtreeRevById, a data change also copies nodesById, an insert or removal copies ` +
+          `four — so a commit costs what the DOCUMENT costs, not what the edit costs: ` +
+          `measured at 3.3 ms per keystroke at 25,000 nodes and 17.1 ms at 100,000, where ` +
+          `one keystroke is a whole 60Hz frame before anything renders. Set ` +
+          `EngineConfig.interactiveNodeBudget to silence this once you have priced it.`,
+      );
+    };
+    warnIfCommitCostIsPastInteractive(initialGraph);
+
     // Handed out here, before the store exists and before any fold can run, so
     // a consumer that wants the counters has them from the first `aggregate`
     // rather than from whenever it next remembered to ask.
@@ -552,9 +637,11 @@ export function createEngine<
 
       graph = next;
       auditIfDev(label, next);
-      // A graph grows; the table does not. Latched, so this is one integer
-      // compare behind a boolean after the first crossing.
+      // A graph grows; the table does not, and neither does the frame. Both
+      // latched, so each is one integer compare behind a boolean after the
+      // first crossing.
       warnIfCacheCannotCover(next);
+      warnIfCommitCostIsPastInteractive(next);
 
       const selectionChanged = pruneSelection();
 

--- a/packages/keel-core/index.ts
+++ b/packages/keel-core/index.ts
@@ -203,4 +203,10 @@ export {
 // The assembled engine
 // ---------------------------------------------------------------------------
 
-export { createEngine } from "./engine";
+export {
+  createEngine,
+  // Named for the same reason the other two defaults are: a consumer deciding
+  // whether to raise `EngineConfig.interactiveNodeBudget` needs to see what
+  // they are raising it from, and the measurement that set it.
+  DEFAULT_INTERACTIVE_NODE_BUDGET,
+} from "./engine";

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1250,6 +1250,23 @@ export type EngineConfig<
    */
   maxNodes?: number;
   /**
+   * Live-node count past which each store warns ONCE that its commits no
+   * longer fit an interactive frame. Defaults to
+   * `DEFAULT_INTERACTIVE_NODE_BUDGET`; `0` silences it.
+   *
+   * NOT A CEILING, and specifically not `maxNodes` by another name. `maxNodes`
+   * is a trust boundary on one incoming payload — it refuses hostile input so a
+   * document cannot decide this process's memory. This is a property of ANY
+   * graph however it got that big, including one that loaded at 900 nodes and
+   * grew past the budget an insert at a time, which no load-time check can see.
+   *
+   * Set it when you know your documents are large and you have accepted what a
+   * commit costs there — the number in `DEFAULT_INTERACTIVE_NODE_BUDGET` is
+   * measured, not guessed, and a consumer who names their own has named THE
+   * budget. Setting `0` is the same statement, said louder.
+   */
+  interactiveNodeBudget?: number;
+  /**
    * Ceiling on nesting depth. Defaults to UNBOUNDED, deliberately.
    *
    * Depth is not a correctness risk here and a default would be a fiction:


### PR DESCRIPTION
A commit copies whole maps. Every mutation copies `subtreeRevById` (in
`bumpSubtreeRevs`), a data change also copies `nodesById` (in
`applyDataChanged`), and an insert or removal copies four rather than two.
So the price of a keystroke is set by how many nodes the DOCUMENT holds and
not at all by how small the edit was — and there is no symptom short of a
laggy app. Nothing throws, nothing is dropped, every result is correct, and
the frame is simply gone.

MEASURED, one `edit-nodes` and one `insert-nodes`, best-of-25, product-
shaped fixture (root -> folders of 20 clips):

   10,025 nodes   edit  1.21 ms   insert  2.33 ms   0.120 us/node
   25,025 nodes   edit  3.26 ms   insert  6.28 ms   0.130 us/node
   50,025 nodes   edit  7.59 ms   insert 14.92 ms   0.152 us/node
  100,025 nodes   edit 17.06 ms   insert 33.89 ms   0.171 us/node

`DEFAULT_MAX_NODES` is 100,000 — the last row, where ONE KEYSTROKE IS A
WHOLE 60Hz FRAME inside the reducer before React is asked to render
anything. The engine's own default admits documents it cannot serve
interactively. That is the same shape #585 just fixed between `maxNodes`
and `foldCacheLimit`: two numbers that do not know about each other.

Note the per-node cost RISES with size — 42% worse at 100,000 than at
10,000, as allocation and GC stop being free — so extrapolating the small
sizes linearly understates what a large document costs.

`DEFAULT_INTERACTIVE_NODE_BUDGET` is 25,000: where the worst common gesture
(an insert, four maps) still costs 6.3 ms, about a third of a frame,
leaving the rest for render. Above it the curve bends the wrong way.

A DIAGNOSTIC, NOT A GATE, and deliberately not a lowered `maxNodes`. That
ceiling is a TRUST boundary — it exists so a hostile payload cannot decide
how much memory this process allocates — and lowering it to serve a
performance argument would refuse honest documents for the wrong reason.
The two numbers answer different questions and both should be sayable.

Same shape as the fold-cache warning: checked against `nodesById.size`
rather than a ceiling, latched to one integer compare behind a boolean, and
re-checked on commit because the case a load-time check cannot see is the
document that loads at 900 nodes and is edited past the line one insert at
a time.

ONE DEPARTURE. It is NOT gated on `maxNodes`, where the cache warning does
go quiet when `foldCacheLimit` is named. `foldCacheLimit` and the table it
sizes answer the same question, so naming one IS choosing. `maxNodes` does
not: a consumer who bounded allocation at 50,000 against hostile input has
said nothing whatever about what they will accept per keystroke. Reading
their security number as a performance opinion would silence exactly the
deployment most likely to need this. `EngineConfig.interactiveNodeBudget`
is the knob that means what it says; `0` silences.

MUTATION-PROVEN, five mutations, each killed by the test written for it:

  never fires (budget x1000)      -> 6 tests fail
  default not wired (?? 0)        -> "uses the measured default" fails
  no re-check on commit           -> "warns when a graph GROWS" fails
  gated on maxNodes               -> "is NOT silenced by maxNodes" fails
  off-by-one (< instead of <=)    -> "stays silent AT the budget" fails

AND PROVEN NOT TO BE NOISY, which is the failure the #579 diagnostic hit
three times before it landed. Grepping the suite output was useless —
vitest does not print `console.error` — so the check was to make the
warning THROW and run all 1,419 tests: it fires exactly 6 times, all 6 in
this commit's own fixtures, zero anywhere else in the package.

1,419 unit tests pass, tsc clean on both packages.

Part of the #580 discussion — this is the half that does not depend on choosing a graph representation. #580 stays open for that choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)