### PR TITLE
Every package is linted and typechecked, and turning it on found dead code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,24 @@ jobs:
       - name: Install
         run: npm install
 
-      - name: Typecheck UI package
-        working-directory: packages/ui
-        run: npx tsc --noEmit -p tsconfig.json
+      # EVERY package with a tsconfig, discovered from disk rather than listed
+      # here. This step used to be `packages/ui` alone, which left four packages
+      # unchecked — including both keel packages and `timeline-model`, which did
+      # not compile at all and had not for long enough that nobody knew.
+      - name: Typecheck packages
+        run: npm run typecheck:packages
 
       - name: Typecheck app
         working-directory: apps/timeline-gstudio001
         run: npx tsc --noEmit
+
+      # The app's eslint base path is the app directory, so running its lint
+      # against a workspace package answered "File ignored because outside of
+      # base path" — a WARNING and exit 0, which reads as a pass. Nothing in
+      # `packages/` had ever been linted; the first run found three unreferenced
+      # production symbols in keel-core alone.
+      - name: Lint packages
+        run: npm run lint:packages
 
       - name: Lint app
         working-directory: apps/timeline-gstudio001

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,100 @@
+// Lint for the WORKSPACE PACKAGES. The app has its own config and its own
+// `npm run lint`; this one exists because nothing covered `packages/` at all.
+//
+// WHAT WAS WRONG. eslint's base path is the directory holding the config, so
+// running the app's eslint against a workspace package answered:
+//
+//     0:0  warning  File ignored because outside of base path
+//     ✖ 1 problem (0 errors, 1 warning)   exit 0
+//
+// A warning and a zero exit — which reads as a pass and is not one. Six
+// packages, including the only two that ship JSX, had never been linted once.
+// `react/display-name` is an ERROR in this repo's app config and has failed a
+// Vercel build before; `keel-react` is the package that actually ships JSX.
+//
+// WHY A SEPARATE CONFIG rather than widening the app's base path: `keel-core`,
+// `collections-core`, `timeline-model` and `timeline-domain` are
+// framework-agnostic by rule, and inheriting the Next preset would subject them
+// to React rules they cannot violate and Next rules about a framework they must
+// never import.
+//
+// TURNING THIS ON FOUND DEAD CODE ON THE FIRST RUN — three unreferenced
+// production symbols in keel-core alone, two of them left behind by the fix
+// that replaced them, with comments still describing them as live. That is the
+// argument for the file.
+import { defineConfig } from "eslint/config";
+import tseslint from "typescript-eslint";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default defineConfig([
+  {
+    ignores: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.next/**",
+      "**/.next-dev/**",
+      "**/storybook-static/**",
+      "**/coverage/**",
+      "**/test-results/**",
+      "**/playwright-report/**",
+      // The app owns its own config, base path and `lint` script. Linting it
+      // from here would apply the wrong ruleset and drop its Next preset.
+      "apps/**",
+    ],
+  },
+
+  {
+    files: ["packages/**/*.{ts,tsx}"],
+    extends: [...tseslint.configs.recommended],
+    rules: {
+      // The repo's own rule, stated in AGENTS.md and previously enforced by
+      // nothing: "Never use `any`."
+      "@typescript-eslint/no-explicit-any": "error",
+
+      // A LEADING UNDERSCORE IS A DECLARATION OF INTENT, and this repo uses it
+      // deliberately in three shapes the default rule cannot tell from waste:
+      // a required-by-signature parameter the implementation ignores (`_ctx`
+      // in a codec that needs no context), a compile-time-only assertion whose
+      // whole job is to fail typecheck rather than run
+      // (`_previewKindsAreMediaKinds`), and a destructured field discarded on
+      // purpose (`_enabled`). Without this the rule reports 6 of its 24 hits
+      // on code that is doing exactly what it means to.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+
+      // OFF, and this is a considered exemption rather than a shrug. The rule
+      // warns that `{}` admits any non-nullish value — true, and the reason it
+      // is a good default. Every one of its ten hits here is
+      // `createEngine<Types, Summary, {}>`: a type ARGUMENT in a position
+      // already constrained to `FoldRegistry<Ts, S>`, spelling "an engine with
+      // no folds registered". The constraint does the narrowing the rule is
+      // asking for, and `Record<string, never>` would say the same thing less
+      // clearly at ten call sites.
+      "@typescript-eslint/no-empty-object-type": "off",
+    },
+  },
+
+  // React rules reach ONLY the files that can violate them. `keel-core` and
+  // the other framework-free packages are excluded by the glob, not by an
+  // override, so a React rule can never fire on a package whose whole contract
+  // is that it does not import React.
+  {
+    files: ["packages/**/*.tsx"],
+    plugins: { react, "react-hooks": reactHooks },
+    settings: { react: { version: "detect" } },
+    rules: {
+      // The one that has actually broken a deploy here. It is an ERROR in the
+      // app's config, and the packages shipping JSX had no equivalent.
+      "react/display-name": "error",
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
+    },
+  },
+]);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "storybook": "npm run storybook --workspace=apps/storybook",
     "build-storybook": "npm run build-storybook --workspace=apps/storybook",
     "dev:frontend": "npm run dev --workspace=apps/timeline-gstudio001",
