### PR TITLE
The delete gate stops measuring corpses, and two comments stop lying

### DIFF
--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -389,8 +389,18 @@ export function createEngine<
      * many (fold, node, rev) entries the memo table holds. They are
      * independent numbers describing one graph, and at the DEFAULTS they
      * disagree: a registry of 8 folds — the size ./folds itself calls
-     * realistic — makes the table cover 16,384 nodes while the node ceiling
-     * admits 100,000.
+     * realistic — makes the table cover `limit / (folds × FOLD_CACHE_HEADROOM)`
+     * = 8,192 nodes, while the node ceiling admits 100,000. That is a factor of
+     * twelve, not the factor of six the bare product would suggest.
+     *
+     * DERIVED, NOT QUOTED, and that is deliberate. These two sentences said
+     * "16,384" until the headroom multiple landed, because 16,384 was the bare
+     * `limit / folds` and had been right until it wasn't. Writing the division
+     * out means the next change to `FOLD_CACHE_HEADROOM` cannot leave this
+     * paragraph asserting a number the code disagrees with — which it did, for
+     * three pull requests, introduced by the fix for the previous instance of
+     * exactly that. `./review3-the-two-default-ceilings-agree.test.ts` holds
+     * both numbers executably; this is the reading, not the record.
      *
      * Past that point the LRU does not degrade, it INVERTS: fold k's walk
      * evicts fold 1's entries, fold 1's next read misses at the root, and every
@@ -419,9 +429,11 @@ export function createEngine<
       if (warnedAboutCacheSize) return;
       // ONLY WHEN THE LIMIT IS THE DEFAULT. A consumer who wrote a number chose
       // it; the failure this exists to catch belongs to the consumer who wrote
-      // none and does not know the default stops covering at 16,384 nodes. This
-      // is the same rule `maxNodes` states a few lines up — "a consumer who
-      // names a ceiling has named THE ceiling" — applied to the other one.
+      // none and does not know the default stops comfortably covering at
+      // `servable` nodes — 8,192 at 8 folds, computed below rather than quoted
+      // here. This is the same rule `maxNodes` states a few lines up — "a
+      // consumer who names a ceiling has named THE ceiling" — applied to the
+      // other one.
       //
       // It is also what makes the diagnostic quiet enough to keep: checking
       // every store took out four of this package's own capacity tests, which

--- a/packages/keel-core/performance.test.ts
+++ b/packages/keel-core/performance.test.ts
@@ -328,6 +328,41 @@ function at<T>(items: readonly T[], index: number, what: string): T {
   return item;
 }
 
+/**
+ * THE ASSERTION THAT WOULD HAVE CAUGHT IT, and the reason it now runs on every
+ * fixture in this file rather than on the one that was wrong.
+ *
+ * A quarantined node is a SUCCESS, by design: the four-state model exists so a
+ * node the codec refuses can still be held, named and repaired rather than
+ * taking its document down with it. That is exactly what makes a quarantined
+ * FIXTURE invisible. `deserialize` returns ok, `report.nodeCount` matches,
+ * `expect(loaded.ok).toBe(true)` passes, and every count a benchmark normally
+ * checks agrees — while the graph is a field of corpses and the parsed path the
+ * gate claims to measure never executes.
+ *
+ * MEASURED: the flat delete fixture omitted the `assetId` that `clipType.parse`
+ * requires, so 1,000/1,000 and 10,000/10,000 clips quarantined, and the timed
+ * path ran roughly 20-28% under the gesture the gate is named after. It went
+ * green for three review rounds and its number was the headline row of the
+ * survey.
+ *
+ * Nothing else distinguishes the two states, so this has to be its own check.
+ * It THROWS rather than expects because two of its three call sites are
+ * module-level fixture builders with no `expect` in scope, and because a broken
+ * fixture is a harness bug rather than a result.
+ */
+function assertNothingQuarantined(
+  report: Readonly<{ quarantined: readonly unknown[] }>,
+  label: string,
+): void {
+  if (report.quarantined.length === 0) return;
+  throw new Error(
+    `keel performance fixture: ${label} quarantined ` +
+      `${report.quarantined.length} node(s) — the fixture does not satisfy its ` +
+      `own codec, so this measures the unparsed path rather than the gesture`,
+  );
+}
+
 type WideFixture = Readonly<{
   label: string;
   nodeCount: number;
@@ -426,6 +461,9 @@ function makeWideFixture(nodeCount: number): WideFixture {
         `${loaded.value.report.nodeCount} of ${nodes.length} nodes`,
     );
   }
+  // `nodeCount` counts quarantined nodes too, so the check above agrees with
+  // a document that parsed nothing. This is the one that does not.
+  assertNothingQuarantined(loaded.value.report, `wide/${nodeCount}`);
 
   return {
     label: `wide/${nodeCount}`,
@@ -478,6 +516,7 @@ function makeDeepFixture(depth: number): DeepFixture {
       `keel performance fixture: deep/${depth} failed to load: ${loaded.error.message}`,
     );
   }
