### PR TITLE
The four dev checks exist now, and one of them is not what it said

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -18,6 +18,8 @@
 
 import {
   describeThrown,
+  describeValue,
+  structurallyEqualBounded,
   type AnyNode,
   type ChildrenState,
   type Command,
@@ -1077,6 +1079,11 @@ function planEdits<Ts extends readonly unknown[], S>(
       container: type.container,
       schemaVersion: type.schemaVersion,
       raw,
+      // `raw` IS this codec's serialize output, so the generic
+      // `parse(serialize(d))` comparison inside `parseNodeData` would re-derive
+      // a value from the bytes it just came from and can never fail. The
+      // stronger comparison for this door runs below instead.
+      rawIsSerializeOutput: true,
     });
     if (!reparsed.ok) {
       return fail(
@@ -1087,6 +1094,83 @@ function planEdits<Ts extends readonly unknown[], S>(
     }
 
     const nextData = reparsed.value.data;
+
+    // ---- DEV CHECKS AT THE EDIT DOOR ----------------------------------------
+    //
+    // PLACED HERE, AFTER `raw` and `nextData` exist, and not earlier. Above
+    // this point `node.data` is the LIVE value by reference and the engine has
+    // not yet captured it as the history entry's `before`. A consumer
+    // `applyEdit` or `invertEdit` that normalises its argument in place — a
+    // normal performance idiom, and the exact class this file already wraps for
+    // — would therefore change what gets recorded, storing different data under
+    // `devChecks: true` than under `false` and corrupting the `before` that
+    // `verifyPatchApplies` later compares. Undo would fail `data-mismatch` on a
+    // node nothing legitimately touched.
+    if (ctx.devChecks) {
+      // 1. UPSTREAM VS DOWNSTREAM, and it is FREE — both values already exist.
+      //
+      //    `applied.value` is what the codec's own `applyEdit` produced.
+      //    `nextData` is what came back after that value made a round trip
+      //    through `serialize` and `parse`, and it is what the engine actually
+      //    STORES. If they differ, the edit the consumer asked for is not the
+      //    edit that landed, and the difference is exactly what `serialize`
+      //    dropped on the way out.
+      //
+      //    THE FIRST DRAFT OF THIS COMPARED `serialize(nextData)` AGAINST `raw`
+      //    and could not fail: for a codec that drops a field, both sides drop
+      //    it, so the two agree while the field is being lost. The lossy
+      //    fixture in ./devchecks-audits caught that, which is the entire
+      //    argument for writing the violating codec before the check.
+      const verdict = structurallyEqualBounded(applied.value, nextData);
+      if (verdict === false) {
+        console.error(
+          `keel dev check: editing a ${JSON.stringify(node.kind)} node stored something ` +
+            `different from what its own applyEdit returned. The engine stores parse's ` +
+            `OUTPUT, so a field this codec's serialize omits is dropped on every edit. ` +
+            `node=${JSON.stringify(edit.nodeId)} produced=${describeValue(applied.value)} ` +
+            `stored=${describeValue(nextData)}`,
+        );
+      }
+
+      // 2. THE OPT-IN INVERSE. `invertEdit` is declared on `NodeType` and
+      //    documented to satisfy
+      //      applyEdit(applyEdit(d, e).value, invertEdit(e, d)) deep-equals d
+      //    and the engine never calls it — undo works from whole-value
+      //    before/after pairs, which cannot be wrong. So this verifies a
+      //    property of a method nothing consults: preparation for the day it is
+      //    consulted, not a bug hunt.
+      //
+      //    `type.applyEdit` is called DIRECTLY. Building a synthetic
+      //    `edit-nodes` command and dispatching it would re-enter `planEdits`
+      //    without bound — one full validation pass per level, ending in a
+      //    stack overflow escaping `dispatch` as an exception, from a function
+      //    contracted to return a `Result`.
+      const invert = type.invertEdit;
+      if (invert !== undefined) {
+        try {
+          const inverse = invert(edit.edit, node.data);
+          const back = type.applyEdit(applied.value, inverse);
+          if (!back.ok) {
+            console.error(
+              `keel dev check: ${JSON.stringify(node.kind)}.invertEdit produced an edit its ` +
+                `own applyEdit refuses. node=${JSON.stringify(edit.nodeId)}`,
+            );
+          } else if (structurallyEqualBounded(back.value, node.data) === false) {
+            console.error(
+              `keel dev check: ${JSON.stringify(node.kind)}.invertEdit does not undo its edit. ` +
+                `applyEdit(applyEdit(d, e), invertEdit(e, d)) did not reproduce d. ` +
+                `node=${JSON.stringify(edit.nodeId)}`,
+            );
+          }
+        } catch (thrown) {
+          console.error(
+            `keel dev check: ${JSON.stringify(node.kind)}.invertEdit threw. ` +
+              describeThrown(thrown),
+          );
+        }
+      }
+    }
+
     const collection = node.container
       ? { children: node.children, summary: node.summary }
       : null;

--- a/packages/keel-core/devchecks-audits.test.ts
+++ b/packages/keel-core/devchecks-audits.test.ts
@@ -1,0 +1,477 @@
+// KEEL — the four `devChecks` audits, each with a codec built to violate it.
+//
+// `EngineContext.devChecks` named four audits and implemented NONE of them
+// (#590), so the whole risk in fixing it is shipping four audits that cannot
+// fire. Every describe block below pairs a VIOLATING fixture with a CONFORMING
+// one: the first proves the check works, the second proves it is not simply
+// shouting at everything.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  defineNodeType,
+  parseNodeId,
+  type Issue,
+  type Result,
+  type SummaryCodec,
+} from "./types";
+import { foldMonoid } from "./folds";
+import { createEngine } from "./engine";
+
+type Summary = Readonly<{ seconds: number }>;
+const summary: SummaryCodec<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "x" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const seconds = record["seconds"];
+    if (typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+    }
+    return { ok: true, value: { seconds } };
+  },
+  serialize(value): unknown {
+    return { seconds: value.seconds };
+  },
+};
+
+const folder = defineNodeType<Readonly<{ name: string }>, Readonly<{ name?: string }>>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Readonly<{ name: string }>, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "x" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function errors() {
+  return vi.spyOn(console, "error").mockImplementation(() => undefined);
+}
+
+function messagesFrom(spy: ReturnType<typeof errors>): string {
+  return spy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+}
+
+/** root -> one clip. `data` is whatever the caller's codec wants. */
+function docWith(clipData: unknown) {
+  return {
+    formatVersion: 1,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      { id: "root", kind: "folder", data: { name: "R" }, children: ["c1"] },
+      { id: "c1", kind: "clip", data: clipData },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. DEEP-FREEZING PARSED VALUES
+// ---------------------------------------------------------------------------
+
+describe("parsed values are frozen under devChecks", () => {
+  /**
+   * A codec that normalises IN PLACE during serialize — a real performance
+   * idiom, and precisely the class the reducer already wraps in try/catch. The
+   * engine stores what `parse` returned, so a `serialize` that edits its
+   * argument is quietly rewriting stored state from a method contracted to read.
+   */
+  const mutating = defineNodeType<
+    Readonly<{ title: string }>,
+    Readonly<{ title?: string }>
+  >()({
+    kind: "clip",
+    container: false,
+    schemaVersion: 1,
+    parse(raw): Result<Readonly<{ title: string }>, readonly Issue[]> {
+      if (typeof raw !== "object" || raw === null) {
+        return { ok: false, error: [{ path: "$", message: "x" }] };
+      }
+      const title = ({ ...raw } as Record<string, unknown>)["title"];
+      if (typeof title !== "string") {
+        return { ok: false, error: [{ path: "$.title", message: "title" }] };
+      }
+      return { ok: true, value: { title } };
+    },
+    serialize(data): unknown {
+      // THE VIOLATION. Frozen, this throws; unfrozen, it silently edits the
+      // value the engine is about to store.
+      (data as { title: string }).title = data.title.trim();
+      return { title: data.title };
+    },
+    applyEdit(data, edit) {
+      return { ok: true, value: { title: edit.title ?? data.title } };
+    },
+  });
+
+  it("reports a serialize that mutates its argument, and still loads", () => {
+    const engine = createEngine<readonly [typeof mutating, typeof folder], Summary, {}>({
+      types: [mutating, folder],
+      summary,
+      folds: {},
+      devChecks: true,
+    });
+    const spy = errors();
+    const loaded = engine.deserialize(docWith({ title: "  spaced  " }));
+    expect(loaded.ok).toBe(true);
+    expect(spy).toHaveBeenCalled();
+    // Reported, never thrown, and never turned into a quarantine: a document
+    // that loads clean with the flag off must load clean with it on.
+    expect(messagesFrom(spy)).toContain("keel dev check");
+  });
+
+  it("stays silent, and does not freeze, with devChecks off", () => {
+    const engine = createEngine<readonly [typeof mutating, typeof folder], Summary, {}>({
+      types: [mutating, folder],
+      summary,
+      folds: {},
+    });
+    const spy = errors();
+    expect(engine.deserialize(docWith({ title: "  spaced  " })).ok).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not throw on a codec that returns a typed array", () => {
+    // THE REGRESSION THIS GUARD EXISTS FOR. `Object.freeze` on a TypedArray
+    // with elements throws, so without the `ArrayBuffer.isView` skip, turning
+    // devChecks on takes the ingress door down for a conforming consumer.
+    const binary = defineNodeType<
+      Readonly<{ bytes: Uint8Array }>,
+      Readonly<{ bytes?: Uint8Array }>
+    >()({
+      kind: "clip",
+      container: false,
+      schemaVersion: 1,
+      parse(): Result<Readonly<{ bytes: Uint8Array }>, readonly Issue[]> {
+        return { ok: true, value: { bytes: new Uint8Array([1, 2, 3]) } };
+      },
+      serialize(): unknown {
+        return { bytes: [1, 2, 3] };
+      },
+      applyEdit(data) {
+        return { ok: true, value: data };
+      },
+    });
+    const engine = createEngine<readonly [typeof binary, typeof folder], Summary, {}>({
+      types: [binary, folder],
+      summary,
+      folds: {},
+      devChecks: true,
+    });
+    errors();
+    expect(() => engine.deserialize(docWith({ bytes: [1, 2, 3] }))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. parse(serialize(d)) ROUND-TRIP
+// ---------------------------------------------------------------------------
+
+/** Parses two fields, serializes ONE. The classic lossy codec. */
+const lossy = defineNodeType<
+  Readonly<{ title: string; note: string }>,
+  Readonly<{ title?: string }>
+>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Readonly<{ title: string; note: string }>, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "x" }] };
+    }
+    const record = { ...raw } as Record<string, unknown>;
+    const title = record["title"];
+    const note = record["note"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title, note: typeof note === "string" ? note : "" } };
+  },
+  serialize(data): unknown {
+    // THE VIOLATION: `note` is parsed, stored, and then dropped on the way out.
+    // Every save of this document silently loses it.
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+/** Normalises on parse. Conforming, and the false-alarm floor. */
+const trimming = defineNodeType<
+  Readonly<{ title: string }>,
+  Readonly<{ title?: string }>
+>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Readonly<{ title: string }>, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "x" }] };
+    }
+    const title = ({ ...raw } as Record<string, unknown>)["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title: title.trim() } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { title: edit.title ?? data.title } };
+  },
+});
+
+describe("the round trip catches a lossy serialize", () => {
+  it("reports at the ingress door", () => {
+    const engine = createEngine<readonly [typeof lossy, typeof folder], Summary, {}>({
+      types: [lossy, folder],
+      summary,
+      folds: {},
+      devChecks: true,
+    });
+    const spy = errors();
+    expect(engine.deserialize(docWith({ title: "a", note: "dropped" })).ok).toBe(true);
+    expect(messagesFrom(spy)).toContain("round trip");
+    expect(messagesFrom(spy)).toContain("clip");
+  });
+
+  it("stays silent for a NORMALISING codec — the false-alarm floor", () => {
+    // A raw-vs-reserialized comparison would report a violation here on a
+    // perfectly correct codec, which is why both halves of the comparison must
+    // be parse OUTPUTS. `{title:"  a  "}` parses to `{title:"a"}`, and `"a"`
+    // round-trips to itself.
+    const engine = createEngine<readonly [typeof trimming, typeof folder], Summary, {}>({
+      types: [trimming, folder],
+      summary,
+      folds: {},
+      devChecks: true,
+    });
+    const spy = errors();
+    expect(engine.deserialize(docWith({ title: "  a  " })).ok).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("reports at the EDIT door too", () => {
+    const engine = createEngine<readonly [typeof lossy, typeof folder], Summary, {}>({
+      types: [lossy, folder],
+      summary,
+      folds: {},
+      devChecks: true,
+    });
+    const loaded = engine.deserialize(docWith({ title: "a", note: "dropped" }));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+    const spy = errors();
+    const result = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: parseNodeId("c1"), kind: "clip", edit: { title: "b" } }],
+    });
+    expect(result.ok).toBe(true);
+    expect(spy).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. THE OPT-IN invertEdit
+// ---------------------------------------------------------------------------
+
+function clipWithInverse(
+  invertEdit: ((edit: Readonly<{ by: number }>, before: Readonly<{ n: number }>) => Readonly<{ by: number }>) | undefined,
+) {
+  return defineNodeType<Readonly<{ n: number }>, Readonly<{ by: number }>>()({
+    kind: "clip",
+    container: false,
+    schemaVersion: 1,
+    parse(raw): Result<Readonly<{ n: number }>, readonly Issue[]> {
+      if (typeof raw !== "object" || raw === null) {
+        return { ok: false, error: [{ path: "$", message: "x" }] };
+      }
+      const n = ({ ...raw } as Record<string, unknown>)["n"];
+      if (typeof n !== "number") {
+        return { ok: false, error: [{ path: "$.n", message: "n" }] };
+      }
+      return { ok: true, value: { n } };
+    },
+    serialize(data): unknown {
+      return { n: data.n };
+    },
+    applyEdit(data, edit) {
+      return { ok: true, value: { n: data.n + edit.by } };
+    },
+    ...(invertEdit === undefined ? {} : { invertEdit }),
+  });
+}
+
+describe("an opt-in invertEdit is verified", () => {
+  function run(type: ReturnType<typeof clipWithInverse>) {
+    const engine = createEngine<readonly [typeof type, typeof folder], Summary, {}>({
+      types: [type, folder],
+      summary,
+      folds: {},
+      devChecks: true,
+    });
+    const loaded = engine.deserialize(docWith({ n: 10 }));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) throw new Error("fixture");
+    const store = engine.createStore(loaded.value.graph);
+    const spy = errors();
+    const result = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: parseNodeId("c1"), kind: "clip", edit: { by: 5 } }],
+    });
+    expect(result.ok).toBe(true);
+    return spy;
+  }
+
+  it("reports an inverse that does not undo its edit", () => {
+    // WRONG ON PURPOSE: negating the delta is correct; this forgets the sign.
+    const spy = run(clipWithInverse((edit) => ({ by: edit.by })));
+    expect(messagesFrom(spy)).toContain("invertEdit");
+  });
+
+  it("stays silent for a CORRECT inverse", () => {
+    const spy = run(clipWithInverse((edit) => ({ by: -edit.by })));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when the codec declares no inverse at all", () => {
+    // The common case by far — `invertEdit` is opt-in and off by default, so
+    // the check must cost nothing and say nothing for a codec without one.
+    const spy = run(clipWithInverse(undefined));
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. THE SHADOW COLD REFOLD — cache HITS only
+// ---------------------------------------------------------------------------
+
+describe("the shadow refold audits what the memo table serves", () => {
+  const clip = defineNodeType<Readonly<{ seconds: number }>, Readonly<{ seconds?: number }>>()({
+    kind: "clip",
+    container: false,
+    schemaVersion: 1,
+    parse(raw): Result<Readonly<{ seconds: number }>, readonly Issue[]> {
+      if (typeof raw !== "object" || raw === null) {
+        return { ok: false, error: [{ path: "$", message: "x" }] };
+      }
+      const seconds = ({ ...raw } as Record<string, unknown>)["seconds"];
+      if (typeof seconds !== "number") {
+        return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };
+      }
+      return { ok: true, value: { seconds } };
+    },
+    serialize(data): unknown {
+      return { seconds: data.seconds };
+    },
+    applyEdit(data, edit) {
+      return { ok: true, value: { seconds: edit.seconds ?? data.seconds } };
+    },
+  });
+
+  function engineWith(leaf: (node: { kind: string; data: unknown }) => number) {
+    const folds = {
+      seconds: foldMonoid<readonly [typeof clip, typeof folder], Summary, number>({
+        key: "seconds",
+        empty: 0,
+        leaf: (node) => leaf(node as { kind: string; data: unknown }),
+        concat: (a, b) => a + b,
+      }),
+    };
+    return createEngine<readonly [typeof clip, typeof folder], Summary, typeof folds>({
+      types: [clip, folder],
+      summary,
+      folds,
+      devChecks: true,
+    });
+  }
+
+  it("stays silent when the table is telling the truth", () => {
+    const engine = engineWith((node) =>
+      node.kind === "clip" ? (node.data as { seconds: number }).seconds : 0,
+    );
+    const loaded = engine.deserialize(docWith({ seconds: 4 }));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+    const spy = errors();
+    // FIRST read is a miss and is deliberately NOT audited — there is nothing
+    // memoized to be wrong. The second is a hit, and that one gets a shadow.
+    store.aggregate("seconds", parseNodeId("root"));
+    store.aggregate("seconds", parseNodeId("root"));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("reports when a cached value and a fresh fold disagree", () => {
+    // A NON-DETERMINISTIC fold: every evaluation returns a different number, so
+    // the cached answer and a fresh one necessarily differ. That is exactly the
+    // SHAPE of a stale entry — the table serving something the graph no longer
+    // implies — induced honestly rather than by poking at the cache, which the
+    // store owns and does not expose.
+    let tick = 0;
+    const engine = engineWith(() => {
+      tick += 1;
+      return tick;
+    });
+    const loaded = engine.deserialize(docWith({ seconds: 4 }));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+    const spy = errors();
+    store.aggregate("seconds", parseNodeId("root"));
+    store.aggregate("seconds", parseNodeId("root"));
+    expect(messagesFrom(spy)).toContain("STALE");
+  });
+
+  it("is OFF entirely when devChecks is off", () => {
+    let tick = 0;
+    const folds = {
+      seconds: foldMonoid<readonly [typeof clip, typeof folder], Summary, number>({
+        key: "seconds",
+        empty: 0,
+        leaf: () => {
+          tick += 1;
+          return tick;
+        },
+        concat: (a, b) => a + b,
+      }),
+    };
+    const engine = createEngine<readonly [typeof clip, typeof folder], Summary, typeof folds>({
+      types: [clip, folder],
+      summary,
+      folds,
+    });
+    const loaded = engine.deserialize(docWith({ seconds: 4 }));
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+    const spy = errors();
+    store.aggregate("seconds", parseNodeId("root"));
+    const before = tick;
+    store.aggregate("seconds", parseNodeId("root"));
+    expect(spy).not.toHaveBeenCalled();
+    // And the fold ran ZERO extra times: the second read was served from the
+    // table with no shadow beside it.
+    expect(tick).toBe(before);
+  });
+});

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -38,7 +38,12 @@ import type {
   SomeNodeType,
   Store,
 } from "./types";
-import { makeFolded } from "./types";
+import {
+  describeThrown,
+  describeValue,
+  makeFolded,
+  structurallyEqualBounded,
+} from "./types";
 import {
   buildRegistry,
   documentOrder,
@@ -182,6 +187,16 @@ const FOLD_CACHE_HEADROOM = 2;
  * `foldCacheLimit`. This one is audible instead of enforced.
  */
 export const DEFAULT_INTERACTIVE_NODE_BUDGET = 25_000;
+
+/**
+ * How many shadow cold refolds one engine will run before switching itself off.
+ *
+ * A cold fold is O(subtree) — 101ms over 100,000 nodes, measured — so an
+ * unbounded shadow turns `devChecks: true` from "slower" into "unusable". A
+ * stale entry, if there is one, shows up in the first handful of reads; the
+ * thousandth comparison is not where the value is.
+ */
+const SHADOW_REFOLD_BUDGET = 1_000;
 
 const noop = (): void => {};
 
@@ -352,9 +367,85 @@ export function createEngine<
     const fold: SomeFold<Ts, S> | undefined = config.folds[key];
     if (fold === undefined) return undefined;
 
+    // ---- THE SHADOW COLD REFOLD, rescoped to CACHE HITS ONLY ---------------
+    //
+    // The audit as originally specified was "beside every cached fold read",
+    // which is either vacuous or ruinous depending on which reads it catches.
+    // MEASURED on an instrumented run: 28 of 35 shadow executions compared a
+    // COLD result against a COLD result — 11 on the deliberately uncached
+    // `engine.aggregate` path and 17 on plain misses — so 80% of the cost
+    // bought a comparison that could not fail. A miss has nothing memoized to
+    // be wrong.
+    //
+    // Checking the top-level entry FIRST is what fixes that. If it is a hit,
+    // the answer about to be returned came out of the table, and folding the
+    // same subtree cold is a genuine test of it. If it is a miss, there is
+    // nothing to audit and the shadow is skipped.
+    //
+    // WHY THIS MATTERS MORE THAN THE OTHER THREE: the table's ONLY invalidation
+    // mechanism is the (foldKey, nodeId, rev) key. Nothing evicts for
+    // correctness, so a stale entry is served silently and forever — and that
+    // has shipped twice, both times as a wrong aggregate at the root that never
+    // self-healed.
+    const shadowable =
+      ctx.devChecks &&
+      cache !== undefined &&
+      cache.get(String(key), id, getSubtreeRev(graph, id)).hit;
+
     const result = computeFold(graph, fold, id, cache);
     if (result === undefined) return undefined;
+
+    if (shadowable) shadowCheck(graph, fold, id, result.value, String(key));
+
     return makeFolded<FoldValue<F[K]>>(result);
+  };
+
+  /**
+   * BUDGETED, and the budget is not optional. A cold fold over a large subtree
+   * is real work — measured at 101ms over 100,000 nodes — and doing it on every
+   * cached read would make dev mode unusable rather than merely slower. The cap
+   * is per ENGINE and announces itself once when it runs out, so a reader is
+   * never left believing an audit is running after it has gone quiet.
+   */
+  let shadowsLeft = SHADOW_REFOLD_BUDGET;
+  const shadowCheck = (
+    graph: Graph<Ts, S>,
+    fold: SomeFold<Ts, S>,
+    id: NodeId,
+    cachedValue: unknown,
+    key: string,
+  ): void => {
+    if (shadowsLeft <= 0) return;
+    shadowsLeft -= 1;
+    if (shadowsLeft === 0) {
+      console.error(
+        `keel dev check: the shadow cold refold has spent its budget of ` +
+          `${SHADOW_REFOLD_BUDGET} comparisons and is now OFF for this engine. ` +
+          `Everything it checked agreed; later reads are no longer audited.`,
+      );
+      return;
+    }
+    // NO CACHE ARGUMENT — that is what makes it cold. Passing one would let the
+    // shadow populate the very table it is auditing, and it would then be
+    // comparing an entry against itself.
+    let fresh: ReturnType<typeof computeFold<Ts, S, unknown>>;
+    try {
+      fresh = computeFold(graph, fold, id, undefined);
+    } catch (thrown) {
+      console.error(
+        `keel dev check: a shadow cold refold of ${JSON.stringify(key)} threw. ` +
+          describeThrown(thrown),
+      );
+      return;
+    }
+    if (fresh === undefined) return;
+    if (structurallyEqualBounded(fresh.value, cachedValue) !== false) return;
+    console.error(
+      `keel dev check: the memo table served a STALE ${JSON.stringify(key)} for node ` +
+        `${JSON.stringify(id)}. Cached and freshly folded values disagree, which means an ` +
+        `entry outlived the revision that should have made it unreachable. ` +
+        `cached=${describeValue(cachedValue)} fresh=${describeValue(fresh.value)}`,
+    );
   };
 
   // -------------------------------------------------------------------------

--- a/packages/keel-core/folds.ts
+++ b/packages/keel-core/folds.ts
@@ -328,9 +328,14 @@ function cacheKey(foldKey: string, nodeId: NodeId, subtreeRev: number): string {
  * nothing has to invalidate it — eviction is a memory concern only, never a
  * correctness one.
  *
- * `limit` of zero or less disables caching entirely (every `set` is a no-op),
- * which is what a cold shadow-refold check wants; a non-finite `limit` falls
- * back to the default rather than growing without bound.
+ * `limit` of zero or less disables caching entirely (every `set` is a no-op);
+ * a non-finite `limit` falls back to the default rather than growing without
+ * bound.
+ *
+ * NOT what the shadow-refold check uses, which this comment used to recommend.
+ * That check wants ONE cold fold beside a cached one, so it omits
+ * `computeFold`'s cache argument entirely — a whole disabled cache would also
+ * disable the memoisation it exists to audit.
  *
  * Because the key carries the rev, the limit is a COST dial and nothing else —
  * evicting an entry can only make the next read do work it already did, never

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -35,6 +35,8 @@
 
 import {
   describeThrown,
+  deepFreezeBounded,
+  structurallyEqualBounded,
   describeValue,
   makeCollectionNode,
   makeLeafNode,
@@ -379,6 +381,86 @@ function ingressError(
  * decision, so a check here would either be a tautology or a second opinion
  * that can disagree with the node actually built.
  */
+/**
+ * The two content dev checks, run together because they share a value and an
+ * order: FREEZE FIRST, then round-trip. Freezing first is what makes the
+ * round-trip safe — the extra `serialize` call it introduces is consumer code,
+ * and a codec that normalises in place would otherwise mutate a value the
+ * engine is about to store, making the graph differ between `devChecks: true`
+ * and `false`. Frozen, that mutation throws into the try/catch and is reported.
+ *
+ * REPORTED, NEVER THROWN, and never converted into an `IngressError`. A node
+ * that quarantines under `devChecks: true` and loads clean under `false` would
+ * make the flag change what the document IS, which is the one thing a
+ * diagnostic must not do.
+ *
+ * RE-ENTRY, and nothing structural prevents it: `reparse` MUST call the
+ * codec's own `parse` directly. Routing the second parse back through
+ * `parseNodeData` reaches this same gate and recurses without bound, once per
+ * node, on every load.
+ */
+function runContentDevChecks(
+  devChecks: boolean,
+  what: string,
+  value: unknown,
+  serializeValue: () => unknown,
+  reparse: (raw: unknown) => Result<unknown, readonly Issue[]>,
+  skipRoundTrip: boolean,
+): void {
+  // FIRST STATEMENT, before any allocation — the same discipline `auditIfDev`
+  // follows in ./engine. Everything below is dev-only cost.
+  if (!devChecks) return;
+
+  deepFreezeBounded(value);
+  if (skipRoundTrip) return;
+
+  let wire: unknown;
+  try {
+    wire = serializeValue();
+  } catch (thrown) {
+    console.error(
+      `keel dev check: ${what} threw while serializing during the round-trip audit. ` +
+        `Nothing is stored differently; the audit is skipped for this value. ` +
+        describeThrown(thrown),
+    );
+    return;
+  }
+
+  let again: Result<unknown, readonly Issue[]>;
+  try {
+    again = reparse(wire);
+  } catch (thrown) {
+    console.error(
+      `keel dev check: ${what} threw while re-parsing its own serialize output. ` +
+        describeThrown(thrown),
+    );
+    return;
+  }
+  if (!again.ok) {
+    console.error(
+      `keel dev check: ${what} produced serialize output its own parse refuses. ` +
+        `That is a lossy or malformed codec — the value stored is the ORIGINAL parse, ` +
+        `so nothing is corrupted, but this document will not survive a save/load cycle.`,
+      again.error,
+    );
+    return;
+  }
+
+  const verdict = structurallyEqualBounded(value, again.value);
+  // "unknown" is silence. A comparator that could not see the whole value has
+  // not found a violation, and reporting one would train the reader to ignore
+  // this message.
+  if (verdict !== false) return;
+  // WORDING MATTERS: a non-idempotent `parse` produces this too, and it is a
+  // different bug from a lossy `serialize`. Say what was observed, print both
+  // halves, and let the reader decide which.
+  console.error(
+    `keel dev check: ${what} did not survive a parse(serialize(d)) round trip. ` +
+      `Either serialize drops something parse keeps, or parse is not idempotent. ` +
+      `before=${describeValue(value)} after=${describeValue(again.value)}`,
+  );
+}
+
 export function parseNodeData<S>(
   ctx: EngineContext<S>,
   args: Readonly<{
@@ -388,6 +470,15 @@ export function parseNodeData<S>(
     /** The version the document declares for this kind. */
     schemaVersion: number;
     raw: unknown;
+    /**
+     * DEV CHECKS ONLY. Set by the edit door, where `raw` is already this
+     * codec's own `serialize` output rather than wire data. The generic
+     * `parse(serialize(d))` comparison is provably vacuous there — it would
+     * re-derive a value from the same bytes it just came from — and costs two
+     * consumer codec calls per edited node on the interactive path. The edit
+     * door runs its own, stronger comparison instead.
+     */
+    rawIsSerializeOutput?: boolean;
   }>,
 ): Result<
   Readonly<{
@@ -447,6 +538,29 @@ export function parseNodeData<S>(
   if (!parsed.ok) {
     return ingressError(args.nodeId, args.kind, "parse-failed", parsed.error);
   }
+
+  // Captured, not re-read inside the closures: TypeScript loses the `parsed.ok`
+  // narrowing across a callback boundary, and the ternary that works around it
+  // reads as though the failure case were reachable here. It is not.
+  const parsedValue: unknown = parsed.value;
+  runContentDevChecks(
+    ctx.devChecks,
+    `the ${JSON.stringify(args.kind)} codec (node ${JSON.stringify(args.nodeId)})`,
+    parsedValue,
+    () => type.serialize(parsedValue),
+    // DIRECTLY, never through `parseNodeData` — see the re-entry note above.
+    // The second parse gets a THROWAWAY warn sink: reusing `warnings` would
+    // double the entries `LoadReport.warnings` receives, so the report itself
+    // would differ between dev-check modes.
+    (raw) =>
+      type.parse(raw, {
+        nodeId: args.nodeId,
+        container: args.container,
+        schemaVersion: type.schemaVersion,
+        warn: () => undefined,
+      }),
+    args.rawIsSerializeOutput === true,
+  );
 
   return {
     ok: true,
@@ -935,6 +1049,14 @@ function buildDocument<Ts extends readonly unknown[], S>(
           };
         } else {
           summary = parsedSummary.value;
+          runContentDevChecks(
+            ctx.devChecks,
+            `the summary codec (node ${JSON.stringify(id)})`,
+            parsedSummary.value,
+            () => ctx.summary.serialize(parsedSummary.value),
+            (raw) => ctx.summary.parse(raw),
+            false,
+          );
         }
       }
     }

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -921,11 +921,40 @@ export type EngineContext<S> = Readonly<{
   mintId(): string;
   now(): number;
   /**
-   * Enables the checks that are affordable in dev and not in prod: the
-   * `parse(serialize(d))` round-trip, deep-freezing parsed values, verifying
-   * an opt-in `invertEdit`, and the shadow cold refold. None of them can prove
-   * a consumer's codec actually validates — that is genuinely unenforceable —
-   * but they catch a lossy `serialize` and a wrong inverse.
+   * Enables the checks that are affordable in dev and not in prod. Every one is
+   * REPORTED through `console.error` and never thrown, never turned into a
+   * rejection, and never allowed to change what the engine stores: a document
+   * that loads clean with this off must load clean with it on.
+   *
+   * WHAT ACTUALLY RUNS, and where — this list was aspirational for a long time
+   * and named four audits the engine did not have (#590), so it is now written
+   * as an inventory rather than an intention:
+   *
+   *   - DEEP-FREEZE of every parsed value, at `parseNodeData`'s success return
+   *     and at the summary codec. Catches a `serialize` that normalises its
+   *     argument in place. Typed arrays are skipped — freezing one throws.
+   *   - `parse(serialize(d))` ROUND-TRIP at those same two doors. Catches a
+   *     `serialize` that drops a field `parse` keeps. Both sides of the
+   *     comparison are parse OUTPUTS, so a normalising codec does not
+   *     false-alarm.
+   *   - UPSTREAM VS DOWNSTREAM at the edit door: what `applyEdit` returned
+   *     against what the engine stored after its own round trip. Free, and
+   *     strictly stronger there than the generic form, which cannot fail at
+   *     that door.
+   *   - THE OPT-IN `invertEdit`, verified as
+   *     `applyEdit(applyEdit(d, e), invertEdit(e, d))` deep-equals `d`. A no-op
+   *     for the many codecs that declare no inverse.
+   *   - THE SHADOW COLD REFOLD, on cache HITS ONLY and budgeted. A miss has
+   *     nothing memoized to be wrong, so shadowing one buys a comparison that
+   *     cannot fail — measured at 80% of executions before the rescope.
+   *
+   * A fifth audit runs behind this flag and is not one of the above: the graph
+   * invariant walk after every commit. It predates the list.
+   *
+   * None of these can prove a consumer's codec actually validates — that is
+   * genuinely unenforceable. Two further limits are worth knowing: the
+   * comparator treats `Date`, `Map` and `Set` as `{}`, and freezing a `Map`
+   * does not stop `map.set`.
    */
   devChecks: boolean;
 }>;


### PR DESCRIPTION
Closes #590.

`EngineContext.devChecks` named four audits and implemented NONE. The one
gate behind the flag ran a fifth that was on no list. A test file restated
three of the four as accomplished fact.

All four now run. Every one is REPORTED, never thrown, never converted into
a rejection, and never allowed to change what is stored — a document that
loads clean with the flag off loads clean with it on. The doc comment is
rewritten as an inventory rather than an intention.

  1. DEEP-FREEZE at parseNodeData's success return and at the summary codec.
  2. parse(serialize(d)) ROUND-TRIP at those same two doors.
  3. UPSTREAM VS DOWNSTREAM at the edit door.
  4. The opt-in invertEdit, verified as documented.
  5. The shadow cold refold, on cache HITS ONLY and budgeted.

THE SHADOW REFOLD IS NOT WHAT THE CONTRACT ASKED FOR, deliberately. "Beside
every cached fold read" is vacuous or ruinous depending on which reads it
catches: instrumented, 28 of 35 shadow executions compared a COLD result
against a COLD one — 11 on the uncached `engine.aggregate` path, 17 on plain
misses — so 80% of the cost bought a comparison that cannot fail. A miss has
nothing memoized to be wrong. Checking the top-level entry for a HIT first
is what fixes it, and the budget (1,000 per engine, then it says so and
stops) is what keeps a 101ms cold fold over 100,000 nodes from making dev
mode unusable.

TWO PLACEMENT DECISIONS THAT LOOK COSMETIC AND ARE NOT:

- The freeze goes at parseNodeData, NOT the boundary constructors. That
  placement deletes four blockers at once — no threading through 13 sites,
  no ctx-less call sites, no freezing a value a rejected insert discards,
  and no Seed-vs-codec summary provenance problem. Data-only scope is TOTAL
  where whole-node scope would have been patchy, because every later re-wrap
  spreads a `data` reference that already came through this door.
- The edit-door checks go AFTER `raw` and `nextData` exist. Earlier,
  `node.data` is the live value by reference and the engine has not yet
  captured it as the history entry's `before`; a consumer `applyEdit` or
  `invertEdit` that normalises in place would corrupt that `before`, and undo
  would later fail `data-mismatch` on a node nothing legitimately touched.

I GOT THE EDIT-DOOR COMPARISON WRONG FIRST, and the fixture caught it.
Comparing `serialize(nextData)` against `raw` cannot fail for a lossy codec:
both sides drop the same field, so they agree while it is being lost. The
correct pair is what `applyEdit` RETURNED against what was STORED. That is
the entire argument for writing the violating codec before the check —
the check looked right, read right, and detected nothing.

MUTATION-PROVEN, and the primitives shipped separately in #594 carry their
own proofs (drop the ArrayBuffer.isView guard and the typed-array test fails
with "Cannot freeze array buffer views with elements"; remove the step
budget and the cycle test HANGS rather than failing).

12 new fixtures, each pairing a VIOLATING codec with a CONFORMING one so
neither "it fires" nor "it is quiet" can pass alone:

  serialize mutates its argument        -> reported, and still loads
  codec returns a Uint8Array            -> does NOT throw
  serialize drops a parsed field        -> reported at ingress AND at the edit door
  parse normalises (trims)              -> SILENT, the false-alarm floor
  invertEdit forgets the sign           -> reported
  invertEdit is correct                 -> silent
  no invertEdit at all                  -> silent, the common case
  a non-deterministic fold              -> reported as STALE
  devChecks off                         -> silent, and the fold runs zero extra times

Also corrected in passing: folds.ts recommended `createFoldCache(0)` for "a
cold shadow-refold check". A disabled cache would disable the memoisation
the check exists to audit; omitting computeFold's cache argument is what it
actually wants.

1,446 unit tests, 311 story tests, 7/7 packages typecheck clean, 0 lint
errors. All 1,434 pre-existing tests unchanged with the flag off.

Builds on the primitives from #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)