+    "lint:packages": "eslint packages",
+    "typecheck:packages": "node scripts/typecheck-packages.mjs",
     "audit:ui": "node scripts/find-unreachable-ui.mjs",
     "audit:app": "node scripts/find-unreachable-app.mjs",
     "audit:loc": "node scripts/count-loc.mjs",

--- a/packages/keel-core/commands.fuzz.test.ts
+++ b/packages/keel-core/commands.fuzz.test.ts
@@ -49,7 +49,7 @@ import {
   type Issue,
   type NodeId,
   type Patch,
-  type Rejection,
+
   type RejectionCode,
   type Result,
   type Seed,

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -58,7 +58,7 @@ import {
   applyIngestEdits,
   resolveDrop as resolveDropIn,
 } from "./commands";
-import { computeFold, createFoldCache, DEFAULT_FOLD_CACHE_LIMIT } from "./folds";
+import { computeFold, createFoldCache } from "./folds";
 import {
   DEFAULT_MAX_NODES,
   deserializeDocument,

--- a/packages/keel-core/folds.test.ts
+++ b/packages/keel-core/folds.test.ts
@@ -49,6 +49,11 @@ function issue(path: string, message: string): readonly Issue[] {
   return [{ path, message }];
 }
 
+// The codec VALUE is never registered. This file builds its graph with
+// `makeLeafNode<Types>` rather than through an engine, so this exists only so
+// `typeof` can derive the `Types` tuple below — deleting it would mean
+// hand-writing that tuple and letting it drift from the codecs it describes.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const clipType = defineNodeType<ClipData, ClipEdit>()({
   kind: "clip",
   container: false,
@@ -73,6 +78,8 @@ const clipType = defineNodeType<ClipData, ClipEdit>()({
   },
 });
 
+// Same as `clipType` above: a value that exists to be `typeof`-ed.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const folderType = defineNodeType<FolderData, FolderEdit>()({
   kind: "folder",
   container: true,

--- a/packages/keel-core/history.test.ts
+++ b/packages/keel-core/history.test.ts
@@ -47,6 +47,11 @@ import {
 type Clip = Readonly<{ title: string }>;
 type ClipEdit = Readonly<{ op: "set-title"; title: string }>;
 
+// The codec VALUE is never registered. This file builds its graph with
+// `makeLeafNode<Types>` rather than through an engine, so this exists only so
+// `typeof` can derive the `Types` tuple below — deleting it would mean
+// hand-writing that tuple and letting it drift from the codecs it describes.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const clipType = defineNodeType<Clip, ClipEdit>()({
   kind: "clip",
   container: false,
@@ -73,6 +78,8 @@ const clipType = defineNodeType<Clip, ClipEdit>()({
 type Folder = Readonly<{ name: string }>;
 type FolderEdit = Readonly<{ op: "rename"; name: string }>;
 
+// Same as `clipType` above: a value that exists to be `typeof`-ed.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const folderType = defineNodeType<Folder, FolderEdit>()({
   kind: "folder",
   container: true,

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -64,7 +64,6 @@ import {
   dataChangeLeavesDerivedIndexesIntact,
   derivedIndexNeed,
   derivedIndexesAfterRemoval,
-  insertLeavesDerivedIndexesIntact,
   rebuildDerivedIndexes,
   rebuildPlacementIndex,
   reindexPlacementsAcrossMove,
@@ -272,37 +271,30 @@ function spliceIn(
  * the inverse — which is precisely what makes swapping endpoints a complete
  * inversion.
  */
-function spliceOut(
-  children: Map<NodeId, readonly NodeId[]>,
-  parentId: NodeId,
-  id: NodeId,
-): void {
-  const current = children.get(parentId);
-  if (current === undefined) return;
-  const at = current.indexOf(id);
-  if (at === -1) return;
-  const next = current.slice();
-  next.splice(at, 1);
-  children.set(parentId, next);
-}
-
 /**
- * The same copy-on-write removal, for MANY ids at once — ONE pass per parent
- * instead of one per removed node.
+ * Copy-on-write removal for MANY ids at once — ONE pass per parent instead of
+ * one per removed node.
  *
- * `spliceOut` is three O(siblings) passes (`indexOf`, `slice`, `splice`) and
- * allocates a fresh array each time, so calling it per removed node made
- * removing K of N siblings cost O(K x N). The constant is a memcpy, which is
- * why it stayed invisible: free below a thousand siblings, and 5.2 SECONDS
- * measured for select-all-then-Delete on a 40,000-item strip. Both arms that
- * remove in bulk — `applyRemoved` and `applyMoved` — now go through here.
+ * WHAT THIS REPLACED, because the reasoning is the whole justification for the
+ * shape. The per-id predecessor was three O(siblings) passes — `indexOf`,
+ * `slice`, `splice` — allocating a fresh array every call, so removing K of N
+ * siblings cost O(K x N). The constant is a memcpy, which is why it stayed
+ * invisible: free below a thousand siblings, and 5.2 SECONDS measured for
+ * select-all-then-Delete on a 40,000-item strip. Both arms that remove in bulk
+ * — `applyRemoved` and `applyMoved` — go through here.
+ *
+ * That predecessor, `spliceOut`, SAT HERE UNREFERENCED until lint reached this
+ * package for the first time and reported it. Two of the sentences above used
+ * to name it in the present tense, which is how it survived: prose describing
+ * a function nobody calls reads exactly like prose describing one everybody
+ * does. Recovered from `801c286^` if it is ever wanted again.
  *
  * `remaining.delete(id)` rather than `ids.has(id)` is deliberate and preserves
- * `spliceOut`'s exact semantics: `splice(at, 1)` removes AT MOST ONE occurrence
- * of an id, and a `has` filter would remove every copy. That can only differ on
- * a graph already violating "one id in two children arrays", and a bulk removal
- * is not the place to start quietly repairing a corruption the audit exists to
- * report.
+ * the replaced semantics exactly: `splice(at, 1)` removes AT MOST ONE
+ * occurrence of an id, and a `has` filter would remove every copy. That can
+ * only differ on a graph already violating "one id in two children arrays", and
+ * a bulk removal is not the place to start quietly repairing a corruption the
+ * audit exists to report.
  */
 function spliceOutMany(
   children: Map<NodeId, readonly NodeId[]>,

--- a/packages/keel-core/review-f3.test.ts
+++ b/packages/keel-core/review-f3.test.ts
@@ -23,7 +23,6 @@ import {
   DEFAULT_MAX_NODES,
   deserializeDocument,
   loadChildrenInto,
-  parseSerializedDocument,
 } from "./serialize";
 import { createEngine } from "./engine";
 import {

--- a/packages/keel-core/review3-a-leaf-owns-no-subtree.test.ts
+++ b/packages/keel-core/review3-a-leaf-owns-no-subtree.test.ts
@@ -210,7 +210,7 @@ describe("a leaf never owns a sourceKey", () => {
   });
 
   it("records no owner for a leaf's key in the derived index", () => {
-    const { engine, loaded } = twoLeavesSharingASource();
+    const { loaded } = twoLeavesSharingASource();
     // ASSERTED, not just guarded. An early `return` on a refused load makes
     // this test pass vacuously under exactly the mutation it exists to catch —
     // which is how the first draft of it reported a false green.

--- a/packages/keel-core/review3-a-throwing-codec-cannot-escape-as-an-exception.test.ts
+++ b/packages/keel-core/review3-a-throwing-codec-cannot-escape-as-an-exception.test.ts
@@ -148,7 +148,6 @@ function makeEngine() {
 }
 
 const clipAId = parseNodeId("a");
-const boxId = parseNodeId("box");
 
 /** root -> [a(clip 4), box(folder, unloaded, summary { seconds: 30 })] */
 function loadedStore() {

--- a/packages/timeline-domain/src/playback-manifest.test.ts
+++ b/packages/timeline-domain/src/playback-manifest.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { CLIP_GAP_SECONDS } from "@storyboard/timeline-model";
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
 import { compilePlaybackManifest, manifestToClips } from "./playback-manifest";

--- a/packages/timeline-model/layer-frame.test.ts
+++ b/packages/timeline-model/layer-frame.test.ts
@@ -75,11 +75,18 @@ describe("layerFrameForPreset", () => {
   });
 
   it("orders the three sizes, and keeps them all inside the frame", () => {
-    const widths = (["small", "medium", "large"] as const).map(
+    const [small, medium, large] = (["small", "medium", "large"] as const).map(
       (size) => layerFrameForPreset("top-left", size, WIDESCREEN, FRAME).width,
     );
-    expect(widths[0]).toBeLessThan(widths[1]);
-    expect(widths[1]).toBeLessThan(widths[2]);
+    // A real check rather than three `!`s. Under `noUncheckedIndexedAccess`
+    // every element reads as `number | undefined`, and passing that straight to
+    // `toBeLessThan` is what made this package fail `tsc` — unnoticed, because
+    // nothing in CI typechecked it until #572.
+    if (small === undefined || medium === undefined || large === undefined) {
+      throw new Error("layerFrameForPreset did not return three widths");
+    }
+    expect(small).toBeLessThan(medium);
+    expect(medium).toBeLessThan(large);
     for (const position of ["top-left", "top-right", "bottom-left", "bottom-right"] as const) {
       const rect = layerFrameRect(
         layerFrameForPreset(position, "large", WIDESCREEN, FRAME),

--- a/packages/timeline-widget/src/views/TimelineStrip.stories.tsx
+++ b/packages/timeline-widget/src/views/TimelineStrip.stories.tsx
@@ -166,26 +166,37 @@ export const Empty: Story = {
   args: { clips: [] },
 };
 
+/**
+ * A REAL COMPONENT rather than hooks inside `render`.
+ *
+ * `render: (args) => { const [x] = useState() }` is an ordinary arrow function
+ * as far as React is concerned — lowercase, not a hook — so the rules-of-hooks
+ * lint cannot verify it and React's own invariants are not guaranteed to hold
+ * across a re-render. Storybook calls it like a component, which is why it
+ * works; the rule is right that nothing makes that true.
+ */
+function InteractiveStrip(args: React.ComponentProps<typeof TimelineStrip>) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [opened, setOpened] = useState<string | null>(null);
+  return (
+    <div>
+      <TimelineStrip
+        {...args}
+        selectedClipId={selected}
+        onSelect={(clip) => setSelected(clip.id ?? null)}
+        onOpen={(clip) => setOpened(clip.title ?? clip.id ?? null)}
+      />
+      <p className="muted">
+        selected: {selected ?? "none"} · opened: {opened ?? "none"}
+      </p>
+    </div>
+  );
+}
+
 /** Selection driven through the same path the app uses. */
 export const Interactive: Story = {
   args: { clips: foobar },
-  render: (args) => {
-    const [selected, setSelected] = useState<string | null>(null);
-    const [opened, setOpened] = useState<string | null>(null);
-    return (
-      <div>
-        <TimelineStrip
-          {...args}
-          selectedClipId={selected}
-          onSelect={(clip) => setSelected(clip.id ?? null)}
-          onOpen={(clip) => setOpened(clip.title ?? clip.id ?? null)}
-        />
-        <p className="muted">
-          selected: {selected ?? "none"} · opened: {opened ?? "none"}
-        </p>
-      </div>
-    );
-  },
+  render: (args) => <InteractiveStrip {...args} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/packages/ui/dnd-collections/TrimReadouts.stories.tsx
+++ b/packages/ui/dnd-collections/TrimReadouts.stories.tsx
@@ -28,8 +28,6 @@ const neighborsRight = [
   { name: "Interview", seconds: 2, src: new URL("./fixtures/clip-portrait.png", import.meta.url).href },
 ] as const;
 
-const frameCount = (seconds: number) => Math.max(1, Math.min(5, Math.round(seconds / 2)));
-
 /** The bright, visible clip: a frame sequence scaled to `seconds * pps` wide. */
 function Frames({
   seconds,

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -9,7 +9,6 @@ import {
 
 import {
   hasSourceWindow,
-  mediaDurationSeconds,
   type MediaNode,
   type VideoMediaNode,
 } from "@storyboard/collections-core/graph";

--- a/packages/ui/timeline/hooks/use-timeline-clips.ts
+++ b/packages/ui/timeline/hooks/use-timeline-clips.ts
@@ -3,7 +3,6 @@ import {
   baseWidth,
   clamp,
   cycle,
-  getPackedDurationBefore,
   getSpec,
 } from "../utils";
 import {
@@ -21,7 +20,7 @@ export function createClip(
   forceVideo?: boolean,
 ): TimelineClip {
   let spec = getSpec(index);
-  
+
   if (forceVideo && spec.kind !== "video") {
     spec = {
       ...spec,
@@ -81,7 +80,7 @@ export function createInitialClips(itemCount: number, pixelsPerSecond: number) {
     const isFirst = index === 0;
     const isLast = index === itemCount - 1;
     const forceVideo = isFirst || isLast;
-    
+
     const clip = createClip(index, nextStartTime, pixelsPerSecond, forceVideo);
     clips.push(clip);
     nextStartTime += clip.duration + CLIP_GAP_SECONDS;
@@ -263,7 +262,6 @@ export function editVideoSourceWindowFromBaseline({
   anchorIndex,
   mode,
   deltaTime = 0,
-  sourceTime = 0,
   minDuration,
 }: {
   baselineClips: TimelineClip[];

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -798,7 +798,7 @@ export const TheInsetLandsWhereTheRenderPutsIt: Story = {
     const found: Array<[number, number]> = [];
     for (let x = 0; x < canvas.width; x += 8) {
       for (let y = 0; y < canvas.height; y += 8) {
-        const [r, g, b] = context.getImageData(x, y, 1, 1).data;
+        const [r, , b] = context.getImageData(x, y, 1, 1).data;
         if (b! > 150 && r! < 120) found.push([x, y]);
       }
     }

--- a/scripts/typecheck-packages.mjs
+++ b/scripts/typecheck-packages.mjs
@@ -1,0 +1,55 @@
+// Typecheck EVERY workspace package that declares a tsconfig.
+//
+// WHY A SCRIPT and not seven CI steps: the list is derived from what is on
+// disk, so a new package is covered the day it is created rather than the day
+// someone remembers to add a step. CI had four packages uncovered — including
+// both keel packages and `timeline-model`, which did not compile at all and
+// had not for long enough that nobody knew.
+import { readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const packagesDir = join(root, "packages");
+const tscEntry = join(root, "node_modules", "typescript", "bin", "tsc");
+
+const packages = readdirSync(packagesDir).filter((name) =>
+  existsSync(join(packagesDir, name, "tsconfig.json")),
+);
+
+if (packages.length === 0) {
+  console.error("typecheck:packages found no package with a tsconfig.json");
+  process.exit(1);
+}
+
+let failed = 0;
+for (const name of packages) {
+  const cwd = join(packagesDir, name);
+  process.stdout.write(`typecheck ${name} ... `);
+  // The compiler is invoked as a JS entry point through the CURRENT node, not
+  // through `npx`. `spawnSync("npx")` fails silently on Windows without a
+  // shell — status 1, both streams empty — which reads as "every package is
+  // broken" and is really "the command never ran".
+  const run = spawnSync(process.execPath, [tscEntry, "--noEmit", "-p", "tsconfig.json"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if (run.error !== undefined) {
+    failed += 1;
+    console.log("FAILED to launch tsc:", run.error.message);
+    continue;
+  }
+  if (run.status === 0) {
+    console.log("ok");
+    continue;
+  }
+  failed += 1;
+  console.log("FAILED");
+  process.stdout.write(`${run.stdout ?? ""}${run.stderr ?? ""}\n`);
+}
+
+console.log(
+  `\n${packages.length - failed}/${packages.length} packages typecheck clean`,
+);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #572.

TWO HOLES, BOTH SILENT.

Lint: eslint's base path is the directory holding the config, so running the
app's eslint against a workspace package answered

    0:0  warning  File ignored because outside of base path
    ✖ 1 problem (0 errors, 1 warning)          exit 0

A warning and a zero exit — which reads as a pass. Seven packages had never
been linted once, including both that ship JSX. `react/display-name` is an
ERROR in this repo's app config and has failed a Vercel build before.

Typecheck: CI ran `tsc` on `packages/ui` and nothing else. Four packages
were unchecked, and `timeline-model` DID NOT COMPILE — two
`noUncheckedIndexedAccess` errors in layer-frame.test.ts, passing
`number | undefined` to `toBeLessThan`. Fixed here with a real check rather
than three `!`s.

WHAT TURNING LINT ON FOUND, on the first run, in production files:

  patches.ts:275   `spliceOut` — the per-id removal #576 replaced with
                   `spliceOutMany`, left behind unreferenced. Its
                   replacement's doc comment named it twice IN THE PRESENT
                   TENSE, which is how it survived: prose describing a
                   function nobody calls reads exactly like prose describing
                   one everybody does.
  patches.ts:67    `insertLeavesDerivedIndexesIntact` imported, never called;
                   two comments describe it in the past tense.
  engine.ts:61     `DEFAULT_FOLD_CACHE_LIMIT` imported, only ever mentioned
                   in a comment.

That is the same defect class this package's review has now found eight
times, in a form no reviewer would catch by reading: the comment is true
history and the code under it is dead.

Plus 16 more across the other packages — dead imports, an unused arg, an
unused destructured element, and a real `react-hooks/rules-of-hooks`
violation in timeline-widget, where `useState` was called inside a `render`
arrow. That one is now a named component, which is what makes the rule able
to check it at all.

THE CONFIG, and the three decisions in it:

  - `packages/**` only. The app keeps its own config, base path and script;
    linting it from here would apply the wrong ruleset and drop its Next
    preset.
  - React rules reach only `**/*.tsx`, by glob rather than by override, so a
    React rule can never fire on a package whose whole contract is that it
    does not import React.
  - `^_` is exempt from no-unused-vars. This repo uses the prefix
    deliberately in three shapes the default rule cannot tell from waste: a
    required-by-signature parameter the implementation ignores, a
    compile-time-only assertion whose job is to fail typecheck rather than
    run, and a deliberately discarded destructured field. Without it the rule
    reported 6 of 24 hits on code doing exactly what it means to.
  - `no-empty-object-type` off, with the reason written down: all ten hits
    are `createEngine<Types, Summary, {}>`, a type argument in a position
    already constrained to `FoldRegistry`.

Four codec values in keel-core tests are `typeof`-ed but never registered —
those files build graphs with `makeLeafNode<Types>` rather than an engine.
They carry an inline disable and the reason, rather than being deleted and
the tuple hand-written.

THE TYPECHECK SWEEP discovers packages from disk rather than listing them,
so a new package is covered the day it is created. It also carries a scar:
`spawnSync("npx")` fails silently on Windows without a shell — status 1,
both streams empty — which reports every package as broken when the command
never ran. It now invokes the compiler's JS entry through the current node.

MUTATION-PROVEN, both gates, four mutations:

  type error in keel-core        -> sweep FAILS, 5/7 clean, names the file
  unused const                   -> eslint exit 1, no-unused-vars
  an explicit `any`              -> eslint exit 1, no-explicit-any
  unused const named `__unused`  -> PASSES, and correctly so

That last one is in here because it was my first attempt and it proved
nothing: the name starts with an underscore, which the config deliberately
exempts. A mutation that the gate is designed to ignore is not evidence the
gate is dead.

1,421 unit tests pass, 7/7 packages typecheck clean, 0 lint errors
(14 warnings left visible: 11 unused `no-console` directives guarding a rule
this config does not enable, and 3 `exhaustive-deps` judgement calls in
existing code — both worth their own decision, neither worth bundling here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)