### PR TITLE
A node type is not a codec, and a rejection now names the method that refused

### DIFF
--- a/packages/keel-core/commands.fuzz.test.ts
+++ b/packages/keel-core/commands.fuzz.test.ts
@@ -31,7 +31,7 @@
 // FIXTURES COME THROUGH THE REAL INGRESS. Graphs are built by
 // `deserializeDocument` on generated wire documents rather than by a local
 // node-assembler, so quarantine arises the way it does in production (an
-// unregistered kind, data its own codec refuses) instead of being hand-planted
+// unregistered kind, data its own node type refuses) instead of being hand-planted
 // — and the ingress door is fuzzed along with the reducer.
 
 import { describe, expect, test } from "vitest";
@@ -55,7 +55,7 @@ import {
   type Seed,
   type SerializedDocument,
   type SerializedNode,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 import {
   ancestorChain,
@@ -151,7 +151,7 @@ type ClipEdit = Readonly<{ title?: string; seconds?: number }>;
  * `parse` is deliberately STRICTER than `applyEdit`: it caps `seconds` at 100
  * while `applyEdit` does not. That asymmetry is the only way the fuzz reaches
  * the "the edit produced a value that no longer parses" branch without the
- * codec refusing the edit itself, and both branches are rejection paths the
+ * node type refusing the edit itself, and both branches are rejection paths the
  * property covers.
  */
 const clipType = defineNodeType<Clip, ClipEdit>()({
@@ -239,7 +239,7 @@ const nodeTypes = [clipType, folderType] as const;
 type Types = typeof nodeTypes;
 type Summary = Readonly<{ label: string }>;
 
-const summaryCodec: SummaryCodec<Summary> = {
+const summaryType: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };
@@ -276,7 +276,7 @@ function makeCtx(): Ctx {
   return {
     engineId: Symbol("keel-fuzz"),
     registry,
-    summary: summaryCodec,
+    summary: summaryType,
     onUnknownKind: "quarantine",
     onParseFailure: "quarantine",
     maxNodes: DEFAULT_MAX_NODES,
@@ -401,7 +401,7 @@ function randomDocument(
       return id;
     }
     if (roll < 0.66) {
-      // Registered kind, data its own codec refuses ⇒ `parse-failed`
+      // Registered kind, data its own node type refuses ⇒ `parse-failed`
       // quarantine. Byte-exact re-emit is the same promise either way.
       const data = { title: 42, seconds: "nope" };
       nodes.push({ id, kind: "clip", data });
@@ -559,18 +559,18 @@ function stateLabel(state: ChildrenState | null): string | null {
 
 function nodeDataJson(node: FuzzNode): string {
   if (node.quarantined) return stableJson(node.raw);
-  const type = registry.get(node.kind);
+  const nodeType = registry.get(node.kind);
   // Compared on the SERIALIZED form for the same reason `verifyDataChanged`
-  // does: a parsed value may carry identity its codec does not consider
-  // meaningful, and the wire form is the codec's own statement of what the
+  // does: a parsed value may carry identity its node type does not consider
+  // meaningful, and the wire form is the node type's own statement of what the
   // value IS.
-  return stableJson(type === undefined ? node.data : type.serialize(node.data));
+  return stableJson(nodeType === undefined ? node.data : nodeType.serialize(node.data));
 }
 
 function nodeSummaryJson(node: FuzzNode): string {
   if (node.quarantined) return stableJson(node.summary);
   if (!node.container) return "leaf";
-  return node.summary === null ? "null" : stableJson(summaryCodec.serialize(node.summary));
+  return node.summary === null ? "null" : stableJson(summaryType.serialize(node.summary));
 }
 
 function graphShape(graph: FuzzGraph): GraphShape {
@@ -648,7 +648,7 @@ function randomSeed(rand: () => number, graph: FuzzGraph, depth: number): FuzzSe
     return { kind: "clip", data: { title: "   ", seconds: -1 } };
   }
   if (roll < 0.54) {
-    // `seconds` above the parse cap: legal to the type, refused by the codec.
+    // `seconds` above the parse cap: legal to the type, refused by the node type.
     return { kind: "clip", data: { title: "too long", seconds: 500 } };
   }
   if (roll < 0.60) {
@@ -692,7 +692,7 @@ function randomEdit(rand: () => number, graph: FuzzGraph, nodeId: NodeId): EditO
   if (asClip) {
     const roll = rand();
     if (roll < 0.15) {
-      // The codec's own refusal — relayed as `edit-rejected`.
+      // The node type's own refusal — relayed as `edit-rejected`.
       return { nodeId, kind: "clip", edit: { title: "" } };
     }
     if (roll < 0.30) {
@@ -1520,7 +1520,7 @@ describe("fuzz: quarantined nodes under structural churn", () => {
         // Unwind everything. A quarantined node that was REMOVED during churn
         // has to come back byte-exact too — the patch records the whole node,
         // `raw` included, which is what makes "delete then undo" safe for data
-        // no codec in this build can read.
+        // no node type in this build can read.
         while (canUndo(history)) {
           const stepBack = commitUndo(history);
           if (stepBack === null) break;

--- a/packages/keel-core/commands.test.ts
+++ b/packages/keel-core/commands.test.ts
@@ -24,7 +24,7 @@ import {
   type Rejection,
   type Result,
   type Seed,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   makeCollectionNode,
   makeLeafNode,
@@ -55,10 +55,10 @@ type ClipEdit = Readonly<{ title?: string; seconds?: number }>;
  * `parse` is deliberately STRICTER than `applyEdit` and also NORMALIZING:
  *
  *  - it trims `title`, which is how the tests prove the reducer stores parse's
- *    OUTPUT rather than the raw seed or the codec's edit result;
+ *    OUTPUT rather than the raw seed or the node type's edit result;
  *  - it caps `seconds` at 100 while `applyEdit` does not, which is how the
  *    tests reach the "the edit produced a value that no longer parses" branch
- *    without the codec having to refuse the edit itself.
+ *    without the node type having to refuse the edit itself.
  */
 const clipType = defineNodeType<Clip, ClipEdit>()({
   kind: "clip",
@@ -141,7 +141,7 @@ const types = [clipType, folderType] as const;
 type Types = typeof types;
 type Summary = Readonly<{ label: string }>;
 
-const summaryCodec: SummaryCodec<Summary> = {
+const summaryType: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };
@@ -282,14 +282,14 @@ function rebuildFixtureIndexes(
     const node = graph.nodesById.get(nodeId);
     if (node === undefined) return;
     if (!node.quarantined) {
-      const type = registry.get(node.kind);
-      const contentKey = type?.contentKey?.(node.data) ?? null;
+      const nodeType = registry.get(node.kind);
+      const contentKey = nodeType?.contentKey?.(node.data) ?? null;
       if (contentKey !== null) {
         const list = placements.get(contentKey);
         if (list === undefined) placements.set(contentKey, [nodeId]);
         else list.push(nodeId);
       }
-      const sourceKey = type?.sourceKey?.(node.data) ?? null;
+      const sourceKey = nodeType?.sourceKey?.(node.data) ?? null;
       const owns = !node.container || node.children.status !== "reference";
       if (sourceKey !== null && owns && !owners.has(sourceKey)) {
         owners.set(sourceKey, nodeId);
@@ -359,7 +359,7 @@ function makeHarness(
   const ctx: EngineContext<Summary> = {
     engineId,
     registry,
-    summary: summaryCodec,
+    summary: summaryType,
     onUnknownKind: "quarantine",
     onParseFailure: "quarantine",
     maxNodes: DEFAULT_MAX_NODES,
@@ -762,7 +762,7 @@ describe("applyCommand / insert-nodes", () => {
         ctx,
       ),
     );
-    // The seed was typed as `Clip` and still went through the codec, so the
+    // The seed was typed as `Clip` and still went through the node type, so the
     // normalizing parse normalized the insert too.
     expect(labels(next.graph, "dest")).toEqual(["Padded"]);
     expect(getChildren(next.graph, id("dest"))).toEqual([id("mint-1")]);
@@ -1257,7 +1257,7 @@ describe("applyCommand / edit-nodes", () => {
     expectValid(next.graph);
   });
 
-  it("RE-PARSES the codec's own output and stores parse's value", () => {
+  it("RE-PARSES the node type's own output and stores parse's value", () => {
     // `applyEdit` hands back "  Spaced  "; the stored value is the trimmed one,
     // which is only possible if the result went back through `parse`.
     const { graph, ctx } = makeHarness();
@@ -1277,7 +1277,7 @@ describe("applyCommand / edit-nodes", () => {
   });
 
   it("rejects an edit whose RESULT no longer parses", () => {
-    // The codec happily accepts seconds: 500; its own `parse` caps at 100. The
+    // The node type happily accepts seconds: 500; its own `parse` caps at 100. The
     // result of applyEdit is an ingress like any other.
     const { graph, ctx } = makeHarness();
     const error = rejectionOf(
@@ -1294,7 +1294,7 @@ describe("applyCommand / edit-nodes", () => {
     expect(error.issues).toEqual([{ path: "$.seconds", message: "seconds <= 100" }]);
   });
 
-  it("relays the codec's own refusal verbatim", () => {
+  it("relays the node type's own refusal verbatim", () => {
     const { graph, ctx } = makeHarness();
     const error = rejectionOf(
       applyCommand(
@@ -1691,7 +1691,7 @@ describe("applyIngestEdits", () => {
     expectValid(result.graph);
   });
 
-  it("normalizes through the same codec path an edit command uses", () => {
+  it("normalizes through the same node-type path an edit command uses", () => {
     const { graph, ctx } = makeHarness();
     const result = unwrap(
       applyIngestEdits(graph, createHistory(), ingest("a", { title: "  Server  " }), ctx),

--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -242,7 +242,7 @@ function pruneDescendants<Ts extends readonly unknown[], S>(
  * The `sourceKey` this node OWNS, or null.
  *
  * A `reference` placement owns nothing — that is the entire point of the state
- * — so it is exempt from the single-owner rule. A quarantined node has no codec
+ * — so it is exempt from the single-owner rule. A quarantined node has no node type
  * and therefore no key at all.
  */
 function owningSourceKey<Ts extends readonly unknown[], S>(
@@ -754,8 +754,8 @@ function buildSeedPlacements<Ts extends readonly unknown[], S>(
       });
     }
 
-    const type = ctx.registry.get(seed.kind);
-    if (type === undefined) {
+    const nodeType = ctx.registry.get(seed.kind);
+    if (nodeType === undefined) {
       // On the WIRE an unknown kind quarantines, because forward-incompatible
       // stored data has to stay movable and deletable. On the COMMAND path it
       // is refused: the consumer is right here holding a value it just built,
@@ -768,7 +768,7 @@ function buildSeedPlacements<Ts extends readonly unknown[], S>(
     }
 
     const seedChildren = seed.children;
-    if (!type.container && seedChildren !== undefined) {
+    if (!nodeType.container && seedChildren !== undefined) {
       return fail(
         "leaf-seed-with-children",
         `Kind ${JSON.stringify(seed.kind)} is a leaf and cannot be seeded with children.`,
@@ -780,15 +780,15 @@ function buildSeedPlacements<Ts extends readonly unknown[], S>(
     taken.add(nodeId);
 
     // The seed's `data` is already typed as the kind's `Data`, and it STILL goes
-    // through the codec: a normalizing parse must normalize inserts too, and a
+    // through the node type: a normalizing parse must normalize inserts too, and a
     // consumer handing in a value that violates its own invariants deserves to
     // be caught at the same door as wire data. `schemaVersion` is the registry's
     // own, so no migration runs on a value authored against the running code.
     const parsed = parseNodeData<S>(ctx, {
       nodeId,
       kind: seed.kind,
-      container: type.container,
-      schemaVersion: type.schemaVersion,
+      container: nodeType.container,
+      schemaVersion: nodeType.schemaVersion,
       raw: seed.data,
     });
     if (!parsed.ok) {
@@ -799,7 +799,7 @@ function buildSeedPlacements<Ts extends readonly unknown[], S>(
       );
     }
 
-    const node: AnyNode<Ts, S> = type.container
+    const node: AnyNode<Ts, S> = nodeType.container
       ? makeCollectionNode<Ts, S>(
           nodeId,
           seed.kind,
@@ -952,7 +952,7 @@ type EditPlan<S> = Readonly<{
 }>;
 
 /**
- * The shared validation and codec dispatch behind BOTH `edit-nodes` and
+ * The shared validation and dispatch behind BOTH `edit-nodes` and
  * `applyIngest`. Same path, same rejections — the two doors differ only in what
  * they leave behind, never in what they accept.
  */
@@ -998,7 +998,7 @@ function planEdits<Ts extends readonly unknown[], S>(
     }
     if (node.quarantined) {
       // Quarantined nodes move, delete and undo. They do not edit: there is no
-      // codec, and writing through `raw` would forfeit byte-exact re-emit.
+      // node type, and writing through `raw` would forfeit byte-exact re-emit.
       return fail(
         "node-quarantined",
         `Node ${JSON.stringify(edit.nodeId)} is quarantined (${node.reason}) and cannot be edited.`,
@@ -1012,8 +1012,8 @@ function planEdits<Ts extends readonly unknown[], S>(
         { nodeIds: [edit.nodeId], kind: edit.kind },
       );
     }
-    const type = ctx.registry.get(node.kind);
-    if (type === undefined) {
+    const nodeType = ctx.registry.get(node.kind);
+    if (nodeType === undefined) {
       // Defensive: a node of an unregistered kind should already be
       // quarantined, so reaching here means the graph and the registry came
       // from different engines.
@@ -1025,30 +1025,30 @@ function planEdits<Ts extends readonly unknown[], S>(
     }
 
     // WRAPPED for the same reason ./serialize wraps `parse`: `applyEdit` is
-    // consumer code, and a codec that throws must produce the refusal this
+    // consumer code, and a node type that throws must produce the refusal this
     // function is contracted to return rather than an exception out of
     // `dispatch`. A throw and a returned `{ ok: false }` mean the same thing to
-    // the user — the codec would not accept this edit — so they get the same
+    // the user — the node type would not accept this edit — so they get the same
     // code, with the thrown message carried through.
     let applied: Result<unknown, EditRejection>;
     try {
-      applied = type.applyEdit(node.data, edit.edit);
+      applied = nodeType.applyEdit(node.data, edit.edit);
     } catch (thrown) {
       return fail(
         "edit-rejected",
-        `The ${JSON.stringify(node.kind)} codec threw while applying the edit: ${describeThrown(thrown)}`,
+        `${JSON.stringify(node.kind)}.applyEdit threw: ${describeThrown(thrown)}`,
         { nodeIds: [edit.nodeId], kind: node.kind },
       );
     }
     if (!applied.ok) {
       return fail(
         "edit-rejected",
-        `The ${JSON.stringify(node.kind)} codec refused the edit: ${applied.error.message}`,
+        `${JSON.stringify(node.kind)}.applyEdit refused the edit: ${applied.error.message}`,
         { nodeIds: [edit.nodeId], kind: node.kind, editRejection: applied.error },
       );
     }
 
-    // RE-PARSE the codec's own output. `applyEdit` is consumer code, and it is
+    // RE-PARSE the node type's own output. `applyEdit` is consumer code, and it is
     // the one ingress the engine would otherwise trust blind — an edit that
     // walks a clip past its own source length is exactly as invalid as the same
     // value arriving off the wire. Round-tripped through `serialize` because
@@ -1060,11 +1060,11 @@ function planEdits<Ts extends readonly unknown[], S>(
     // side of one expression and as a `Result` from the other.
     let raw: unknown;
     try {
-      raw = type.serialize(applied.value);
+      raw = nodeType.serialize(applied.value);
     } catch (thrown) {
       return fail(
         "parse-failed",
-        `The ${JSON.stringify(node.kind)} codec threw while serializing the edited value: ${describeThrown(thrown)}`,
+        `${JSON.stringify(node.kind)}.serialize threw while re-encoding the edited value: ${describeThrown(thrown)}`,
         {
           nodeIds: [edit.nodeId],
           kind: node.kind,
@@ -1076,10 +1076,10 @@ function planEdits<Ts extends readonly unknown[], S>(
     const reparsed = parseNodeData<S>(ctx, {
       nodeId: edit.nodeId,
       kind: node.kind,
-      container: type.container,
-      schemaVersion: type.schemaVersion,
+      container: nodeType.container,
+      schemaVersion: nodeType.schemaVersion,
       raw,
-      // `raw` IS this codec's serialize output, so the generic
+      // `raw` IS this node type's serialize output, so the generic
       // `parse(serialize(d))` comparison inside `parseNodeData` would re-derive
       // a value from the bytes it just came from and can never fail. The
       // stronger comparison for this door runs below instead.
@@ -1109,7 +1109,7 @@ function planEdits<Ts extends readonly unknown[], S>(
     if (ctx.devChecks) {
       // 1. UPSTREAM VS DOWNSTREAM, and it is FREE — both values already exist.
       //
-      //    `applied.value` is what the codec's own `applyEdit` produced.
+      //    `applied.value` is what the node type's own `applyEdit` produced.
       //    `nextData` is what came back after that value made a round trip
       //    through `serialize` and `parse`, and it is what the engine actually
       //    STORES. If they differ, the edit the consumer asked for is not the
@@ -1117,16 +1117,16 @@ function planEdits<Ts extends readonly unknown[], S>(
       //    dropped on the way out.
       //
       //    THE FIRST DRAFT OF THIS COMPARED `serialize(nextData)` AGAINST `raw`
-      //    and could not fail: for a codec that drops a field, both sides drop
+      //    and could not fail: for a node type that drops a field, both sides drop
       //    it, so the two agree while the field is being lost. The lossy
       //    fixture in ./devchecks-audits caught that, which is the entire
-      //    argument for writing the violating codec before the check.
+      //    argument for writing the violating node type before the check.
       const verdict = structurallyEqualBounded(applied.value, nextData);
       if (verdict === false) {
         console.error(
           `keel dev check: editing a ${JSON.stringify(node.kind)} node stored something ` +
             `different from what its own applyEdit returned. The engine stores parse's ` +
-            `OUTPUT, so a field this codec's serialize omits is dropped on every edit. ` +
+            `OUTPUT, so a field this node type's serialize omits is dropped on every edit. ` +
             `node=${JSON.stringify(edit.nodeId)} produced=${describeValue(applied.value)} ` +
             `stored=${describeValue(nextData)}`,
         );
@@ -1140,16 +1140,16 @@ function planEdits<Ts extends readonly unknown[], S>(
       //    property of a method nothing consults: preparation for the day it is
       //    consulted, not a bug hunt.
       //
-      //    `type.applyEdit` is called DIRECTLY. Building a synthetic
+      //    `nodeType.applyEdit` is called DIRECTLY. Building a synthetic
       //    `edit-nodes` command and dispatching it would re-enter `planEdits`
       //    without bound — one full validation pass per level, ending in a
       //    stack overflow escaping `dispatch` as an exception, from a function
       //    contracted to return a `Result`.
-      const invert = type.invertEdit;
+      const invert = nodeType.invertEdit;
       if (invert !== undefined) {
         try {
           const inverse = invert(edit.edit, node.data);
-          const back = type.applyEdit(applied.value, inverse);
+          const back = nodeType.applyEdit(applied.value, inverse);
           if (!back.ok) {
             console.error(
               `keel dev check: ${JSON.stringify(node.kind)}.invertEdit produced an edit its ` +
@@ -1177,7 +1177,7 @@ function planEdits<Ts extends readonly unknown[], S>(
 
     // A `reference` owns nothing, so its key cannot collide with anyone.
     if (collection === null || ownsSubtree(collection.children)) {
-      const nextKey = type.sourceKey?.(nextData) ?? null;
+      const nextKey = nodeType.sourceKey?.(nextData) ?? null;
       if (nextKey !== null) {
         const owner = graph.ownerBySourceKey.get(nextKey);
         const claimed = claimedSourceKeys.get(nextKey);
@@ -1402,15 +1402,15 @@ function resolveInsertDrop<Ts extends readonly unknown[], S>(
   // CONTENT parse deliberately does not run twice: it happens once, in
   // `applyCommand`, where its output is the value that actually gets stored.
   for (const seed of seeds) {
-    const type = ctx.registry.get(seed.kind);
-    if (type === undefined) {
+    const nodeType = ctx.registry.get(seed.kind);
+    if (nodeType === undefined) {
       return fail(
         "unknown-kind",
         `No node type registered for kind ${JSON.stringify(seed.kind)}.`,
         { kind: seed.kind },
       );
     }
-    if (!type.container && seed.children !== undefined) {
+    if (!nodeType.container && seed.children !== undefined) {
       return fail(
         "leaf-seed-with-children",
         `Kind ${JSON.stringify(seed.kind)} is a leaf and cannot be seeded with children.`,
@@ -1438,7 +1438,7 @@ function resolveInsertDrop<Ts extends readonly unknown[], S>(
  * either Ctrl-Z undoes a thumbnail, or a dormant whole-value `before` silently
  * clobbers the server's write on the next undo. This is the third option.
  *
- * It applies each edit exactly as `edit-nodes` does — same codec path, same
+ * It applies each edit exactly as `edit-nodes` does — same node-type path, same
  * rejections — and then:
  *   - produces NO patch, NO history entry, NO change-feed event;
  *   - bumps `subtreeRev` along each edited node's chain, so rollups and

--- a/packages/keel-core/commit-cost-budget.test.ts
+++ b/packages/keel-core/commit-cost-budget.test.ts
@@ -28,7 +28,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -88,7 +88,7 @@ const types = [clipType, folderType] as const;
 type Types = typeof types;
 type Summary = Readonly<{ n: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/devchecks-audits.test.ts
+++ b/packages/keel-core/devchecks-audits.test.ts
@@ -1,4 +1,4 @@
-// KEEL — the four `devChecks` audits, each with a codec built to violate it.
+// KEEL — the four `devChecks` audits, each with a node type built to violate it.
 //
 // `EngineContext.devChecks` named four audits and implemented NONE of them
 // (#590), so the whole risk in fixing it is shipping four audits that cannot
@@ -12,13 +12,13 @@ import {
   parseNodeId,
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 import { foldMonoid } from "./folds";
 import { createEngine } from "./engine";
 
 type Summary = Readonly<{ seconds: number }>;
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "x" }] };
@@ -69,7 +69,7 @@ function messagesFrom(spy: ReturnType<typeof errors>): string {
   return spy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
 }
 
-/** root -> one clip. `data` is whatever the caller's codec wants. */
+/** root -> one clip. `data` is whatever the caller's node type wants. */
 function docWith(clipData: unknown) {
   return {
     formatVersion: 1,
@@ -88,7 +88,7 @@ function docWith(clipData: unknown) {
 
 describe("parsed values are frozen under devChecks", () => {
   /**
-   * A codec that normalises IN PLACE during serialize — a real performance
+   * A node type that normalises IN PLACE during serialize — a real performance
    * idiom, and precisely the class the reducer already wraps in try/catch. The
    * engine stores what `parse` returned, so a `serialize` that edits its
    * argument is quietly rewriting stored state from a method contracted to read.
@@ -148,7 +148,7 @@ describe("parsed values are frozen under devChecks", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("does not throw on a codec that returns a typed array", () => {
+  it("does not throw on a node type that returns a typed array", () => {
     // THE REGRESSION THIS GUARD EXISTS FOR. `Object.freeze` on a TypedArray
     // with elements throws, so without the `ArrayBuffer.isView` skip, turning
     // devChecks on takes the ingress door down for a conforming consumer.
@@ -184,7 +184,7 @@ describe("parsed values are frozen under devChecks", () => {
 // 2. parse(serialize(d)) ROUND-TRIP
 // ---------------------------------------------------------------------------
 
-/** Parses two fields, serializes ONE. The classic lossy codec. */
+/** Parses two fields, serializes ONE. The classic lossy node type. */
 const lossy = defineNodeType<
   Readonly<{ title: string; note: string }>,
   Readonly<{ title?: string }>
@@ -254,9 +254,9 @@ describe("the round trip catches a lossy serialize", () => {
     expect(messagesFrom(spy)).toContain("clip");
   });
 
-  it("stays silent for a NORMALISING codec — the false-alarm floor", () => {
+  it("stays silent for a NORMALISING node type — the false-alarm floor", () => {
     // A raw-vs-reserialized comparison would report a violation here on a
-    // perfectly correct codec, which is why both halves of the comparison must
+    // perfectly correct node type, which is why both halves of the comparison must
     // be parse OUTPUTS. `{title:"  a  "}` parses to `{title:"a"}`, and `"a"`
     // round-trips to itself.
     const engine = createEngine<readonly [typeof trimming, typeof folder], Summary, {}>({
@@ -354,9 +354,9 @@ describe("an opt-in invertEdit is verified", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("stays silent when the codec declares no inverse at all", () => {
+  it("stays silent when the node type declares no inverse at all", () => {
     // The common case by far — `invertEdit` is opt-in and off by default, so
-    // the check must cost nothing and say nothing for a codec without one.
+    // the check must cost nothing and say nothing for a node type without one.
     const spy = run(clipWithInverse(undefined));
     expect(spy).not.toHaveBeenCalled();
   });

--- a/packages/keel-core/devchecks-primitives.test.ts
+++ b/packages/keel-core/devchecks-primitives.test.ts
@@ -42,13 +42,13 @@ describe("structurallyEqualBounded", () => {
   });
 
   it("treats NaN as equal to itself", () => {
-    // `===` would answer false and report a violation on a codec that
+    // `===` would answer false and report a violation on a node type that
     // legitimately stores NaN. Object.is at the leaves is what prevents it.
     expect(structurallyEqualBounded({ n: Number.NaN }, { n: Number.NaN })).toBe(true);
   });
 
   it("distinguishes a present undefined from an absent key", () => {
-    // `{a: undefined}` and `{}` have different SERIALIZED shapes, and a codec
+    // `{a: undefined}` and `{}` have different SERIALIZED shapes, and a node type
     // is entitled to care. An own-key count plus hasOwnProperty is what keeps
     // them apart; a plain `right[key] === undefined` test would not.
     expect(structurallyEqualBounded({ a: undefined }, {})).toBe(false);
@@ -92,7 +92,7 @@ describe("deepFreezeBounded", () => {
   it("does not throw on a typed array", () => {
     // THE SINGLE MOST IMPORTANT LINE IN THE CHECK. `Object.freeze` on a
     // TypedArray with elements THROWS "Cannot freeze array buffer views with
-    // elements". A codec returning binary data is conforming, so without the
+    // elements". A node type returning binary data is conforming, so without the
     // ArrayBuffer.isView guard, turning devChecks on takes the ingress door
     // down for that consumer. Remove the guard and this test fails with that
     // exact message.

--- a/packages/keel-core/engine.test.ts
+++ b/packages/keel-core/engine.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, it } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -87,7 +87,7 @@ type Types = typeof types;
 
 type Summary = Readonly<{ seconds: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/fold-cache-capacity.test.ts
+++ b/packages/keel-core/fold-cache-capacity.test.ts
@@ -37,7 +37,7 @@ import type {
   Issue,
   NodeId,
   Result,
-  SummaryCodec,
+  SummaryType,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -109,7 +109,7 @@ const types = [clipType, folderType] as const;
 type Types = typeof types;
 type TestGraph = Graph<Types, Summary>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: fail("$", "expected an object") };
@@ -260,7 +260,7 @@ function buildDocument(
       childrenState: "missing",
       missingReason: "404",
     });
-    // No codec is registered for this kind, so it lands quarantined.
+    // No node type is registered for this kind, so it lands quarantined.
     nodes.push({ id: "mystery", kind: "mystery", data: { opaque: true } });
     nodes.push({ id: "empty", kind: "folder", data: { name: "empty" }, children: [] });
     rootChildren.push("unloaded", "gone", "mystery", "empty");

--- a/packages/keel-core/folds.test.ts
+++ b/packages/keel-core/folds.test.ts
@@ -49,10 +49,10 @@ function issue(path: string, message: string): readonly Issue[] {
   return [{ path, message }];
 }
 
-// The codec VALUE is never registered. This file builds its graph with
+// The node type VALUE is never registered. This file builds its graph with
 // `makeLeafNode<Types>` rather than through an engine, so this exists only so
 // `typeof` can derive the `Types` tuple below — deleting it would mean
-// hand-writing that tuple and letting it drift from the codecs it describes.
+// hand-writing that tuple and letting it drift from the node types it describes.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const clipType = defineNodeType<ClipData, ClipEdit>()({
   kind: "clip",
@@ -163,7 +163,7 @@ function buildGraph(roots: readonly Spec[]): TestGraph {
           schemaVersion: 0,
           raw: { opaque: spec.id },
           reason: "unknown-kind",
-          issues: issue("$.kind", "no codec registered"),
+          issues: issue("$.kind", "no node type registered"),
           children: container ? LOADED : null,
           summary: null,
         }),

--- a/packages/keel-core/graph.test.ts
+++ b/packages/keel-core/graph.test.ts
@@ -50,10 +50,10 @@ import type {
 } from "./types";
 
 // ---------------------------------------------------------------------------
-// Fixtures: a two-kind registry with real codecs
+// Fixtures: a two-kind registry with real node types
 // ---------------------------------------------------------------------------
 //
-// The codecs CONSTRUCT rather than cast, matching the rule the engine relies
+// The node types CONSTRUCT rather than cast, matching the rule the engine relies
 // on. They are only exercised here through `contentKey` / `sourceKey`, but a
 // permissive `parse` in a fixture is exactly the shape of test double that
 // hides a real bug, so they are written honestly.
@@ -120,7 +120,7 @@ const folderType = defineNodeType<FolderData, FolderEdit>()({
   },
 });
 
-/** Declares NEITHER optional key hook, so it covers the "codec opted out" arm
+/** Declares NEITHER optional key hook, so it covers the "node type opted out" arm
  *  of `contentKeyOf` / `sourceKeyOf` — distinct from "kind not registered". */
 const noteType = defineNodeType<NoteData, NoteEdit>()({
   kind: "note",
@@ -249,14 +249,14 @@ function sampleGraph(): TestGraph {
 // ---------------------------------------------------------------------------
 
 describe("buildRegistry", () => {
-  it("keys every codec by its kind", () => {
+  it("keys every node type by its kind", () => {
     expect([...registry.keys()].sort()).toEqual(["clip", "folder", "note"]);
     expect(registry.get("clip")).toBe(clipType);
   });
 
   it("THROWS on a duplicate kind, naming it", () => {
     // Not Result-shaped on purpose: a duplicate kind is a module-init
-    // programmer error, and there is no partial-success answer — one codec
+    // programmer error, and there is no partial-success answer — one node type
     // would silently win at the trust boundary.
     expect(() => buildRegistry([clipType, folderType, clipType])).toThrow(
       /duplicate node kind "clip"/,
@@ -495,12 +495,12 @@ describe("contentKeyOf / sourceKeyOf", () => {
     return [contentKeyOf(registry, node), sourceKeyOf(registry, node)];
   }
 
-  it("reads the codec's hooks when it declares them", () => {
+  it("reads the node type's hooks when it declares them", () => {
     expect(keysOf("c1")).toEqual(["asset-x", null]);
     expect(keysOf("owned")).toEqual([null, "doc-1"]);
   });
 
-  it("is null when the codec declined the hook", () => {
+  it("is null when the node type declined the hook", () => {
     expect(keysOf("n1")).toEqual([null, null]);
   });
 
@@ -508,7 +508,7 @@ describe("contentKeyOf / sourceKeyOf", () => {
     expect(keysOf("q")).toEqual([null, null]);
   });
 
-  it("is null when no codec is registered for the kind", () => {
+  it("is null when no node type is registered for the kind", () => {
     expect(keysOf("ghost-kind")).toEqual([null, null]);
   });
 });

--- a/packages/keel-core/graph.ts
+++ b/packages/keel-core/graph.ts
@@ -57,11 +57,11 @@ export const NO_DEAD_REVS: ReadonlyMap<NodeId, number> = new Map();
 // ---------------------------------------------------------------------------
 
 /**
- * Build the kind -> codec map.
+ * Build the kind -> node type map.
  *
  * THROWS on a duplicate kind, and this is the only function in keel-core that
  * throws. It is a module-init programmer error, not a recoverable condition:
- * two codecs claiming one kind means one of them silently wins at the trust
+ * two node types claiming one kind means one of them silently wins at the trust
  * boundary, so `switch (node.kind)` narrows `data` to a type the node does not
  * hold and the whole discriminated union is quietly a lie. There is no
  * partial-success answer worth returning — the consumer's module graph is
@@ -69,14 +69,14 @@ export const NO_DEAD_REVS: ReadonlyMap<NodeId, number> = new Map();
  */
 export function buildRegistry(types: readonly SomeNodeType[]): NodeTypeRegistry {
   const registry = new Map<string, SomeNodeType>();
-  for (const type of types) {
-    if (registry.has(type.kind)) {
+  for (const nodeType of types) {
+    if (registry.has(nodeType.kind)) {
       throw new Error(
-        `keel: duplicate node kind ${JSON.stringify(type.kind)} in ` +
-          `createEngine({ types }). Each kind may be claimed by exactly one codec.`,
+        `keel: duplicate node kind ${JSON.stringify(nodeType.kind)} in ` +
+          `createEngine({ types }). Each kind may be claimed by exactly one node type.`,
       );
     }
-    registry.set(type.kind, type);
+    registry.set(nodeType.kind, nodeType);
   }
   return registry;
 }
@@ -398,12 +398,12 @@ export function documentOrder<Ts extends readonly unknown[], S>(
 // ---------------------------------------------------------------------------
 //
 // Both return `null` for a quarantined node, and that is not a shortcut. A
-// quarantined node holds `raw`, not parsed `Data`; no codec is willing to vouch
+// quarantined node holds `raw`, not parsed `Data`; no node type is willing to vouch
 // for it, so handing `raw` to `contentKey` would ask a function typed against
 // `Data` to read something that failed to become `Data`. A node whose content
 // could not be understood has no content identity.
 //
-// Neither wraps the codec call in try/catch. A throwing `contentKey` is a
+// Neither wraps the call in try/catch. A throwing `contentKey` is a
 // consumer bug, and swallowing it into `null` would silently disable the
 // single-owner rule — the invariant that stops two placements from both
 // claiming one stored subtree, which is the condition the predecessor's server
@@ -414,9 +414,9 @@ export function contentKeyOf<Ts extends readonly unknown[], S>(
   node: AnyNode<Ts, S>,
 ): string | null {
   if (node.quarantined) return null;
-  const type = registry.get(node.kind);
-  if (type === undefined || type.contentKey === undefined) return null;
-  return type.contentKey(node.data);
+  const nodeType = registry.get(node.kind);
+  if (nodeType === undefined || nodeType.contentKey === undefined) return null;
+  return nodeType.contentKey(node.data);
 }
 
 export function sourceKeyOf<Ts extends readonly unknown[], S>(
@@ -434,7 +434,7 @@ export function sourceKeyOf<Ts extends readonly unknown[], S>(
  * `verifyDataChanged` needs exactly this: it must know what key a patch's
  * `after` would claim before deciding whether replaying it is safe, and the
  * node in the graph still carries the old value. Split out rather than
- * duplicated so the two cannot disagree about which codec hook answers, and so
+ * duplicated so the two cannot disagree about which node-type hook answers, and so
  * the deliberate absence of a try/catch stays in ONE place — see the block
  * comment above `contentKeyOf` for why a throwing key function is not swallowed
  * into `null`.
@@ -444,9 +444,9 @@ export function sourceKeyOfKindData(
   kind: string,
   data: unknown,
 ): string | null {
-  const type = registry.get(kind);
-  if (type === undefined || type.sourceKey === undefined) return null;
-  return type.sourceKey(data);
+  const nodeType = registry.get(kind);
+  if (nodeType === undefined || nodeType.sourceKey === undefined) return null;
+  return nodeType.sourceKey(data);
 }
 
 /**
@@ -475,7 +475,7 @@ export function sourceKeyOfKindData(
  *     exists to prevent and which this repo has already paid for once.
  *
  * A quarantined node owns nothing either: its key would have to come from a
- * codec that by definition did not run, so `sourceKeyOf` already answers `null`
+ * node type that by definition did not run, so `sourceKeyOf` already answers `null`
  * for it. Stated here as well so the predicate is total on its own terms rather
  * than relying on a caller having checked first.
  */
@@ -582,7 +582,7 @@ export type DerivedIndexes<Ts extends readonly unknown[], S> = Pick<
   "placementsByContentKey" | "ownerBySourceKey"
 >;
 
-/** Which halves of the derived pair the registered codecs can populate AT ALL. */
+/** Which halves of the derived pair the registered node types can populate AT ALL. */
 export type DerivedIndexNeed = Readonly<{ content: boolean; source: boolean }>;
 
 /**
@@ -598,9 +598,9 @@ export type DerivedIndexNeed = Readonly<{ content: boolean; source: boolean }>;
 export function derivedIndexNeed(registry: NodeTypeRegistry): DerivedIndexNeed {
   let content = false;
   let source = false;
-  for (const type of registry.values()) {
-    if (type.contentKey !== undefined) content = true;
-    if (type.sourceKey !== undefined) source = true;
+  for (const nodeType of registry.values()) {
+    if (nodeType.contentKey !== undefined) content = true;
+    if (nodeType.sourceKey !== undefined) source = true;
     if (content && source) break;
   }
   return { content, source };
@@ -908,7 +908,7 @@ export function documentOrderComparator<Ts extends readonly unknown[], S>(
  * is to lift out the ids that travelled and merge them back at their new
  * positions. A bucket holding nothing that moved cannot change at all — which
  * is why the common shape, a content key placed exactly once so that every
- * bucket holds one id, settles in a handful of codec calls and no comparisons
+ * bucket holds one id, settles in a handful of node-type calls and no comparisons
  * at all, against a full document walk before.
  *
  * Returns `previous` BY IDENTITY when nothing reordered, and `null` for
@@ -932,7 +932,7 @@ export function reindexPlacementsAcrossMove<Ts extends readonly unknown[], S>(
   }
   if (travelled.size === 0) return previous;
 
-  // The ONLY codec calls this function makes: one per node that actually
+  // The ONLY node-type calls this function makes: one per node that actually
   // travelled. Every other node's key is not merely unchanged but irrelevant —
   // `contentKey` reads `data`, and a move does not touch `data`.
   const moversByKey = new Map<string, NodeId[]>();
@@ -1058,7 +1058,7 @@ export function placementsAfterInsert<Ts extends readonly unknown[], S>(
   previous: ReadonlyMap<string, readonly NodeId[]>,
   arrived: readonly AnyNode<Ts, S>[],
 ): ReadonlyMap<string, readonly NodeId[]> | null {
-  // THE ONLY codec calls this function makes: one per ARRIVING node. Every
+  // THE ONLY node-type calls this function makes: one per ARRIVING node. Every
   // other node's key is not merely unchanged but irrelevant — `contentKey`
   // reads `data`, and an insert does not touch anybody else's.
   const arrivalsByKey = new Map<string, NodeId[]>();
@@ -1264,7 +1264,7 @@ export function insertLeavesDerivedIndexesIntact<Ts extends readonly unknown[], 
 /**
  * True when one node's data change cannot move EITHER derived index.
  *
- * Asks the codec rather than the registry shape, because the high-value case is
+ * Asks the node type rather than the registry shape, because the high-value case is
  * a kind that DOES define `contentKey` and whose key does not depend on the
  * field being edited — retitling a clip whose `contentKey` is its asset id. The
  * cheap structural case (a kind defining neither function) falls out of the same
@@ -1279,12 +1279,12 @@ export function dataChangeLeavesDerivedIndexesIntact(
   before: unknown,
   after: unknown,
 ): boolean {
-  const type = registry.get(kind);
-  if (type === undefined) return true;
-  if (type.contentKey !== undefined && type.contentKey(before) !== type.contentKey(after)) {
+  const nodeType = registry.get(kind);
+  if (nodeType === undefined) return true;
+  if (nodeType.contentKey !== undefined && nodeType.contentKey(before) !== nodeType.contentKey(after)) {
     return false;
   }
-  if (type.sourceKey !== undefined && type.sourceKey(before) !== type.sourceKey(after)) {
+  if (nodeType.sourceKey !== undefined && nodeType.sourceKey(before) !== nodeType.sourceKey(after)) {
     return false;
   }
   return true;
@@ -1497,7 +1497,7 @@ export function findInvariantViolation<Ts extends readonly unknown[], S>(
     seenRootIds.add(rootId);
     // Read straight off the node, not through `isCollection`: a quarantined
     // root is judged by the `container` flag its document declared, which is
-    // the only evidence there is when no codec would parse it.
+    // the only evidence there is when no node type would parse it.
     if (!node.container) {
       return {
         code: "root-not-container",

--- a/packages/keel-core/history.test.ts
+++ b/packages/keel-core/history.test.ts
@@ -47,10 +47,10 @@ import {
 type Clip = Readonly<{ title: string }>;
 type ClipEdit = Readonly<{ op: "set-title"; title: string }>;
 
-// The codec VALUE is never registered. This file builds its graph with
+// The node type VALUE is never registered. This file builds its graph with
 // `makeLeafNode<Types>` rather than through an engine, so this exists only so
 // `typeof` can derive the `Types` tuple below — deleting it would mean
-// hand-writing that tuple and letting it drift from the codecs it describes.
+// hand-writing that tuple and letting it drift from the node types it describes.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const clipType = defineNodeType<Clip, ClipEdit>()({
   kind: "clip",

--- a/packages/keel-core/history.ts
+++ b/packages/keel-core/history.ts
@@ -244,7 +244,7 @@ export function clearHistory<Ts extends readonly unknown[], S>(
  *
  * NOT checked: that `previous`'s `after` equals `next`'s `before`. `Data` is
  * opaque to the engine, and the only sanctioned equality on it goes through a
- * codec's `serialize` — which needs an `EngineContext` this function
+ * node type's `serialize` — which needs an `EngineContext` this function
  * deliberately does not take. Coalescing is driven by a caller-supplied key; a
  * caller that reuses one key across unrelated edits gets a merged entry that
  * skips an intermediate value, which is exactly what coalescing is for.

--- a/packages/keel-core/index.ts
+++ b/packages/keel-core/index.ts
@@ -19,7 +19,7 @@
 //   - every module-local helper, which is the rest of the six modules.
 
 // ---------------------------------------------------------------------------
-// Types, the id door, the codec factory, and the boundary constructors
+// Types, the id door, the node type factory, and the boundary constructors
 // ---------------------------------------------------------------------------
 
 export {
@@ -88,7 +88,7 @@ export {
   type Store,
   type StructuralError,
   type StructuralErrorCode,
-  type SummaryCodec,
+  type SummaryType,
   type ValueOf,
   type Violation,
   type ViolationCode,

--- a/packages/keel-core/localized-order.test.ts
+++ b/packages/keel-core/localized-order.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createEngine } from "./engine";
 import { defineNodeType, parseNodeId } from "./types";
-import type { Issue, NodeId, Result, SummaryCodec } from "./types";
+import type { Issue, NodeId, Result, SummaryType } from "./types";
 
 type Clip = Readonly<{ t: string }>;
 type Folder = Readonly<{ n: string }>;
@@ -16,7 +16,7 @@ const folder = defineNodeType<Folder, Record<string, never>>()({
   serialize: (d) => d, applyEdit: (d) => ({ ok: true, value: d }),
 });
 const types = [clip, folder] as const;
-const summary: SummaryCodec<Record<string, never>> = { parse: () => ({ ok: true, value: {} }), serialize: () => ({}) };
+const summary: SummaryType<Record<string, never>> = { parse: () => ({ ok: true, value: {} }), serialize: () => ({}) };
 const engine = createEngine<typeof types, Record<string, never>, Record<string, never>>({
   types, summary, folds: {}, now: () => 0,
 });

--- a/packages/keel-core/move-cost.test.ts
+++ b/packages/keel-core/move-cost.test.ts
@@ -20,18 +20,18 @@ import {
   type NodeId,
   type Patch,
   type SomeNodeType,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 import { DEFAULT_MAX_NODES } from "./serialize";
 
 // A single commit used to do FIVE pieces of whole-graph work for a change that
 // touched one children array: a clone of `parentById` (one entry per node), two
 // clones of `subtreeRevById` (one entry per node), a document-order DFS, and a
-// from-scratch rebuild of both derived indexes with a codec call per node — the
-// last of these running even when no registered codec defined either key.
+// from-scratch rebuild of both derived indexes with a node-type call per node — the
+// last of these running even when no registered node type defined either key.
 //
 // These tests pin the scaling properties that removed that work. They assert
-// STRUCTURE — reference identity, and how many times a codec was asked — never
+// STRUCTURE — reference identity, and how many times a node type was asked — never
 // wall clock, so they cannot flake on a slow machine. A comment claiming a map
 // is shared is not a guarantee; `toBe` is.
 
@@ -43,7 +43,7 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** Bumped by the KEYED codecs below, so a test can ask how much of the graph a
+/** Bumped by the KEYED node types below, so a test can ask how much of the graph a
  *  commit actually looked at. Reset by `beforeEach`. */
 let contentKeyCalls = 0;
 let sourceKeyCalls = 0;
@@ -151,7 +151,7 @@ const keylessRegistry: ReadonlyMap<string, SomeNodeType> = new Map<string, SomeN
   ["folder", keylessFolderType],
 ]);
 
-const summaryCodec: SummaryCodec<Summary> = {
+const summaryType: SummaryType<Summary> = {
   parse(raw) {
     if (isRecord(raw)) {
       const label = raw["label"];
@@ -171,7 +171,7 @@ function makeCtx(registry: ReadonlyMap<string, SomeNodeType>): EngineContext<Sum
   return {
     engineId: ENGINE_ID,
     registry,
-    summary: summaryCodec,
+    summary: summaryType,
     onUnknownKind: "quarantine",
     onParseFailure: "quarantine",
     maxNodes: DEFAULT_MAX_NODES,
@@ -300,7 +300,7 @@ function commit(
   // scoped reindex that is wrong shows up here as `parent-index-disagrees` or
   // `derived-index-stale`, not as a silently wrong render three commits later.
   //
-  // It walks the whole graph and calls both codecs per node — twice, checks 8
+  // It walks the whole graph and calls both node types per node — twice, checks 8
   // and 9 — so the counters are snapshotted around it. Without this the
   // "how much did the commit look at" tests would be measuring the ASSERTION,
   // which is the one thing production never runs.
@@ -360,16 +360,16 @@ function bumpedIds(before: TestGraph, after: TestGraph): readonly string[] {
 }
 
 /**
- * Zero the codec counters. Called by `beforeEach`, and AGAIN by hand after a
+ * Zero the node-type counters. Called by `beforeEach`, and AGAIN by hand after a
  * fixture is built — `buildGraph` derives its indexes through the real rebuild,
  * so a 400-clip fixture arrives having already asked `contentKey` 400 times.
  */
-function resetCodecCounters(): void {
+function resetNodeTypeCounters(): void {
   contentKeyCalls = 0;
   sourceKeyCalls = 0;
 }
 
-beforeEach(resetCodecCounters);
+beforeEach(resetNodeTypeCounters);
 
 // ---------------------------------------------------------------------------
 // Structural sharing
@@ -485,7 +485,7 @@ describe("move commit cost — index sharing", () => {
 // ---------------------------------------------------------------------------
 
 describe("derived index cost", () => {
-  it("does no index work at all when no codec defines either key", () => {
+  it("does no index work at all when no node type defines either key", () => {
     const ctx = makeCtx(keylessRegistry);
     const graph = wideGraph(10, 10, { registry: keylessRegistry });
     // The shared empties, so a consumer memoising on these fields sees no churn
@@ -498,7 +498,7 @@ describe("derived index cost", () => {
 
   it("never asks for a sourceKey on a move", () => {
     const graph = wideGraph(20, 20);
-    resetCodecCounters();
+    resetNodeTypeCounters();
     commit(graph, {
       type: "moved",
       moves: [
@@ -532,7 +532,7 @@ describe("derived index cost", () => {
     const widths = [5, 20, 50] as const;
     const counts = widths.map((width) => {
       const graph = wideGraph(20, width);
-      resetCodecCounters();
+      resetNodeTypeCounters();
       commit(graph, reorderWithin("c0", "c0-m0", 0, 3));
       return contentKeyCalls;
     });
@@ -546,11 +546,11 @@ describe("derived index cost", () => {
     // whole sibling list while the cross-parent move already cost one.
     const graph = wideGraph(20, 20);
 
-    resetCodecCounters();
+    resetNodeTypeCounters();
     commit(graph, reorderWithin("c0", "c0-m0", 0, 5));
     const withinCalls = contentKeyCalls;
 
-    resetCodecCounters();
+    resetNodeTypeCounters();
     commit(graph, moveAcross("c0", "c1", "c0-m0", 0, 0));
     const acrossCalls = contentKeyCalls;
 
@@ -562,12 +562,12 @@ describe("derived index cost", () => {
     // collection under the root made the scope root the DOCUMENT root, so the
     // cheap path was skipped and every node in the graph was asked for its key.
     const small = wideGraph(10, 20); // 200 clips + 10 folders
-    resetCodecCounters();
+    resetNodeTypeCounters();
     commit(small, reorderWithin("root", "c0", 0, 5));
     const smallCalls = contentKeyCalls;
 
     const large = wideGraph(20, 20); // 400 clips + 20 folders
-    resetCodecCounters();
+    resetNodeTypeCounters();
     commit(large, reorderWithin("root", "c0", 0, 5));
     const largeCalls = contentKeyCalls;
 
@@ -756,7 +756,7 @@ describe("derived index cost", () => {
 
   it("does not walk the document when a clip changes parents", () => {
     const graph = wideGraph(20, 20); // 400 clips, one asset each
-    resetCodecCounters();
+    resetNodeTypeCounters();
     const next = commit(graph, moveAcross("c0", "c1", "c0-m0", 0, 0));
     // ONE key: the clip that travelled. The old path rebuilt the index from a
     // full document walk and asked all 400. Nothing else in the graph moved
@@ -795,7 +795,7 @@ describe("derived index cost", () => {
         ],
       },
     ]);
-    resetCodecCounters();
+    resetNodeTypeCounters();
     commit(graph, moveAcross("c0", "c1", "nested", 0, 0));
     // `nested` itself is a folder and has no content key, so the two clips
     // inside it are the whole bill. `stay` and `far` are never asked.
@@ -1177,7 +1177,7 @@ describe("insert / remove / edit commit cost", () => {
 
   it("shares both indexes for an edit that does not move a key", () => {
     const graph = wideGraph(10, 10);
-    resetCodecCounters();
+    resetNodeTypeCounters();
     const next = commit(graph, {
       type: "data-changed",
       changes: [

--- a/packages/keel-core/patches.test.ts
+++ b/packages/keel-core/patches.test.ts
@@ -30,7 +30,7 @@ import {
   type Patch,
   type Placement,
   type SomeNodeType,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 import { DEFAULT_MAX_NODES } from "./serialize";
 
@@ -113,7 +113,7 @@ const registry: ReadonlyMap<string, SomeNodeType> = new Map<string, SomeNodeType
   ],
 );
 
-const summaryCodec: SummaryCodec<Summary> = {
+const summaryType: SummaryType<Summary> = {
   parse(raw) {
     if (isRecord(raw)) {
       const label = raw["label"];
@@ -132,7 +132,7 @@ function makeCtx(engineId: symbol = ENGINE_ID): EngineContext<Summary> {
   return {
     engineId,
     registry,
-    summary: summaryCodec,
+    summary: summaryType,
     onUnknownKind: "quarantine",
     onParseFailure: "quarantine",
     maxNodes: DEFAULT_MAX_NODES,

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -122,7 +122,7 @@ function isLoadedContainer<Ts extends readonly unknown[], S>(
  * the wire, so its nesting depth is hostile input. This is the same rule the
  * graph walks follow, applied to content.
  *
- * Object.is (not ===) so a codec that legitimately stores NaN compares equal to
+ * Object.is (not ===) so a node type that legitimately stores NaN compares equal to
  * itself; otherwise a `data-changed` undo of a NaN-bearing node would be
  * refused forever with "data-mismatch".
  */
@@ -151,7 +151,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
     if (leftKeys.length !== Object.keys(right).length) return false;
     for (const key of leftKeys) {
       // An own-key check, not just `right[key] !== undefined`: `{a: undefined}`
-      // and `{}` have different serialized shapes and a codec is entitled to
+      // and `{}` have different serialized shapes and a node type is entitled to
       // care about the difference.
       if (!Object.prototype.hasOwnProperty.call(right, key)) return false;
       stack.push({ left: left[key], right: right[key] });
@@ -379,7 +379,7 @@ function placementsAfterMove<Ts extends readonly unknown[], S>(
   previous: ReadonlyMap<string, readonly NodeId[]>,
   moves: readonly Move[],
 ): ReadonlyMap<string, readonly NodeId[]> {
-  // No registered codec defines `contentKey`, so the index is permanently empty
+  // No registered node type defines `contentKey`, so the index is permanently empty
   // and the walk that would rediscover that is pure waste.
   if (!derivedIndexNeed(registry).content) return previous;
   // A patch that moves nothing reorders nothing. Worth stating, because
@@ -786,9 +786,9 @@ function applyDataChanged<Ts extends readonly unknown[], S>(
   };
 
   // `contentKey` and `sourceKey` are read off `data`, so both derived indexes
-  // CAN move under a pure content edit — but usually do not. The keys a codec
+  // CAN move under a pure content edit — but usually do not. The keys a node type
   // exposes are identity ("which asset is this"), and the fields a user edits
-  // are not. Asking the codec whether either key actually moved costs two calls
+  // are not. Asking the node type whether either key actually moved costs two calls
   // per change; rebuilding costs a document-order DFS plus two calls per NODE.
   const movesAKey = changes.some(
     (change) =>
@@ -989,7 +989,7 @@ function requireLoadedParent<Ts extends readonly unknown[], S>(
  * `duplicate-owner` before any patch is built (measured), so nothing on either
  * history stack can carry one. The exemption cost a second `ReadonlyMap` and a
  * `sourceKey` call per changed node on the undo path — the same path the last
- * round worked to get down to zero codec calls for a common replay — to guard a
+ * round worked to get down to zero node-type calls for a common replay — to guard a
  * state the reducer will not produce. Mutation testing is what surfaced it:
  * deleting the exemption failed no test, which is the signature of code that
  * defends nothing.
@@ -1087,7 +1087,7 @@ function verifyInserted<Ts extends readonly unknown[], S>(
   // impossible reports that rather than an ownership complaint about a node it
   // could never have placed. Nothing is vacating a key here — an insert only
   // adds — so the second argument is null.
-  // Gated on the registry, not on the patch: when no codec declares
+  // Gated on the registry, not on the patch: when no node type declares
   // `sourceKey` at all, `ownerBySourceKey` is permanently empty and this check
   // could never fire, so the whole pass — including a `sourceKey` call per
   // arriving node — is skipped rather than run to reach a foregone answer.
@@ -1211,23 +1211,23 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
         { nodeId: change.nodeId },
       );
     }
-    const codec = ctx.registry.get(change.kind);
-    if (codec === undefined) {
+    const nodeType = ctx.registry.get(change.kind);
+    if (nodeType === undefined) {
       return replayError(
         "kind-mismatch",
         `Kind "${change.kind}" is not registered, so its recorded value cannot be compared.`,
         { nodeId: change.nodeId },
       );
     }
-    // Compare on the SERIALIZED form. Parsed values may carry identity a codec
+    // Compare on the SERIALIZED form. Parsed values may carry identity a node type
     // does not consider meaningful (a normalized copy, a cached derivation), and
-    // comparing those would refuse valid undos; the wire form is the codec's own
+    // comparing those would refuse valid undos; the wire form is the node type's own
     // statement of what its value IS.
     // IDENTITY FIRST. `change.before` and the node's live data are usually the
     // very same object — the reducer stores exactly what `applyEdit` returned
     // and the patch records that reference — so the common replay is settled
     // without calling the consumer's `serialize` at all. Sound because same
-    // reference implies same serialization for any deterministic codec, and a
+    // reference implies same serialization for any deterministic node type, and a
     // non-deterministic one already fails the slow path.
     //
     // Worth doing for the same reason the cross-parent move stopped asking for
@@ -1237,7 +1237,7 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
 
     // WRAPPED. `serialize` is consumer code, and this function is contracted to
     // return a `Result` — a throw here escaped `verifyPatchApplies` and took
-    // `undo` and `redo` with it. A codec that cannot serialize its own value
+    // `undo` and `redo` with it. A node type that cannot serialize its own value
     // cannot prove the recorded `before` still stands, so the honest verdict is
     // the same one a genuine difference produces: this patch no longer applies.
     // Refusing is safe (the entry stays on the stack, the graph is untouched);
@@ -1245,13 +1245,13 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
     let matches: boolean;
     try {
       matches = deepEqual(
-        codec.serialize(change.before),
-        codec.serialize(node.data),
+        nodeType.serialize(change.before),
+        nodeType.serialize(node.data),
       );
     } catch (thrown) {
       return replayError(
         "data-mismatch",
-        `Node ${change.nodeId} could not be compared against this patch's recorded "before": the ${JSON.stringify(change.kind)} codec threw while serializing (${describeThrown(thrown)}).`,
+        `Node ${change.nodeId} could not be compared against this patch's recorded "before": ${JSON.stringify(change.kind)}.serialize threw (${describeThrown(thrown)}).`,
         { nodeId: change.nodeId },
       );
     }
@@ -1276,7 +1276,7 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
   // END UP rather than on one intermediate state that never exists.
   // Gated for the same reason as the insert arm, and it matters more here: undo
   // runs this per changed node, and the last round spent real effort getting a
-  // common replay down to zero consumer-codec calls.
+  // common replay down to zero consumer node-type calls.
   if (derivedIndexNeed(ctx.registry).source) {
     const claims = new Map<NodeId, string | null>();
     for (const change of changes) {

--- a/packages/keel-core/performance.test.ts
+++ b/packages/keel-core/performance.test.ts
@@ -62,7 +62,7 @@ import {
   type Result,
   type SerializedDocument,
   type SerializedNode,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -226,7 +226,7 @@ type Types = typeof types;
 
 type Summary = Readonly<{ seconds: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };
@@ -333,7 +333,7 @@ function at<T>(items: readonly T[], index: number, what: string): T {
  * fixture in this file rather than on the one that was wrong.
  *
  * A quarantined node is a SUCCESS, by design: the four-state model exists so a
- * node the codec refuses can still be held, named and repaired rather than
+ * node the node type refuses can still be held, named and repaired rather than
  * taking its document down with it. That is exactly what makes a quarantined
  * FIXTURE invisible. `deserialize` returns ok, `report.nodeCount` matches,
  * `expect(loaded.ok).toBe(true)` passes, and every count a benchmark normally
@@ -359,7 +359,7 @@ function assertNothingQuarantined(
   throw new Error(
     `keel performance fixture: ${label} quarantined ` +
       `${report.quarantined.length} node(s) — the fixture does not satisfy its ` +
-      `own codec, so this measures the unparsed path rather than the gesture`,
+      `own node type, so this measures the unparsed path rather than the gesture`,
   );
 }
 
@@ -1089,7 +1089,7 @@ describe("deserialize", () => {
         noteCount("deserialize", fx.label, fx.nodeCount, "parse", counts.parse),
       ).toBe(fx.nodeCount);
 
-      // Ingress does NOT touch the codec's `serialize`. Round-tripping to
+      // Ingress does NOT touch the node type's `serialize`. Round-tripping to
       // normalise would be a plausible implementation and would silently double
       // the work; asserting zero pins the choice.
       expect(counts.serialize).toBe(0);
@@ -1154,7 +1154,7 @@ describe("mutations", () => {
         ),
       );
 
-      // A move carries no content, so no codec is consulted about data. If this
+      // A move carries no content, so no node type is consulted about data. If this
       // ever fires, a structural command has started re-parsing the graph.
       expect(counts.parse).toBe(0);
       expect(counts.applyEdit).toBe(0);
@@ -1397,7 +1397,7 @@ describe("mutations", () => {
     expectConstantTime(large / small, "selection.has");
   }, 120_000);
 
-  it("a content edit consults exactly one codec, whatever the graph size", () => {
+  it("a content edit consults exactly one node type, whatever the graph size", () => {
     const perOp = new Map<string, number>();
     const reindexed = new Map<string, number>();
 
@@ -1410,7 +1410,7 @@ describe("mutations", () => {
       });
 
       // ONE node edited => ONE `applyEdit`, plus one `serialize` and one `parse`
-      // for the reducer's re-validation of the codec's own output. These are
+      // for the reducer's re-validation of the node type's own output. These are
       // CONSTANTS: they do not move when the graph grows 100x, and that is the
       // property worth pinning.
       expect(
@@ -1641,7 +1641,7 @@ describe("undo and redo", () => {
           counts.contentKey,
         ),
       );
-      // Replay must never re-run a codec: the patch stores whole values, which
+      // Replay must never re-run a node type: the patch stores whole values, which
       // is exactly what makes an inverse impossible to get wrong.
       expect(counts.parse).toBe(0);
       expect(counts.applyEdit).toBe(0);

--- a/packages/keel-core/review-f1.test.ts
+++ b/packages/keel-core/review-f1.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -84,7 +84,7 @@ type Types = typeof types;
 
 type Summary = Readonly<{ seconds: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/review-f2.test.ts
+++ b/packages/keel-core/review-f2.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -90,7 +90,7 @@ type Types = typeof types;
 
 type Summary = Readonly<{ seconds: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/review-f3.test.ts
+++ b/packages/keel-core/review-f3.test.ts
@@ -35,7 +35,7 @@ import {
   type ParseCtx,
   type Result,
   type SerializedNode,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 import { buildRegistry } from "./graph";
 
@@ -94,7 +94,7 @@ type Types = typeof TYPES;
 
 type Summary = Readonly<{ count: number }>;
 
-const summaryCodec: SummaryCodec<Summary> = {
+const summaryType: SummaryType<Summary> = {
   parse(raw: unknown): Result<Summary, readonly Issue[]> {
     if (!isRecord(raw) || typeof raw.count !== "number") {
       return { ok: false, error: [{ path: "$.count", message: "count" }] };
@@ -114,7 +114,7 @@ function makeCtx(
   return {
     engineId: ENGINE_ID,
     registry: buildRegistry(TYPES),
-    summary: summaryCodec,
+    summary: summaryType,
     onUnknownKind: "quarantine",
     onParseFailure: "quarantine",
     maxNodes: DEFAULT_MAX_NODES,
@@ -261,7 +261,7 @@ describe("the size bound runs before the document is normalised", () => {
 
     const engine = createEngine({
       types: TYPES,
-      summary: summaryCodec,
+      summary: summaryType,
       folds: {},
       maxNodes: CEILING,
     });
@@ -282,7 +282,7 @@ describe("the size bound runs before the document is normalised", () => {
     // `unknown` precisely because it came from IO.
     const engine = createEngine({
       types: TYPES,
-      summary: summaryCodec,
+      summary: summaryType,
       folds: {},
       maxNodes: CEILING,
     });

--- a/packages/keel-core/review-f4.test.ts
+++ b/packages/keel-core/review-f4.test.ts
@@ -1,9 +1,9 @@
-// F4 regression: a THROWING summary codec must quarantine, not kill the document.
+// F4 regression: a THROWING summary type must quarantine, not kill the document.
 //
-// `parseNodeData` wraps `type.parse` in try/catch precisely because "a codec is
+// `parseNodeData` wraps `nodeType.parse` in try/catch precisely because "a node type is
 // consumer code, and an ingress door that throws takes the whole document
 // down". `ctx.summary.parse` (serialize.ts, buildDocument, pass F) is the other
-// consumer-supplied codec on the same ingress path, and must get the same
+// consumer-supplied node type on the same ingress path, and must get the same
 // protection. The two CONTROL cases below pass on unfixed code; the three
 // throwing-summary cases fail on unfixed code.
 import { describe, expect, it } from "vitest";
@@ -18,7 +18,7 @@ import {
   type EngineContext,
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 
 type Clip = Readonly<{ title: string }>;
@@ -73,7 +73,7 @@ type Types = typeof types;
 type Summary = Readonly<{ seconds: number }>;
 
 /** The whole point: consumer code on the ingress path that throws. */
-const throwingSummary: SummaryCodec<Summary> = {
+const throwingSummary: SummaryType<Summary> = {
   parse(): Result<Summary, readonly Issue[]> {
     throw new Error("summary parse exploded");
   },
@@ -82,8 +82,8 @@ const throwingSummary: SummaryCodec<Summary> = {
   },
 };
 
-/** Control: the well-behaved codec, same shape, REFUSES instead of throwing. */
-const wellBehavedSummary: SummaryCodec<Summary> = {
+/** Control: the well-behaved node type, same shape, REFUSES instead of throwing. */
+const wellBehavedSummary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };
@@ -124,7 +124,7 @@ function docWithSummary(summary: unknown): unknown {
   };
 }
 
-function ctxWith(summary: SummaryCodec<Summary>): EngineContext<Summary> {
+function ctxWith(summary: SummaryType<Summary>): EngineContext<Summary> {
   return {
     engineId: Symbol("f4-probe"),
     registry: buildRegistry(types),
@@ -139,8 +139,8 @@ function ctxWith(summary: SummaryCodec<Summary>): EngineContext<Summary> {
   };
 }
 
-describe("a throwing summary codec quarantines rather than crashing", () => {
-  it("CONTROL: a summary codec that RETURNS a failure quarantines the node", () => {
+describe("a throwing summary type quarantines rather than crashing", () => {
+  it("CONTROL: a summary type that RETURNS a failure quarantines the node", () => {
     const ctx = ctxWith(wellBehavedSummary);
     const out = deserializeDocument<Types, Summary>(
       docWithSummary({ seconds: "thirty" }),
@@ -152,7 +152,7 @@ describe("a throwing summary codec quarantines rather than crashing", () => {
     expect(out.value.report.quarantined[0]?.reason).toBe("parse-failed");
   });
 
-  it("CONTROL: a NODE codec that throws is caught and quarantined", () => {
+  it("CONTROL: a NODE node type that throws is caught and quarantined", () => {
     const boomType = defineNodeType<Readonly<{ ok: true }>, never>()({
       kind: "boom",
       container: false,
@@ -222,8 +222,8 @@ describe("a throwing summary codec quarantines rather than crashing", () => {
   });
 
   it("PUBLIC API: store.load returns a Result instead of throwing", () => {
-    // Parent loads with a codec that tolerates the parent summary, then a child
-    // payload whose summary trips the same codec into throwing.
+    // Parent loads with a node type that tolerates the parent summary, then a child
+    // payload whose summary trips the same node type into throwing.
     const engine = createEngine({
       types,
       summary: {
@@ -236,7 +236,7 @@ describe("a throwing summary codec quarantines rather than crashing", () => {
         serialize(value: Summary): unknown {
           return { seconds: value.seconds };
         },
-      } satisfies SummaryCodec<Summary>,
+      } satisfies SummaryType<Summary>,
       folds: {},
     });
     const loaded = engine.deserialize(docWithSummary({ seconds: 30 }));

--- a/packages/keel-core/review-f6.test.ts
+++ b/packages/keel-core/review-f6.test.ts
@@ -29,7 +29,7 @@ import {
   parseNodeId,
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -64,7 +64,7 @@ type Proto = Readonly<{ text: string }>;
 /**
  * A leaf kind literally named `__proto__`, at schemaVersion 2, with a v1 -> v2
  * migration that renames `body` to `text`. Nothing about this is exotic to the
- * engine: it is an ordinary registered codec whose kind string happens to
+ * engine: it is an ordinary registered node type whose kind string happens to
  * collide with an accessor on `Object.prototype`.
  */
 const protoType = defineNodeType<Proto, never>()({
@@ -97,7 +97,7 @@ type Types = typeof types;
 
 type Summary = Readonly<{ seconds: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (!isRecord(raw) || typeof raw.seconds !== "number") {
       return { ok: false, error: [{ path: "$.seconds", message: "seconds" }] };

--- a/packages/keel-core/review2-destroy.test.ts
+++ b/packages/keel-core/review2-destroy.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import { createEngine } from "./engine";
 import { defineNodeType, parseNodeId } from "./types";
-import type { Issue, Result, SummaryCodec } from "./types";
+import type { Issue, Result, SummaryType } from "./types";
 
 type Clip = Readonly<{ title: string }>;
 type ClipEdit = Readonly<{ title: string }>;
@@ -39,7 +39,7 @@ const folderType = defineNodeType<Folder, Record<string, never>>()({
 });
 
 const types = [clipType, folderType] as const;
-const summary: SummaryCodec<Record<string, never>> = {
+const summary: SummaryType<Record<string, never>> = {
   parse: () => ({ ok: true, value: {} }),
   serialize: () => ({}),
 };
@@ -155,10 +155,10 @@ describe("a destroyed store refuses every write", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Undo verification must not call the consumer's codec when it does not have to
+// Undo verification must not call the consumer's node type when it does not have to
 // ---------------------------------------------------------------------------
 
-describe("verifyDataChanged consults the codec only when it must", () => {
+describe("verifyDataChanged consults the node type only when it must", () => {
   it("serializes nothing on an ordinary undo/redo of an edit", () => {
     // The machine-independent form of this claim: COUNT the consumer calls
     // rather than time them. `serialize` is consumer code of unknown cost, and

--- a/packages/keel-core/review3-a-leaf-owns-no-subtree.test.ts
+++ b/packages/keel-core/review3-a-leaf-owns-no-subtree.test.ts
@@ -36,7 +36,7 @@ import { describe, expect, it } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -114,7 +114,7 @@ const types = [clipType, folderType] as const;
 type Types = typeof types;
 type Summary = Readonly<{ n: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/review3-a-quarantined-node-stays-repairable.test.ts
+++ b/packages/keel-core/review3-a-quarantined-node-stays-repairable.test.ts
@@ -22,7 +22,7 @@ import { describe, expect, it } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -100,7 +100,7 @@ const folderType = defineNodeType<Folder, Readonly<{ name?: string }>>()({
 });
 
 type Summary = Readonly<{ n: number }>;
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/review3-a-throwing-node-type-cannot-escape-as-an-exception.test.ts
+++ b/packages/keel-core/review3-a-throwing-node-type-cannot-escape-as-an-exception.test.ts
@@ -1,35 +1,35 @@
 // Third review round — the other half of "the engine survives its consumers".
 //
 // Every consumer `parse` call is defensively wrapped: ./serialize wraps node
-// data, and a prior round wrapped the summary codec beside it. NO `serialize`
+// data, and a prior round wrapped the summary type beside it. NO `serialize`
 // call was, and `serialize` is consumer code on exactly the same footing.
 //
 // The asymmetry costs three different contracts:
 //
-//   - `dispatch` promises a `Result`. A codec that throws while the reducer
+//   - `dispatch` promises a `Result`. A node type that throws while the reducer
 //     round-trips its own output turned that into an unhandled exception out of
 //     a React event handler, at every call site that correctly wrote
 //     `if (!result.ok)`.
 //   - `verifyPatchApplies` promises a `Result`. Undo runs the consumer's
 //     `serialize` once per changed node to prove the recorded `before` still
-//     stands, so a throwing codec took out undo the same way.
+//     stands, so a throwing node type took out undo the same way.
 //   - `serializeGraph` promises to be TOTAL, in those words, "because a save
 //     path that throws loses the user's document". Its own `serializeData`
 //     already states the policy — "an unserializable node should cost one
-//     node's fidelity, never the whole save" — and then called `type.serialize`
+//     node's fidelity, never the whole save" — and then called `nodeType.serialize`
 //     unwrapped on the very next line.
 import { describe, expect, it } from "vitest";
 
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
 import { createEngine } from "./engine";
 
-// Which codec call should blow up. Flipped per test; the throw is realistic —
+// Which node-type call should blow up. Flipped per test; the throw is realistic —
 // an encoder meeting a value it cannot represent, not a synthetic panic.
 const explode = {
   nodeSerialize: false,
@@ -116,7 +116,7 @@ type Types = typeof types;
 
 type Summary = Readonly<{ seconds: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };
@@ -181,7 +181,7 @@ function loadedStore() {
 // dispatch
 // ---------------------------------------------------------------------------
 
-describe("the reducer refuses rather than throwing when a codec blows up", () => {
+describe("the reducer refuses rather than throwing when a node type blows up", () => {
   it("returns a Result when applyEdit throws", () => {
     resetExplosions();
     const { store } = loadedStore();
@@ -227,7 +227,7 @@ describe("the reducer refuses rather than throwing when a codec blows up", () =>
     if (result && !result.ok) expect(result.error.code).toBe("parse-failed");
   });
 
-  it("leaves the graph and the history stack untouched after a codec throw", () => {
+  it("leaves the graph and the history stack untouched after a node type throw", () => {
     resetExplosions();
     const { store } = loadedStore();
     const before = store.getGraph();
@@ -285,7 +285,7 @@ describe("replay verification refuses rather than throwing", () => {
     }
   });
 
-  it("keeps undo Result-shaped when the codec throws mid-verification", () => {
+  it("keeps undo Result-shaped when the node type throws mid-verification", () => {
     resetExplosions();
     const { store } = loadedStore();
     store.dispatch({
@@ -315,8 +315,8 @@ describe("replay verification refuses rather than throwing", () => {
 // serializeGraph — the save path, which is documented TOTAL
 // ---------------------------------------------------------------------------
 
-describe("the save path stays total when a codec throws", () => {
-  it("does not lose the document when a node codec throws", () => {
+describe("the save path stays total when a node type throws", () => {
+  it("does not lose the document when a node type throws", () => {
     resetExplosions();
     const { engine, store } = loadedStore();
     const graph = store.getGraph();
@@ -344,7 +344,7 @@ describe("the save path stays total when a codec throws", () => {
     expect(root?.data).toEqual({ name: "Root" });
   });
 
-  it("does not lose the document when the summary codec throws", () => {
+  it("does not lose the document when the summary type throws", () => {
     resetExplosions();
     const { engine, store } = loadedStore();
     const graph = store.getGraph();
@@ -365,7 +365,7 @@ describe("the save path stays total when a codec throws", () => {
       "box",
       "root",
     ]);
-    // The clip beside it is untouched by the summary codec's failure.
+    // The clip beside it is untouched by the summary type's failure.
     const clip = doc?.nodes.find((node) => node.id === "a");
     expect(clip?.data).toEqual({ title: "A", seconds: 4 });
   });

--- a/packages/keel-core/review3-removal-notification-and-listener-isolation.test.ts
+++ b/packages/keel-core/review3-removal-notification-and-listener-isolation.test.ts
@@ -26,7 +26,7 @@ import { describe, expect, it } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -101,7 +101,7 @@ type Types = typeof types;
 
 type Summary = Readonly<{ seconds: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/review3-replay-cannot-install-a-duplicate-owner.test.ts
+++ b/packages/keel-core/review3-replay-cannot-install-a-duplicate-owner.test.ts
@@ -22,7 +22,7 @@ import { describe, expect, it } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -100,7 +100,7 @@ const types = [boxType, clipType] as const;
 type Types = typeof types;
 type Summary = Readonly<{ n: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/review3-the-ceilings-bound-the-graph-not-one-payload.test.ts
+++ b/packages/keel-core/review3-the-ceilings-bound-the-graph-not-one-payload.test.ts
@@ -28,7 +28,7 @@ import { describe, expect, it } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -87,7 +87,7 @@ const types = [clipType, folderType] as const;
 type Types = typeof types;
 type Summary = Readonly<{ n: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/review3-the-two-default-ceilings-agree.test.ts
+++ b/packages/keel-core/review3-the-two-default-ceilings-agree.test.ts
@@ -35,7 +35,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type Issue,
   type Result,
-  type SummaryCodec,
+  type SummaryType,
   defineNodeType,
   parseNodeId,
 } from "./types";
@@ -96,7 +96,7 @@ const types = [clipType, folderType] as const;
 type Types = typeof types;
 type Summary = Readonly<{ n: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-core/serialize.test.ts
+++ b/packages/keel-core/serialize.test.ts
@@ -21,7 +21,7 @@ import {
   type Result,
   type SerializedDocument,
   type SerializedNode,
-  type SummaryCodec,
+  type SummaryType,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -172,7 +172,7 @@ const sparseType = defineNodeType<Readonly<{ v: number }>, never>()({
   },
 });
 
-/** A codec whose migration throws, and whose parse throws. Both are consumer
+/** A node type whose migration throws, and whose parse throws. Both are consumer
  *  code, and an ingress door that propagates either takes the document down. */
 const hostileType = defineNodeType<Readonly<{ ok: true }>, never>()({
   kind: "hostile",
@@ -199,7 +199,7 @@ type Types = typeof TYPES;
 
 type Summary = Readonly<{ count: number }>;
 
-const summaryCodec: SummaryCodec<Summary> = {
+const summaryType: SummaryType<Summary> = {
   parse(raw: unknown): Result<Summary, readonly Issue[]> {
     if (!isRecord(raw) || typeof raw.count !== "number") {
       return { ok: false, error: issue("$.count", "summary.count must be a number") };
@@ -219,7 +219,7 @@ function makeCtx(
   return {
     engineId: ENGINE_ID,
     registry: buildRegistry(TYPES),
-    summary: summaryCodec,
+    summary: summaryType,
     onUnknownKind: "quarantine",
     onParseFailure: "quarantine",
     maxNodes: DEFAULT_MAX_NODES,
@@ -408,7 +408,7 @@ describe("parseNodeData", () => {
     expect(error.kind).toBe("ghost");
   });
 
-  it("relays the codec's own issues on a parse failure", () => {
+  it("relays the node type's own issues on a parse failure", () => {
     const error = expectErr(
       parseNodeData(makeCtx(), {
         nodeId: id("n"),
@@ -439,7 +439,7 @@ describe("parseNodeData", () => {
     ]);
   });
 
-  it("does not throw when a codec's parse throws", () => {
+  it("does not throw when a node type's parse throws", () => {
     // An ingress door that propagates a consumer exception takes the whole
     // document down, which is exactly what quarantine exists to prevent.
     const error = expectErr(
@@ -658,7 +658,7 @@ describe("deserializeDocument", () => {
     expect(graph.childrenById.has(id("root"))).toBe(false);
   });
 
-  it("carries summary through the codec, and absent summary as null", () => {
+  it("carries summary through the node type, and absent summary as null", () => {
     const graph = loadSimple();
     const sub = nodeIn(graph, "sub");
     const root = nodeIn(graph, "root");
@@ -668,9 +668,9 @@ describe("deserializeDocument", () => {
     expect(root.summary).toBeNull();
   });
 
-  it("reads an explicit null summary as no summary, not as codec input", () => {
+  it("reads an explicit null summary as no summary, not as node type input", () => {
     // Our own writer omits the key, but a reformatted document spells it out,
-    // and handing `null` to a codec expecting S would quarantine a node for the
+    // and handing `null` to a node type expecting S would quarantine a node for the
     // crime of having no rollup yet.
     const graph = expectOk(
       deserializeDocument<Types, Summary>(
@@ -781,7 +781,7 @@ describe("deserializeDocument", () => {
     expect(note.data).toEqual({ text: "kept", color: "blue" });
   });
 
-  it("collects codec warnings against their node", () => {
+  it("collects node type warnings against their node", () => {
     const report = expectOk(
       deserializeDocument<Types, Summary>(
         {
@@ -1185,7 +1185,7 @@ describe("quarantine", () => {
     expect(node.children).toBeNull();
   });
 
-  it("quarantines a node whose SUMMARY fails its codec, keeping it raw", () => {
+  it("quarantines a node whose SUMMARY fails its node type, keeping it raw", () => {
     // A failed summary is per-node content, not a malformed document. The node
     // stays movable and deletable and its raw summary survives.
     const loaded = expectOk(
@@ -1271,7 +1271,7 @@ describe("quarantine", () => {
   });
 
   it("does not let a quarantined node claim ownership of a sourceKey", () => {
-    // `sourceKey` comes from a codec that by definition did not run, so a
+    // `sourceKey` comes from a node type that by definition did not run, so a
     // quarantined node cannot be an owner and cannot conflict with one.
     const ctx = makeCtx();
     const graph = expectOk(
@@ -1371,7 +1371,7 @@ describe("serializeGraph", () => {
   });
 
   it("round-trips a quarantined UNLOADED container as a container", () => {
-    // The trap: an unregistered kind has no codec to declare container-ness, so
+    // The trap: an unregistered kind has no node type to declare container-ness, so
     // the wire decides. Without an explicit `childrenState: "unloaded"` this
     // node would reload as a quarantined LEAF and its subtree would become
     // unreachable forever.
@@ -1594,7 +1594,7 @@ describe("loadChildrenInto", () => {
   });
 
   it("can fill a quarantined container", () => {
-    // Its kind failed a codec, but its subtree is real and refusing to load it
+    // Its kind failed a node type, but its subtree is real and refusing to load it
     // would strand every node underneath it.
     const ctx = makeCtx();
     const graph = expectOk(

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -5,7 +5,7 @@
 // This module owns the only place untrusted content becomes typed `Data`.
 // Every ingress in the engine funnels through `parseNodeData`: `deserialize`,
 // `loadChildren`, `insert-nodes` seeds, and `applyIngest`. One door means one
-// place migrations run, one place a codec's refusal is interpreted, and one
+// place migrations run, one place a node type's refusal is interpreted, and one
 // place to look when forward-incompatible data shows up in production.
 //
 // TWO VERSION AXES, deliberately separate:
@@ -14,7 +14,7 @@
 //     children encoding.
 //   - `schemaVersions` — the CONSUMER's per-kind content schema. One number
 //     per kind, because one number cannot advance three independent schemas
-//     without forcing every codec to bump when any one of them changes.
+//     without forcing every node type to bump when any one of them changes.
 //
 // QUARANTINE, NOT REJECTION, IS THE DEFAULT. An unregistered kind or a failed
 // parse becomes a `QuarantinedNode` that keeps its id, its position and its
@@ -156,13 +156,13 @@ function malformed(message: string): Result<never, StructuralError> {
 }
 
 /**
- * Shape validator for an untrusted document. STRUCTURE ONLY — no codec runs
+ * Shape validator for an untrusted document. STRUCTURE ONLY — no node type runs
  * here, and no referential integrity is checked (dangling children, duplicate
  * ids, unreachable nodes and the forest condition all belong to
  * `deserializeDocument`, which needs the whole node set to judge them).
  *
  * It CONSTRUCTS a normalized document rather than asserting over the input,
- * for the same reason a codec's `parse` must construct: an assertion is a
+ * for the same reason a node type's `parse` must construct: an assertion is a
  * promise the compiler cannot check, and a document that merely *looks* right
  * to a type predicate would then be indexed as if every field were the
  * declared type.
@@ -295,7 +295,7 @@ function parseSerializedNode(
   // `undefined` (a marker node, a kind whose whole content is its id) would
   // round-trip through our own writer and then fail to load. Requiring the key
   // would make the engine unable to read documents it wrote itself. The
-  // codec's `parse` is the thing that decides whether `undefined` is
+  // node type's `parse` is the thing that decides whether `undefined` is
   // acceptable content for that kind — that is its job, not ours.
   const draft: NodeDraft = {
     id: raw.id,
@@ -350,7 +350,7 @@ function parseSerializedNode(
     draft.missingReason = raw.missingReason;
   }
 
-  // Preserved verbatim; the summary CODEC runs later, per node, and a failure
+  // Preserved verbatim; the summary type runs later, per node, and a failure
   // there is per-node content, not a malformed document.
   if ("summary" in raw) draft.summary = raw.summary;
 
@@ -376,7 +376,7 @@ function ingressError(
  *
  * `args.container` is what the engine is ABOUT to treat this node as, and is
  * simply forwarded into `ParseCtx`. This function does not cross-check it
- * against `type.container` — the caller computes it from the registry (for a
+ * against `nodeType.container` — the caller computes it from the registry (for a
  * registered kind) or from the wire (for an unregistered one) and owns that
  * decision, so a check here would either be a tautology or a second opinion
  * that can disagree with the node actually built.
@@ -385,7 +385,7 @@ function ingressError(
  * The two content dev checks, run together because they share a value and an
  * order: FREEZE FIRST, then round-trip. Freezing first is what makes the
  * round-trip safe — the extra `serialize` call it introduces is consumer code,
- * and a codec that normalises in place would otherwise mutate a value the
+ * and a node type that normalises in place would otherwise mutate a value the
  * engine is about to store, making the graph differ between `devChecks: true`
  * and `false`. Frozen, that mutation throws into the try/catch and is reported.
  *
@@ -395,7 +395,7 @@ function ingressError(
  * diagnostic must not do.
  *
  * RE-ENTRY, and nothing structural prevents it: `reparse` MUST call the
- * codec's own `parse` directly. Routing the second parse back through
+ * node type's own `parse` directly. Routing the second parse back through
  * `parseNodeData` reaches this same gate and recurses without bound, once per
  * node, on every load.
  */
@@ -439,7 +439,7 @@ function runContentDevChecks(
   if (!again.ok) {
     console.error(
       `keel dev check: ${what} produced serialize output its own parse refuses. ` +
-        `That is a lossy or malformed codec — the value stored is the ORIGINAL parse, ` +
+        `Its serialize and its parse disagree — the value stored is the ORIGINAL parse, ` +
         `so nothing is corrupted, but this document will not survive a save/load cycle.`,
       again.error,
     );
@@ -472,10 +472,10 @@ export function parseNodeData<S>(
     raw: unknown;
     /**
      * DEV CHECKS ONLY. Set by the edit door, where `raw` is already this
-     * codec's own `serialize` output rather than wire data. The generic
+     * node type's own `serialize` output rather than wire data. The generic
      * `parse(serialize(d))` comparison is provably vacuous there — it would
      * re-derive a value from the same bytes it just came from — and costs two
-     * consumer codec calls per edited node on the interactive path. The edit
+     * consumer node-type calls per edited node on the interactive path. The edit
      * door runs its own, stronger comparison instead.
      */
     rawIsSerializeOutput?: boolean;
@@ -488,8 +488,8 @@ export function parseNodeData<S>(
   }>,
   IngressError
 > {
-  const type = ctx.registry.get(args.kind);
-  if (type === undefined) {
+  const nodeType = ctx.registry.get(args.kind);
+  if (nodeType === undefined) {
     return ingressError(args.nodeId, args.kind, "unknown-kind", [
       {
         path: "$.kind",
@@ -501,8 +501,8 @@ export function parseNodeData<S>(
   const migration = runMigrations(
     args.raw,
     args.schemaVersion,
-    type.schemaVersion,
-    type.migrations,
+    nodeType.schemaVersion,
+    nodeType.migrations,
   );
   if (!migration.ok) {
     return ingressError(args.nodeId, args.kind, "parse-failed", [
@@ -514,18 +514,18 @@ export function parseNodeData<S>(
   const parseCtx: ParseCtx = {
     nodeId: args.nodeId,
     container: args.container,
-    schemaVersion: type.schemaVersion,
+    schemaVersion: nodeType.schemaVersion,
     warn(issue: Issue): void {
       warnings.push(issue);
     },
   };
 
-  // A codec is consumer code, and an ingress door that throws takes the whole
+  // A node type is consumer code, and an ingress door that throws takes the whole
   // document down — the exact failure quarantine exists to prevent. A thrown
   // parse is reported as the refusal it evidently is.
   let parsed: Result<unknown, readonly Issue[]>;
   try {
-    parsed = type.parse(migration.value.data, parseCtx);
+    parsed = nodeType.parse(migration.value.data, parseCtx);
   } catch (thrown) {
     return ingressError(args.nodeId, args.kind, "parse-failed", [
       {
@@ -545,18 +545,18 @@ export function parseNodeData<S>(
   const parsedValue: unknown = parsed.value;
   runContentDevChecks(
     ctx.devChecks,
-    `the ${JSON.stringify(args.kind)} codec (node ${JSON.stringify(args.nodeId)})`,
+    `the ${JSON.stringify(args.kind)} node type (node ${JSON.stringify(args.nodeId)})`,
     parsedValue,
-    () => type.serialize(parsedValue),
+    () => nodeType.serialize(parsedValue),
     // DIRECTLY, never through `parseNodeData` — see the re-entry note above.
     // The second parse gets a THROWAWAY warn sink: reusing `warnings` would
     // double the entries `LoadReport.warnings` receives, so the report itself
     // would differ between dev-check modes.
     (raw) =>
-      type.parse(raw, {
+      nodeType.parse(raw, {
         nodeId: args.nodeId,
         container: args.container,
-        schemaVersion: type.schemaVersion,
+        schemaVersion: nodeType.schemaVersion,
         warn: () => undefined,
       }),
     args.rawIsSerializeOutput === true,
@@ -589,7 +589,7 @@ function runMigrations(
 ): Result<Readonly<{ data: unknown; migratedFrom: number | null }>, Issue> {
   // `from > to` means the document was written by a NEWER build than this one.
   // No migration can walk backwards, so nothing runs and the value goes
-  // straight to `parse` — a codec that tolerates unknown additive fields reads
+  // straight to `parse` — a node type that tolerates unknown additive fields reads
   // it fine, and one that does not quarantines the node loudly. Refusing here
   // instead would turn every rolling deploy into a document that will not open.
   if (migrations === undefined || from >= to) {
@@ -760,14 +760,14 @@ function buildDocument<Ts extends readonly unknown[], S>(
   /** Leaf kinds that arrived carrying children. Quarantined in Pass F. */
   const shapeMismatchById = new Map<NodeId, Issue>();
   for (const [id, node] of wireById) {
-    const type = ctx.registry.get(node.kind);
+    const nodeType = ctx.registry.get(node.kind);
     const hasChildren = node.children !== undefined;
 
     // For a REGISTERED kind the registry is the sole authority: `container` is
     // kind-level and immutable, never a predicate over data, so a wire that
     // disagrees is wrong rather than informative.
     //
-    // For an UNREGISTERED kind there is no codec to ask, so the wire decides —
+    // For an UNREGISTERED kind there is no node type to ask, so the wire decides —
     // and the rule is "a children array or an explicit childrenState makes it
     // a container", NOT the "default to unloaded" rule below. That asymmetry
     // is what keeps quarantine round-tripping: `serializeGraph` writes an
@@ -776,8 +776,8 @@ function buildDocument<Ts extends readonly unknown[], S>(
     // guessing "unloaded container" would silently grow it a subtree it never
     // had.
     const container =
-      type !== undefined
-        ? type.container
+      nodeType !== undefined
+        ? nodeType.container
         : hasChildren || node.childrenState !== undefined;
 
     if (!container) {
@@ -970,7 +970,7 @@ function buildDocument<Ts extends readonly unknown[], S>(
     if (wire === undefined) continue; // `order` came from `wireById`; unreachable.
     const container = containerById.get(id) === true;
     const state = stateById.get(id) ?? { status: "unloaded" };
-    const type = ctx.registry.get(wire.kind);
+    const nodeType = ctx.registry.get(wire.kind);
 
     // A SHAPE MISMATCH SHORT-CIRCUITS THE CONTENT PASSES. There is no point
     // migrating or parsing data for a node already known not to fit its own
@@ -1000,7 +1000,7 @@ function buildDocument<Ts extends readonly unknown[], S>(
       (Object.hasOwn(doc.schemaVersions, wire.kind)
         ? doc.schemaVersions[wire.kind]
         : undefined) ??
-      type?.schemaVersion ??
+      nodeType?.schemaVersion ??
       0;
 
     let failure: IngressError | null =
@@ -1028,7 +1028,7 @@ function buildDocument<Ts extends readonly unknown[], S>(
 
     if (parsedData === null) {
       // A shape mismatch, already recorded above. Its DATA is never parsed:
-      // running the codec on a node known not to fit its own kind reports a
+      // running the node type on a node known not to fit its own kind reports a
       // second, derived failure that tells the reader nothing about the real
       // one. `raw` is carried through byte-exact, as with every quarantine.
     } else if (!parsedData.ok) {
@@ -1038,24 +1038,24 @@ function buildDocument<Ts extends readonly unknown[], S>(
       for (const issue of parsedData.value.warnings) {
         warnings.push({ nodeId: id, issue });
       }
-      if (parsedData.value.migratedFrom !== null && type !== undefined) {
+      if (parsedData.value.migratedFrom !== null && nodeType !== undefined) {
         migrated.push({
           nodeId: id,
           kind: wire.kind,
           from: parsedData.value.migratedFrom,
-          to: type.schemaVersion,
+          to: nodeType.schemaVersion,
         });
       }
 
       // A summary belongs to a collection; a leaf has nothing to summarize.
       // `null` and absent are BOTH read as "no summary" without calling the
-      // codec: our own writer omits the key for a null summary, but a
+      // node type: our own writer omits the key for a null summary, but a
       // hand-written or reformatted document spells it out, and handing `null`
-      // to a codec that expects `S` would quarantine a node for the crime of
+      // to a node type that expects `S` would quarantine a node for the crime of
       // having no rollup yet.
       if (container && wire.summary !== undefined && wire.summary !== null) {
-        // WRAPPED, exactly as `parseNodeData` wraps a node codec's `parse`. The
-    // summary codec is consumer-supplied and runs on untrusted bytes, so a
+        // WRAPPED, exactly as `parseNodeData` wraps a node type's `parse`. The
+    // summary type is consumer-supplied and runs on untrusted bytes, so a
     // throw here is the same class of event as a throw there — and it used to
     // take the whole `deserialize` down instead of quarantining one node,
     // which is the failure quarantine exists to prevent.
@@ -1090,7 +1090,7 @@ function buildDocument<Ts extends readonly unknown[], S>(
           summary = parsedSummary.value;
           runContentDevChecks(
             ctx.devChecks,
-            `the summary codec (node ${JSON.stringify(id)})`,
+            `the summary type (node ${JSON.stringify(id)})`,
             parsedSummary.value,
             () => ctx.summary.serialize(parsedSummary.value),
             (raw) => ctx.summary.parse(raw),
@@ -1177,7 +1177,7 @@ function buildDocument<Ts extends readonly unknown[], S>(
  *
  * Leaves are exempt: `childrenStateOf` returns `null` for them, and a node
  * with no subtree cannot own one. Quarantined nodes are exempt too —
- * `sourceKeyOf` returns `null` for them, since the key comes from a codec that
+ * `sourceKeyOf` returns `null` for them, since the key comes from a node type that
  * by definition did not run.
  */
 function findDuplicateOwner<Ts extends readonly unknown[], S>(
@@ -1284,8 +1284,8 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
     string,
     number
   >;
-  for (const [kind, type] of ctx.registry) {
-    schemaVersions[kind] = type.schemaVersion;
+  for (const [kind, nodeType] of ctx.registry) {
+    schemaVersions[kind] = nodeType.schemaVersion;
   }
 
   const nodes: SerializedNode[] = [];
@@ -1307,28 +1307,28 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
   };
 
   const serializeData = (kind: string, data: unknown): unknown => {
-    const type = ctx.registry.get(kind);
-    // Unreachable: a non-quarantined node was built by a codec found in this
+    const nodeType = ctx.registry.get(kind);
+    // Unreachable: a non-quarantined node was built by a node type found in this
     // very registry. Falling back to the live value rather than throwing keeps
     // this function total — an unserializable node should cost one node's
     // fidelity, never the whole save.
-    if (type === undefined) return data;
+    if (nodeType === undefined) return data;
     // The SAME fallback, for the reachable version of the same problem. The
-    // branch above handles a codec that is missing; this one handles a codec
+    // branch above handles a node type that is missing; this one handles a node type
     // that is present and throws, which is consumer code and therefore not
     // hypothetical. Leaving it bare contradicted this function's own policy one
     // line up and, worse, the module's promise that `serializeGraph` is TOTAL
     // "because a save path that throws loses the user's document".
     //
-    // The live value is the best remaining representation: it is what the codec
+    // The live value is the best remaining representation: it is what the node type
     // was asked to encode, it is usually near-identical to the wire form, and
     // on reload it either parses or quarantines loudly. Both outcomes beat
     // losing the whole save.
     try {
-      return type.serialize(data);
+      return nodeType.serialize(data);
     } catch (thrown) {
       console.error(
-        `keel: the ${JSON.stringify(kind)} codec threw while serializing a node for save. ` +
+        `keel: ${JSON.stringify(kind)}.serialize threw while writing a node for save. ` +
           `That node is being written in its live form instead, which may not round-trip. ` +
           `The rest of the document is unaffected.`,
         thrown,
@@ -1374,11 +1374,11 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
     };
     if (node.container) {
       // `null` is written as an absent key, and read back as `null`. Emitting
-      // an explicit null would round-trip too, but only if the summary codec
+      // an explicit null would round-trip too, but only if the summary type
       // tolerated being handed one.
       if (node.summary !== null) {
         // Guarded like `serializeData`, and for the same reason: the summary
-        // codec is consumer code on the same footing as a node codec, and its
+        // type is consumer code on the same footing as a node type, and its
         // `parse` half is already wrapped at ingress. A summary is a DERIVED
         // rollup, so dropping it costs strictly less than dropping a node —
         // the next reader sees an unloaded container with no stored estimate,
@@ -1387,7 +1387,7 @@ export function serializeGraph<Ts extends readonly unknown[], S>(
           draft.summary = ctx.summary.serialize(node.summary);
         } catch (thrown) {
           console.error(
-            `keel: the summary codec threw while serializing node ${JSON.stringify(id)} for save. ` +
+            `keel: the summary type's serialize threw while writing node ${JSON.stringify(id)} for save. ` +
               `Its stored summary is being omitted; the rest of the document is unaffected.`,
             thrown,
           );
@@ -1469,7 +1469,7 @@ export function loadChildrenInto<Ts extends readonly unknown[], S>(
 
   // `childrenStateOf` returns null for a leaf, an unknown node, or a
   // QUARANTINED leaf — which is exactly the set that cannot be loaded into. A
-  // quarantined CONTAINER can be: its kind failed a codec, but its subtree is
+  // quarantined CONTAINER can be: its kind failed to parse, but its subtree is
   // still real, still addressable, and refusing to load it would strand every
   // node underneath it.
   const state = childrenStateOf(graph, id);

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -9,7 +9,7 @@
 //
 // Layout:
 //   1. Primitives      — NodeId, Result, Issue
-//   2. Node types      — the per-kind codec registry and its factory
+//   2. Node types      — the per-kind registry and its factory
 //   3. The graph       — nodes, children states, derived indexes
 //   4. Commands        — the only user-intent mutation vocabulary
 //   5. Patches         — the reversible record of a mutation
@@ -82,10 +82,10 @@ export function tryParseNodeId(id: string): Result<NodeId, Issue> {
 }
 
 // ---------------------------------------------------------------------------
-// 2. Node types — the per-kind codec registry
+// 2. Node types — the per-kind registry
 // ---------------------------------------------------------------------------
 
-/** Handed to `parse` so a codec can warn without failing, and can see whether
+/** Handed to `parse` so a node type can warn without failing, and can see whether
  *  the engine is about to treat this node as a container. */
 export type ParseCtx = Readonly<{
   nodeId: NodeId;
@@ -95,8 +95,17 @@ export type ParseCtx = Readonly<{
 }>;
 
 /**
- * One kind's codec: how its opaque `Data` is parsed, serialized, edited, and
- * (optionally) keyed for identity.
+ * One kind's node type — everything the engine knows about that kind: how its
+ * opaque `Data` is parsed, serialized, edited, and (optionally) keyed for
+ * identity.
+ *
+ * CONSUMER-DEFINED, and that is the load-bearing fact rather than a note about
+ * authorship. Every member below is code the engine calls but did not write, so
+ * each one is a place a throw has to be caught and a returned value has to be
+ * distrusted — which is why `parse`, `applyEdit` and `serialize` are wrapped at
+ * every door, and why `contentKey` and `sourceKey` deliberately are not (see
+ * ./graph). "Consumer" here means the programmer integrating keel; "user" in
+ * this package always means the person pressing Ctrl-Z.
  *
  * ALL MEMBERS ARE METHOD SHORTHAND, NOT ARROW PROPERTIES. This is load-bearing
  * and it is verified, not assumed: under `strictFunctionTypes` an arrow
@@ -106,12 +115,12 @@ export type ParseCtx = Readonly<{
  * — every real node type rejected at the `createEngine` call. Method shorthand
  * stays bivariant, including through the `Readonly<>` wrapper (I compiled both
  * forms to confirm the wrapper preserves it). That bivariance is also what
- * lets the reducer call `type.applyEdit(node.data, edit.edit)` off an erased
+ * lets the reducer call `nodeType.applyEdit(node.data, edit.edit)` off an erased
  * `SomeNodeType` with no cast anywhere.
  *
- * The price is honest: bivariance is unsound, so a codec that lies about its
+ * The price is honest: bivariance is unsound, so a node type that lies about its
  * own Data type is not caught here. The trust boundary is enforceable; the
- * codec's interior is not.
+ * node type's interior is not.
  */
 export type NodeType<K extends string, Data, Edit> = Readonly<{
   kind: K;
@@ -166,7 +175,7 @@ export type SomeNodeType = NodeType<string, unknown, unknown>;
 
 /**
  * CURRIED, and that is the whole point. `Edit` has exactly one inference site
- * (`applyEdit`'s second parameter), so an uncurried factory lets a codec whose
+ * (`applyEdit`'s second parameter), so an uncurried factory lets a node type whose
  * `applyEdit` ignores its edit argument silently infer `Edit = unknown` — at
  * which point every dispatched edit for that kind typechecks and the per-kind
  * edit typing is dead. Making `Data` and `Edit` explicit closes it while `K`
@@ -186,8 +195,8 @@ export function defineNodeType<Data, Edit = never>(): <K extends string>(
  */
 export type NodeTypeRegistry = ReadonlyMap<string, SomeNodeType>;
 
-/** `S`'s own codec — the summary has its own lifecycle, separate from any kind. */
-export type SummaryCodec<S> = Readonly<{
+/** `S`'s own parse/serialize pair — the summary has its own lifecycle, separate from any kind. */
+export type SummaryType<S> = Readonly<{
   parse(raw: unknown): Result<S, readonly Issue[]>;
   serialize(summary: S): unknown;
 }>;
@@ -335,7 +344,7 @@ export type QuarantineReason =
  * and since the trash bin is rewritten on every delete, deleting *anything*
  * became impossible.
  *
- * `container` comes from the WIRE, not from a codec — there is no codec.
+ * `container` comes from the WIRE, not from a node type — there is no node type.
  */
 export type QuarantinedNode = Readonly<{
   id: NodeId;
@@ -352,7 +361,7 @@ export type QuarantinedNode = Readonly<{
    * `null` on a quarantined leaf.
    */
   children: ChildrenState | null;
-  /** Carried through untouched — the summary codec is not the failing one. */
+  /** Carried through untouched — the summary type is not the failing one. */
   summary: unknown;
 }>;
 
@@ -456,7 +465,7 @@ export type Graph<Ts extends readonly unknown[], S> = Readonly<{
  * by convention.
  *
  * `data` is typed as the kind's `D`, and the engine STILL runs `parse` on it
- * and stores parse's OUTPUT — so a normalizing codec normalizes inserts too,
+ * and stores parse's OUTPUT — so a normalizing node type normalizes inserts too,
  * and a consumer handing in a value that violates its own invariants is caught
  * at the same door as wire data.
  *
@@ -647,7 +656,7 @@ export type RejectionCode =
   | "node-quarantined"
   /** `edit.kind` does not match the target node's kind. */
   | "kind-mismatch"
-  /** The codec's own `applyEdit` said no. See `editRejection`. */
+  /** The node type's own `applyEdit` said no. See `editRejection`. */
   | "edit-rejected"
   /** A seed's data failed its own `parse`. See `issues`. */
   | "parse-failed"
@@ -680,7 +689,7 @@ export type Rejection = Readonly<{
   /** The existing owner, on `"duplicate-owner"`. */
   ownerId?: NodeId;
   issues?: readonly Issue[];
-  /** The codec's verbatim complaint, on `"edit-rejected"`. */
+  /** The node type's verbatim complaint, on `"edit-rejected"`. */
   editRejection?: EditRejection;
   /** The ceiling that was hit, on the two `would-exceed-*` codes. Named the
    *  same as `StructuralError`'s pair so a consumer reporting a limit to the
@@ -691,7 +700,7 @@ export type Rejection = Readonly<{
 }>;
 
 /**
- * A codec's own refusal. Consumer-authored, so `code` is a free string — the
+ * A node type's own refusal. Consumer-authored, so `code` is a free string — the
  * engine only relays it.
  */
 export type EditRejection = Readonly<{
@@ -916,7 +925,7 @@ export type LoadReport = Readonly<{
     from: number;
     to: number;
   }>[];
-  /** Non-fatal complaints a codec raised via `ParseCtx.warn`. */
+  /** Non-fatal complaints a node type raised via `ParseCtx.warn`. */
   warnings: readonly Readonly<{ nodeId: NodeId; issue: Issue }>[];
 }>;
 
@@ -928,7 +937,7 @@ export type LoadReport = Readonly<{
 export type EngineContext<S> = Readonly<{
   engineId: symbol;
   registry: NodeTypeRegistry;
-  summary: SummaryCodec<S>;
+  summary: SummaryType<S>;
   onUnknownKind: "quarantine" | "reject";
   onParseFailure: "quarantine" | "reject";
   /** Ceiling on nodes in one document. See `EngineConfig.maxNodes`. */
@@ -949,11 +958,11 @@ export type EngineContext<S> = Readonly<{
    * as an inventory rather than an intention:
    *
    *   - DEEP-FREEZE of every parsed value, at `parseNodeData`'s success return
-   *     and at the summary codec. Catches a `serialize` that normalises its
+   *     and at the summary type. Catches a `serialize` that normalises its
    *     argument in place. Typed arrays are skipped — freezing one throws.
    *   - `parse(serialize(d))` ROUND-TRIP at those same two doors. Catches a
    *     `serialize` that drops a field `parse` keeps. Both sides of the
-   *     comparison are parse OUTPUTS, so a normalising codec does not
+   *     comparison are parse OUTPUTS, so a normalising node type does not
    *     false-alarm.
    *   - UPSTREAM VS DOWNSTREAM at the edit door: what `applyEdit` returned
    *     against what the engine stored after its own round trip. Free, and
@@ -961,7 +970,7 @@ export type EngineContext<S> = Readonly<{
    *     that door.
    *   - THE OPT-IN `invertEdit`, verified as
    *     `applyEdit(applyEdit(d, e), invertEdit(e, d))` deep-equals `d`. A no-op
-   *     for the many codecs that declare no inverse.
+   *     for the many node types that declare no inverse.
    *   - THE SHADOW COLD REFOLD, on cache HITS ONLY and budgeted. A miss has
    *     nothing memoized to be wrong, so shadowing one buys a comparison that
    *     cannot fail — measured at 80% of executions before the rescope.
@@ -969,7 +978,7 @@ export type EngineContext<S> = Readonly<{
    * A fifth audit runs behind this flag and is not one of the above: the graph
    * invariant walk after every commit. It predates the list.
    *
-   * None of these can prove a consumer's codec actually validates — that is
+   * None of these can prove a consumer's node type actually validates — that is
    * genuinely unenforceable. Two further limits are worth knowing: the
    * comparator treats `Date`, `Map` and `Set` as `{}`, and freezing a `Map`
    * does not stop `map.set`.
@@ -1260,10 +1269,10 @@ export type EngineConfig<
 > = Readonly<{
   /** Duplicate `kind` is REJECTED at runtime — it THROWS, because a duplicate
    *  is a programmer error at module init, not a recoverable condition. Two
-   *  codecs claiming one kind means one silently wins at the trust boundary
+   *  node types claiming one kind means one silently wins at the trust boundary
    *  and the discriminant is dead. */
   types: Ts;
-  summary: SummaryCodec<S>;
+  summary: SummaryType<S>;
   folds: F;
   /** Default `"quarantine"`. */
   onUnknownKind?: "quarantine" | "reject";
@@ -1473,7 +1482,7 @@ export type Engine<
 // permitted.
 //
 // The soundness argument is the same for all four and worth stating once: the
-// caller has just looked a codec up in the registry — where it is erased to
+// caller has just looked a node type up in the registry — where it is erased to
 // `NodeType<string, unknown, unknown>` — and run its `parse`. The value in hand
 // IS that kind's `Data`; the compiler simply cannot see through the erasure to
 // prove it, because the registry is a `Map` and the mapped tuple is a
@@ -1529,7 +1538,7 @@ export function makeCollectionNode<Ts extends readonly unknown[], S>(
 
 /**
  * A quarantined node needs no cast — `QuarantinedNode` is not generic, since
- * there is no codec and therefore no `Data`. Present for symmetry, and to keep
+ * there is no node type and therefore no `Data`. Present for symmetry, and to keep
  * `raw` construction in one place: `raw` MUST be the value exactly as it
  * arrived, or re-emit stops being byte-exact.
  */
@@ -1592,8 +1601,8 @@ export function makeDataChange<Ts extends readonly unknown[]>(
  * returning.
  *
  * It lives HERE, in the module that imports nothing, because all four modules
- * that call into a consumer codec need it — ./serialize wraps `parse` and the
- * summary codec, ./commands wraps `applyEdit` and `serialize`, ./patches wraps
+ * that call into consumer code need it — ./serialize wraps `parse` and the
+ * summary type, ./commands wraps `applyEdit` and `serialize`, ./patches wraps
  * the `serialize` pair that replay verification compares on. One
  * implementation, so the three cannot drift into describing the same throw
  * three different ways.
@@ -1710,7 +1719,7 @@ export function structurallyEqualBounded(
     const frame = stack.pop();
     if (frame === undefined) break;
     const { left, right } = frame;
-    // Object.is, not ===, so a codec that legitimately stores NaN compares
+    // Object.is, not ===, so a node type that legitimately stores NaN compares
     // equal to itself.
     if (Object.is(left, right)) continue;
 
@@ -1729,7 +1738,7 @@ export function structurallyEqualBounded(
     if (leftKeys.length !== Object.keys(right).length) return false;
     for (const key of leftKeys) {
       // An own-key check rather than an undefined test: `{a: undefined}` and
-      // `{}` have different serialized shapes and a codec may care.
+      // `{}` have different serialized shapes and a node type may care.
       if (!Object.prototype.hasOwnProperty.call(right, key)) return false;
       stack.push({ left: left[key], right: right[key] });
     }
@@ -1749,7 +1758,7 @@ function isPlainRecord(value: unknown): value is Readonly<Record<string, unknown
  * FOUR GUARDS, each of which was found by execution rather than by reading:
  *
  *  1. TYPED ARRAYS ARE SKIPPED. `Object.freeze(new Uint8Array([1]))` THROWS
- *     "Cannot freeze array buffer views with elements". A codec returning
+ *     "Cannot freeze array buffer views with elements". A node type returning
  *     binary data is conforming, and without this line turning `devChecks` on
  *     takes the ingress door down.
  *  2. FREEZE BEFORE RECURSING, and skip anything already frozen. That is the

--- a/packages/keel-react/keel-scale.stories.tsx
+++ b/packages/keel-react/keel-scale.stories.tsx
@@ -35,7 +35,7 @@ import {
   type Result,
   type SerializedDocument,
   type SerializedNode,
-  type SummaryCodec,
+  type SummaryType,
 } from "@storyboard/keel-core";
 import { createReactBindings } from "./index";
 
@@ -101,7 +101,7 @@ const types = [clipType, folderType] as const;
 type Types = typeof types;
 type Summary = Readonly<{ seconds: number }>;
 
-const summary: SummaryCodec<Summary> = {
+const summary: SummaryType<Summary> = {
   parse(raw): Result<Summary, readonly Issue[]> {
     if (typeof raw !== "object" || raw === null) {
       return { ok: false, error: [{ path: "$", message: "not an object" }] };

--- a/packages/keel-react/keel.stories.tsx
+++ b/packages/keel-react/keel.stories.tsx
@@ -37,7 +37,7 @@ import {
   type NodeId,
   type SerializedDocument,
   type SerializedNode,
-  type SummaryCodec,
+  type SummaryType,
 } from "@storyboard/keel-core";
 
 import { createReactBindings } from "./index";
@@ -48,8 +48,8 @@ import { createReactBindings } from "./index";
 //
 // Six steps, and they are the whole integration:
 //   1. a `Data` and an `Edit` type per kind
-//   2. `defineNodeType<Data, Edit>()({ ... })` — the codec for that kind
-//   3. a summary codec — the stored rollup a not-yet-loaded collection carries
+//   2. `defineNodeType<Data, Edit>()({ ... })` — the node type for that kind
+//   3. a summary type — the stored rollup a not-yet-loaded collection carries
 //   4. folds — the questions you want answered about a subtree
 //   5. `createEngine({ types, summary, folds })` — PURE, callable from a route
 //      handler; it must not be created inside a `"use client"` module
@@ -98,7 +98,7 @@ function issue(path: string, message: string): readonly Issue[] {
  * `defineNodeType` is CURRIED — `defineNodeType<Shot, ShotEdit>()({ ... })`.
  *
  * That is not decoration. `Edit` has exactly one inference site (`applyEdit`'s
- * second parameter), so an uncurried factory lets a codec whose `applyEdit`
+ * second parameter), so an uncurried factory lets a node type whose `applyEdit`
  * ignores its edit argument silently infer `Edit = unknown`, at which point
  * every dispatched edit for that kind typechecks and the per-kind edit typing
  * is dead. Making `Data` and `Edit` explicit closes that; `K` still infers as
@@ -250,13 +250,13 @@ const sequenceType = defineNodeType<Sequence, SequenceEdit>()({
 type Types = readonly [typeof shotType, typeof noteType, typeof sequenceType];
 
 // ---------------------------------------------------------------------------
-// 3. The summary codec — what a collection remembers about children it has not
+// 3. The summary type — what a collection remembers about children it has not
 //    loaded yet
 // ---------------------------------------------------------------------------
 
 type Summary = Readonly<{ seconds: number; shots: number }>;
 
-const summaryCodec: SummaryCodec<Summary> = {
+const summaryType: SummaryType<Summary> = {
   parse(raw) {
     const record = asRecord(raw);
     if (record === null) {
@@ -379,7 +379,7 @@ function mintId(): string {
 
 const engine = createEngine({
   types: [shotType, noteType, sequenceType] as const,
-  summary: summaryCodec,
+  summary: summaryType,
   folds: { seconds: secondsFold, shots: shotsFold },
   mintId,
   // Deterministic `HistoryEntry.at`, same reasoning as `mintId`.
@@ -1052,7 +1052,7 @@ function certaintyClass(value: Folded<number> | undefined): string {
 
 /**
  * PER KIND, because one number cannot advance three independent schemas.
- * `sticker` is declared even though this build has no codec for it: a document
+ * `sticker` is declared even though this build has no node type for it: a document
  * is allowed to carry kinds you do not understand, and saying so is what lets
  * quarantine round-trip.
  */
@@ -1209,7 +1209,7 @@ const LAZY_PAYLOADS: ReadonlyMap<NodeId, SerializedDocument> = new Map([
 /**
  * Two ways to be un-parseable, side by side.
  *
- *  - `sticker-slate` is an UNKNOWN KIND — no codec is registered for it.
+ *  - `sticker-slate` is an UNKNOWN KIND — no node type is registered for it.
  *  - `shot-broken` is a KNOWN kind whose data fails its own `parse` (empty
  *    slug, non-numeric seconds).
  *
@@ -1384,14 +1384,14 @@ function ReelToolbar() {
  * 4. Editing content.
  *
  * `edit-nodes` is the ONE door into a node's data that the user drives. The
- * codec's `applyEdit` decides, and its refusal comes back as a value — the
+ * node type's `applyEdit` decides, and its refusal comes back as a value — the
  * button below asks for a zero-second shot and prints the rejection instead of
  * throwing it.
  */
 export const EditingContent: Story = {
   render: () => (
     <Stage doc={heterogeneousDoc}>
-      <Lesson title="Edits go through the codec">
+      <Lesson title="Edits go through the node type">
         The engine never interprets a node data field. It hands the edit to that
         kind&apos;s applyEdit and stores whatever comes back — including
         &quot;no&quot;.
@@ -1408,7 +1408,7 @@ export const EditingContent: Story = {
       "Bridge, wide (v2)",
     );
 
-    // A refusal is a Result, not an exception, and it names the codec's code.
+    // A refusal is a Result, not an exception, and it names the node type's code.
     await userEvent.click(canvas.getByTestId("bad-edit"));
     await expect(canvas.getByTestId("edit-result")).toHaveTextContent(
       "edit-rejected",
@@ -1693,7 +1693,7 @@ export const Quarantine: Story = {
   render: () => (
     <Stage doc={quarantineDoc}>
       <Lesson title="Survive the data you do not understand">
-        Two failures here: a kind with no codec, and a known kind whose data is
+        Two failures here: a kind with no node type, and a known kind whose data is
         invalid. Neither kills the document. Rejecting instead is what once made
         a document unwritable forever — and since the trash bin is rewritten on
         every delete, that made deleting anything impossible.

--- a/packages/keel-react/src/types.ts
+++ b/packages/keel-react/src/types.ts
@@ -67,7 +67,7 @@ export type NodeView<
 
 /**
  * The fallback for forward-incompatible data. `QuarantinedNode` is not generic
- * (there is no codec, so there is no `Data`), so neither is this.
+ * (there is no node type, so there is no `Data`), so neither is this.
  *
  * Registering one is optional; without it a quarantined node renders nothing.
  * That is a deliberate default rather than a placeholder box: the engine


### PR DESCRIPTION
Vocabulary pass over keel-core and keel-react. **No behaviour change** — names, comments and message strings only.

## Why

"Codec" was the prose name for `NodeType`. It covered seven members while meaning two: `parse`/`serialize` is a genuine coder/decoder, but `applyEdit`, `invertEdit`, `contentKey`, `sourceKey` and `container` are not. A reader who knew the term was told one thing and handed another.

The replacement is the name the code already had — `NodeType`, `defineNodeType` — so prose and code are greppable together. "Consumer-defined" carries the fact "codec" was actually being used for: this is code the engine calls but did not write. That framing now sits on the `NodeType` doc itself instead of being re-glossed as "a codec is consumer code" 115 times.

`user-defined` was considered and rejected: all 32 uses of "user" in this package mean the person pressing Ctrl-Z, and the user-intent / not-user-intent split is the entire justification for `applyIngest`. "Consumer" is the established word for the integrating programmer (115 uses).

## Identifiers — verified by tsc, not grep

| before | after |
| --- | --- |
| `SummaryCodec<S>` | `SummaryType<S>` |
| `summaryCodec` | `summaryType` |
| `const codec = registry.get(…)` | `const nodeType = …` |
| `const type = registry.get(…)` (14 sites) | `const nodeType = …` |
| `resetCodecCounters` | `resetNodeTypeCounters` |

The `type` → `nodeType` rename is what licenses "node type" in the prose: `nodeType.applyEdit` cannot be misread as a TypeScript type the way `type.applyEdit` could, in files that are mostly type declarations.

## Messages name the method, not a noun

```
"clip".applyEdit threw: …
"clip".applyEdit refused the edit: …
"clip".serialize threw while re-encoding the edited value: …
Its serialize and its parse disagree — the value stored is the ORIGINAL parse
```

A consumer reading one of these knows which function to open.

## Notes

tsc caught four bad sites, which is the argument for doing this as an identifier rename rather than a sed: `registry.set(nodeType.kind, type)`, a destructured `for (const [kind, type] of ctx.registry)`, and two `type?.contentKey` chains. One genuine false positive was reverted by hand — a fuzz-test loop over *command* type strings, not node types — and all 17 renamed locals were audited afterward.

Also fixed the artifacts a mechanical pass leaves: a doubled "a node node type's parse", a "summary codec" that spanned a line break so the phrase rule could not see it, a redundant "the per-kind node type registry", and an escaped apostrophe inside a template literal.

## Verification

- `tsc --noEmit` clean: keel-core, keel-react, ui
- 632/632 tests pass (`vitest --project=unit packages/keel-core/`)
- `npm run lint` — 0 errors (11 pre-existing warnings in files not touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)