### PR TITLE
A leaf arriving with children quarantines instead of killing the document

### DIFF
--- a/packages/keel-core/serialize.test.ts
+++ b/packages/keel-core/serialize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { childrenStateOf, buildRegistry, findInvariantViolation } from "./graph";
+import { childrenStateOf, buildRegistry, findInvariantViolation, getChildren, getParent } from "./graph";
 import {
   DEFAULT_MAX_NODES,
   deserializeDocument,
@@ -939,21 +939,42 @@ describe("deserializeDocument structural failures", () => {
     expect(error.code).toBe("root-not-container");
   });
 
-  it("rejects a leaf kind carrying a children array", () => {
-    const error = expectErr(
+  // THESE TWO USED TO ASSERT REJECTION, and the change is deliberate. A leaf
+  // kind arriving with children was the last shape failure that took the WHOLE
+  // DOCUMENT down, while a node whose DATA failed to parse quarantined and
+  // everything around it loaded. Nothing justified the asymmetry: both are one
+  // node's wire form disagreeing with this build.
+  it("QUARANTINES a leaf kind carrying a children array, and keeps the children", () => {
+    const loaded = expectOk(
       loadNodes(
         ["root"],
         [
           { id: "root", kind: "folder", children: ["a"], data: { title: "R", source: null } },
-          { id: "a", kind: "clip", children: [], data: { name: "A", asset: null } },
+          { id: "a", kind: "clip", children: ["b"], data: { name: "A", asset: null } },
+          { id: "b", kind: "clip", data: { name: "B", asset: null } },
         ],
       ),
     );
-    expect(error.code).toBe("leaf-with-children");
+    expect(loaded.report.quarantined).toHaveLength(1);
+    expect(loaded.report.quarantined[0]?.reason).toBe("shape-mismatch");
+
+    const bad = loaded.graph.nodesById.get(parseNodeId("a"));
+    expect(bad?.quarantined).toBe(true);
+    // HELD AS A CONTAINER, which is the whole point. The node declared a
+    // child; something has to own it.
+    expect(bad?.container).toBe(true);
+
+    // THE ASSERTION THAT MATTERS. Recording the node as a leaf would have left
+    // `b` parentless, and nothing in this engine may be orphaned. Reverting the
+    // `containerById.set(id, true)` fall-through fails HERE, not above.
+    expect(getChildren(loaded.graph, parseNodeId("a"))).toEqual([parseNodeId("b")]);
+    expect(getParent(loaded.graph, parseNodeId("b"))).toBe(parseNodeId("a"));
+    // And the rest of the document is untouched.
+    expect(getChildren(loaded.graph, parseNodeId("root"))).toEqual([parseNodeId("a")]);
   });
 
-  it("rejects a leaf kind carrying a childrenState", () => {
-    const error = expectErr(
+  it("QUARANTINES a leaf kind carrying a childrenState", () => {
+    const loaded = expectOk(
       loadNodes(
         ["root"],
         [
@@ -962,7 +983,50 @@ describe("deserializeDocument structural failures", () => {
         ],
       ),
     );
-    expect(error.code).toBe("invalid-children-state");
+    expect(loaded.report.quarantined).toHaveLength(1);
+    expect(loaded.report.quarantined[0]?.reason).toBe("shape-mismatch");
+    const bad = loaded.graph.nodesById.get(parseNodeId("a"));
+    expect(bad?.quarantined).toBe(true);
+    // The declared load state survives, so a round trip through quarantine does
+    // not forget that the subtree was never fetched.
+    expect(bad?.quarantined === true ? bad.children?.status : null).toBe("unloaded");
+  });
+
+  it("still REJECTS a shape mismatch when the consumer asked for strictness", () => {
+    // A shape mismatch routes through `onParseFailure`, because a consumer who
+    // said "reject on a content failure at ingress" means this too. Quarantine
+    // is the DEFAULT, not the only behaviour.
+    const error = expectErr(
+      deserializeDocument<Types, Summary>(
+        {
+          formatVersion: 1,
+          schemaVersions: { clip: 1, folder: 1 },
+          rootIds: ["root"],
+          nodes: [
+            { id: "root", kind: "folder", children: ["a"], data: { title: "R", source: null } },
+            { id: "a", kind: "clip", children: [], data: { name: "A", asset: null } },
+          ],
+        },
+        { ...makeCtx(), onParseFailure: "reject" },
+      ),
+    );
+    expect(error.code).toBe("ingress-rejected");
+  });
+
+  it("a document with NO shape mismatch quarantines nothing", () => {
+    // The false-alarm floor: a healthy leaf with neither signal must still be
+    // recorded as a leaf, not swept into the new container arm.
+    const loaded = expectOk(
+      loadNodes(
+        ["root"],
+        [
+          { id: "root", kind: "folder", children: ["a"], data: { title: "R", source: null } },
+          { id: "a", kind: "clip", data: { name: "A", asset: null } },
+        ],
+      ),
+    );
+    expect(loaded.report.quarantined).toHaveLength(0);
+    expect(loaded.graph.nodesById.get(parseNodeId("a"))?.container).toBe(false);
   });
 
   it("rejects a node unreachable from any root", () => {

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -757,6 +757,8 @@ function buildDocument<Ts extends readonly unknown[], S>(
   // --- Pass C: container-ness and children state ----------------------------
   const containerById = new Map<NodeId, boolean>();
   const stateById = new Map<NodeId, ChildrenState>();
+  /** Leaf kinds that arrived carrying children. Quarantined in Pass F. */
+  const shapeMismatchById = new Map<NodeId, Issue>();
   for (const [id, node] of wireById) {
     const type = ctx.registry.get(node.kind);
     const hasChildren = node.children !== undefined;
@@ -779,22 +781,38 @@ function buildDocument<Ts extends readonly unknown[], S>(
         : hasChildren || node.childrenState !== undefined;
 
     if (!container) {
-      if (hasChildren) {
-        return fail({
-          code: "leaf-with-children",
-          message: `Node ${JSON.stringify(node.id)} of leaf kind ${JSON.stringify(node.kind)} carries a children array`,
-          nodeId: id,
-        });
+      // A LEAF KIND ARRIVING WITH CHILDREN IS QUARANTINED, NOT REJECTED.
+      //
+      // This was the last shape failure that took the whole document down,
+      // while a node whose DATA failed to parse quarantined and everything
+      // around it loaded. Nothing justified the asymmetry: both are one node's
+      // wire form disagreeing with this build, and `QuarantineReason`'s own
+      // doc already carried the argument — "one refused stored clip made a
+      // whole document unwritable forever."
+      //
+      // HELD AS A CONTAINER, deliberately, and this is the part that matters.
+      // The node declared children; they exist in the flat tree and something
+      // must own them. Recording it as a leaf here would leave every one of
+      // them parentless, which is the single thing this engine refuses to
+      // produce. `QuarantinedNode` carries both `container` and a
+      // `ChildrenState` precisely so this case has somewhere to land.
+      const mismatch = hasChildren
+        ? `carries a children array while kind ${JSON.stringify(node.kind)} is registered as a leaf`
+        : node.childrenState !== undefined
+          ? `carries childrenState ${JSON.stringify(node.childrenState)} while kind ${JSON.stringify(node.kind)} is registered as a leaf`
+          : null;
+      if (mismatch === null) {
+        containerById.set(id, false);
+        continue;
       }
-      if (node.childrenState !== undefined) {
-        return fail({
-          code: "invalid-children-state",
-          message: `Node ${JSON.stringify(node.id)} of leaf kind ${JSON.stringify(node.kind)} carries childrenState ${JSON.stringify(node.childrenState)}`,
-          nodeId: id,
-        });
-      }
-      containerById.set(id, false);
-      continue;
+      shapeMismatchById.set(id, {
+        path: "$",
+        message: `Node ${JSON.stringify(node.id)} ${mismatch}`,
+      });
+      // Fall through to the container arm below, so the declared children are
+      // walked, counted and attached exactly as a real container's would be.
+      // Pass F reads `containerById` and `stateById`, so the quarantined node
+      // it builds gets both.
     }
 
     containerById.set(id, true);
@@ -954,6 +972,12 @@ function buildDocument<Ts extends readonly unknown[], S>(
     const state = stateById.get(id) ?? { status: "unloaded" };
     const type = ctx.registry.get(wire.kind);
 
+    // A SHAPE MISMATCH SHORT-CIRCUITS THE CONTENT PASSES. There is no point
+    // migrating or parsing data for a node already known not to fit its own
+    // kind, and running `parse` on it would report a second, derived failure
+    // that tells the reader nothing about the real one.
+    const shapeIssue = shapeMismatchById.get(id);
+
     // An UNDECLARED version is read as "this build's current version", not 0.
     // Guessing 0 replays every migration over data that may already be
     // current, which corrupts it silently and permanently. Guessing current
@@ -979,12 +1003,22 @@ function buildDocument<Ts extends readonly unknown[], S>(
       type?.schemaVersion ??
       0;
 
-    let failure: IngressError | null = null;
+    let failure: IngressError | null =
+      shapeIssue === undefined
+        ? null
+        : {
+            nodeId: id,
+            kind: wire.kind,
+            reason: "shape-mismatch",
+            issues: [shapeIssue],
+          };
     let summaryFailed = false;
     let data: unknown = undefined;
     let summary: S | null = null;
 
-    const parsedData = parseNodeData(ctx, {
+    const parsedData = shapeIssue !== undefined
+      ? null
+      : parseNodeData(ctx, {
       nodeId: id,
       kind: wire.kind,
       container,
@@ -992,7 +1026,12 @@ function buildDocument<Ts extends readonly unknown[], S>(
       raw: wire.data,
     });
 
-    if (!parsedData.ok) {
+    if (parsedData === null) {
+      // A shape mismatch, already recorded above. Its DATA is never parsed:
+      // running the codec on a node known not to fit its own kind reports a
+      // second, derived failure that tells the reader nothing about the real
+      // one. `raw` is carried through byte-exact, as with every quarantine.
+    } else if (!parsedData.ok) {
       failure = parsedData.error;
     } else {
       data = parsedData.value.data;

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -302,7 +302,25 @@ export type CollectionNode<Ts extends readonly unknown[], S> = {
  * consumer-visible distinction that matters is "we could not build this", and
  * the Issue carries the detail.
  */
-export type QuarantineReason = "unknown-kind" | "parse-failed";
+export type QuarantineReason =
+  | "unknown-kind"
+  | "parse-failed"
+  /**
+   * The node's WIRE SHAPE disagrees with its registered kind: a leaf kind
+   * arriving with a children array or a `childrenState`.
+   *
+   * This used to abort the WHOLE DOCUMENT — the one shape failure that still
+   * did, while a node whose DATA failed to parse quarantined and the document
+   * loaded around it. The asymmetry was not deliberate; the comment two types
+   * down already made the argument against it: "one refused stored clip made
+   * a whole document unwritable forever."
+   *
+   * The node is held as a QUARANTINED CONTAINER carrying the children it
+   * declared, which is what keeps them from being orphaned — the one thing
+   * this engine refuses to do. Repair it by fixing the kind's `container`
+   * flag or the document, and it loads clean.
+   */
+  | "shape-mismatch";
 
 /**
  * A node whose kind is unregistered, or whose parse failed.


### PR DESCRIPTION
The last shape failure at the ingress door that took the WHOLE DOCUMENT
down. A node whose DATA failed to parse quarantined and everything around it
loaded; a node whose SHAPE disagreed with its registered kind aborted the
load entirely. Nothing justified the asymmetry — both are one node's wire
form disagreeing with this build.

`QuarantineReason`'s own doc already carried the argument, four types away
from the code that ignored it: "one refused stored clip made a whole
document unwritable forever, and since the trash bin is rewritten on every
delete, deleting *anything* became impossible."

This is the oldest untouched code in the package — unchanged since the first
KEEL commit — and the only remaining defect that can cost a user a project.
A bad migration, a schema change, one partial write, and the document does
not open at all.

HELD AS A CONTAINER, and that is the part that took the thinking. The node
declared children; they exist in the flat tree and something must own them.
Recording it as a leaf would leave every one parentless, which is the single
thing this engine refuses to produce. `QuarantinedNode` already carries both
`container` and a `ChildrenState` — the model had somewhere for this to land
before there was anything to put there.

So the node is quarantined as a container holding exactly the children it
declared. The subtree survives, addressable and movable. The node is marked
repairable, poisons its ancestors' folds to `partial` like any quarantine,
and re-emits byte-exact. Fix the kind's `container` flag or the document and
it loads clean.

ROUTED THROUGH `onParseFailure`, not through a new knob. A consumer who said
"reject on a content failure at ingress" means this too, so strictness is
preserved and quarantine is the DEFAULT rather than the only behaviour.

ITS DATA IS NEVER PARSED. Running the codec on a node already known not to
fit its own kind would report a second, derived failure that tells the
reader nothing about the real one. `raw` is carried through byte-exact, as
with every quarantine.

TWO TESTS CHANGED SIDES, deliberately: `rejects a leaf kind carrying a
children array` and `rejects a leaf kind carrying a childrenState` now
assert quarantine. They are kept rather than deleted, with the reason for
the reversal written above them, because a test that flips is the clearest
record that a contract moved.

MUTATION-PROVEN. Record the mismatched node as a LEAF instead of falling
through to the container arm — the change that orphans its children:

  QUARANTINES ... and keeps the children  -> FAILS (container false)
  QUARANTINES ... a childrenState         -> FAILS (load state lost)

Two further tests guard the edges: a consumer with `onParseFailure: "reject"`
still gets `ingress-rejected`, and a healthy leaf with neither signal is
still recorded as a leaf rather than swept into the new container arm.

1,448 unit tests, 7/7 packages typecheck clean, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)