+  assertNothingQuarantined(loaded.value.report, `deep/${depth}`);
 
   return {
     label: `deep/${depth}`,
@@ -1245,7 +1284,18 @@ describe("mutations", () => {
         children: childIds,
       });
       for (const id of childIds) {
-        nodes.push({ id, kind: "clip", data: { title: id, seconds: 1 } });
+        // `assetId` IS REQUIRED by `clipType.parse`, and omitting it here cost
+        // this gate its meaning for three rounds. Without it every clip failed
+        // ingress and arrived QUARANTINED — 1,000/1,000 and 10,000/10,000,
+        // reproduced — which is a success path, so `deserialize` returned ok,
+        // the assertion below passed, and the gate measured the corpse path at
+        // roughly 20-28% under the gesture it is named after. See
+        // `expectNothingQuarantined`, which is why it cannot happen again.
+        nodes.push({
+          id,
+          kind: "clip",
+          data: { title: id, seconds: 1, assetId: `asset-${id}` },
+        });
       }
       const loaded = engine.deserialize({
         formatVersion: 1,
@@ -1255,6 +1305,7 @@ describe("mutations", () => {
       });
       expect(loaded.ok).toBe(true);
       if (!loaded.ok) return;
+      assertNothingQuarantined(loaded.value.report, `flat/${siblings}`);
       const graph = loaded.value.graph;
 
       const command: Command<Types, Summary> = {


### PR DESCRIPTION
Closes #588. Closes #589.

#588 — THE GATE MEASURED AN ALL-QUARANTINED GRAPH

The flat fixture for "a multi-select delete is linear in the siblings it
removes" built clips as `{ title, seconds }`. `clipType.parse` in the same
file requires `assetId: string` and refuses without it, so every clip failed
ingress and arrived QUARANTINED.

Quarantine is a SUCCESS path — that is the whole point of the four-state
model — so `deserialize` returned ok, `report.nodeCount` matched, the gate's
own `expect(loaded.ok).toBe(true)` passed, and it went green for three
review rounds while timing the unparsed path. Its number was the headline
row of the survey.

  1000 siblings: loaded.ok=true, quarantined  1000/1000  clips
 10000 siblings: loaded.ok=true, quarantined 10000/10000 clips

The `LoadReport` knew all along. Nothing read it.

Fixed by giving the fixture its `assetId`, and by adding
`assertNothingQuarantined` to all THREE fixtures in the file — flat, wide
and deep — because nothing else distinguishes "loaded" from "loaded, and
every node is a corpse". It throws rather than expects: two of its three
call sites are module-level builders with no `expect` in scope.

The calibrated ratio still holds on the honest fixture with NO
re-baselining. All 15 gates pass.

MUTATION-PROVEN, four ways:

  flat fixture loses assetId   -> FAILS, "flat/1000 quarantined 1000 node(s)"
  wide fixture loses assetId   -> FAILS, "wide/100 quarantined 94 node(s)"
  deep fixture loses assetId   -> FAILS, "deep/1000 quarantined 1 node(s)"
  guard disabled AND fixture broken -> 15 PASS

That last one is the important one. It reproduces exactly the state this
package shipped in, and confirms nothing else in the suite catches it. The
guard is the only thing that does.

AND THE GATE STILL CATCHES WHAT IT EXISTS FOR

A fixture change can quietly cost a gate its teeth, so the regression was
put back rather than argued about. Reverting #576's memoised slot lookup to
the pre-fix `indexOf` per node, on the honest fixture:

  ratio 54.7x against a linear reference of 13.8x  -> FAILS

Control, with the fix in place: ratio 14.8x against 14.0x. The gate is
intact and, if anything, now measures the gesture it names.

ONE THING THIS TURNED UP THAT IS NOT FIXED HERE. #576 removed two
quadratics. Reverting the OTHER one — the `splice`-per-id shape in
`spliceOutMany` — produces ratio 17.6x against a reference of 14.8x, which
PASSES. Either the hand-written revert does not match the original defect,
or this gate covers only one of the two halves at 1,000/10,000 siblings.
Worth its own investigation; deliberately not guessed at here.

#589 — TWO COMMENTS SAID 16,384 WHERE THE CODE COMPUTES 8,192

`engine.ts:392` and `:422` both told the reader the default fold table
covers 16,384 nodes. `engine.ts:460` computes
`limit / (folds x FOLD_CACHE_HEADROOM)` = 8,192 at the defaults. 16,384 was
the bare `limit / folds` and was right until #585 added the headroom
multiple, updated the message and the tests, and left the prose.

That made it the seventh instance of this package's signature defect —
introduced by the fix for the sixth, and surviving #586, #587 and a
four-lens audit.

Both now state the DIVISION rather than the constant, so the next change to
`FOLD_CACHE_HEADROOM` cannot leave them stale a third time. The executable
record already lives in review3-the-two-default-ceilings-agree.test.ts;
these are the reading, not the record.

1,421 unit tests pass, tsc clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)