### PR TITLE
The type surface now tells the truth about what has been validated

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -42,6 +42,7 @@ import {
   makeDataChange,
   makeLeafNode,
   tryParseNodeId,
+  type ErasedNodeType,
 } from "./types";
 import {
   dataChangeLeavesDerivedIndexesIntact,
@@ -88,7 +89,7 @@ function ok<T>(value: T): Result<T, Rejection> {
  * id minted by engine A typechecks against engine B and only this runtime check
  * separates them. Every mutating door runs it first.
  */
-function foreignGraph<Ts extends readonly unknown[], S>(
+function foreignGraph<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   ctx: EngineContext<S>,
 ): Rejection | null {
@@ -109,7 +110,7 @@ function foreignGraph<Ts extends readonly unknown[], S>(
  * from inside a comparator. It is the same order `selection.selectRange` uses,
  * so a shift-click range and a multi-node drag agree about what "first" means.
  */
-function documentOrderRank<Ts extends readonly unknown[], S>(
+function documentOrderRank<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
 ): ReadonlyMap<NodeId, number> {
   const rank = new Map<NodeId, number>();
@@ -127,7 +128,7 @@ function documentOrderRank<Ts extends readonly unknown[], S>(
  * invariant violation `findInvariantViolation` reports; putting it somewhere
  * deterministic beats crashing the drag that discovered it.
  */
-function inDocumentOrder<Ts extends readonly unknown[], S>(
+function inDocumentOrder<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   ids: Iterable<NodeId>,
 ): readonly NodeId[] {
@@ -194,7 +195,7 @@ function inDocumentOrder<Ts extends readonly unknown[], S>(
  * a specific graph, and holding it beyond the command would be a stale index
  * one mutation later.
  */
-function childSlots<Ts extends readonly unknown[], S>(
+function childSlots<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   parentId: NodeId,
   cache: Map<NodeId, ReadonlyMap<NodeId, number>>,
@@ -220,7 +221,7 @@ function childSlots<Ts extends readonly unknown[], S>(
  * id instead of O(n^2), and `ancestorChain` needs no visiting set because the
  * `reference` children state makes the placement forest a genuine tree.
  */
-function pruneDescendants<Ts extends readonly unknown[], S>(
+function pruneDescendants<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   ids: ReadonlySet<NodeId>,
 ): readonly NodeId[] {
@@ -245,7 +246,7 @@ function pruneDescendants<Ts extends readonly unknown[], S>(
  * — so it is exempt from the single-owner rule. A quarantined node has no node type
  * and therefore no key at all.
  */
-function owningSourceKey<Ts extends readonly unknown[], S>(
+function owningSourceKey<Ts extends readonly ErasedNodeType[], S>(
   ctx: EngineContext<S>,
   node: GraphNode<Ts, S>,
 ): string | null {
@@ -286,7 +287,7 @@ type MovePlan = Readonly<{
  * and `resolveDrop` disagree about which coordinate system the caller handed
  * them, and agree about everything else.
  */
-function planMove<Ts extends readonly unknown[], S>(
+function planMove<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   nodeIds: readonly NodeId[],
   toParentId: NodeId,
@@ -450,7 +451,7 @@ function isNoOpMove(moves: readonly Move[]): boolean {
  * later is bounded by `loadChildrenInto`'s own check rather than pre-refused
  * here on a guess about what it might contain.
  */
-function tallestSubtree<Ts extends readonly unknown[], S>(
+function tallestSubtree<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): number {
@@ -463,7 +464,7 @@ function tallestSubtree<Ts extends readonly unknown[], S>(
   return tallest;
 }
 
-function applyMoveNodes<Ts extends readonly unknown[], S>(
+function applyMoveNodes<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   nodeIds: readonly NodeId[],
   toParentId: NodeId,
@@ -553,7 +554,7 @@ function mintFreshId<S>(
 
 /** One frame of the seed walk, plus the ancestor link that turns a cyclic seed
  *  into a rejection rather than a hang. */
-type SeedFrame<Ts extends readonly unknown[], S> = Readonly<{
+type SeedFrame<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   seed: Seed<Ts, S>;
   parentId: NodeId;
   index: number;
@@ -566,12 +567,12 @@ type SeedFrame<Ts extends readonly unknown[], S> = Readonly<{
  * inserting the same seed VALUE twice as two siblings is legitimate (two copies
  * of one thing), while a seed that appears inside itself is a cycle.
  */
-type SeedPath<Ts extends readonly unknown[], S> = Readonly<{
+type SeedPath<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   seed: Seed<Ts, S>;
   parent: SeedPath<Ts, S> | null;
 }>;
 
-function seedPathContains<Ts extends readonly unknown[], S>(
+function seedPathContains<Ts extends readonly ErasedNodeType[], S>(
   path: SeedPath<Ts, S> | null,
   seed: Seed<Ts, S>,
 ): boolean {
@@ -581,7 +582,7 @@ function seedPathContains<Ts extends readonly unknown[], S>(
   return false;
 }
 
-function applyInsertNodes<Ts extends readonly unknown[], S>(
+function applyInsertNodes<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   seeds: readonly Seed<Ts, S>[],
   toParentId: NodeId,
@@ -641,7 +642,7 @@ function applyInsertNodes<Ts extends readonly unknown[], S>(
   return ok({ graph: applyPatch(graph, patch, ctx), patch });
 }
 
-function checkInsertTarget<Ts extends readonly unknown[], S>(
+function checkInsertTarget<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   toParentId: NodeId,
 ): Result<void, Rejection> {
@@ -685,7 +686,7 @@ function checkInsertTarget<Ts extends readonly unknown[], S>(
  * lazy payload is being attached. Stated once here so the reducer and the
  * ingress door cannot drift about what "depth" counts.
  */
-function depthOf<Ts extends readonly unknown[], S>(
+function depthOf<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): number {
@@ -699,7 +700,7 @@ function depthOf<Ts extends readonly unknown[], S>(
  * package is: a seed's children are consumer-supplied and their nesting is not
  * this module's to trust.
  */
-function tallestSeed<Ts extends readonly unknown[], S>(
+function tallestSeed<Ts extends readonly ErasedNodeType[], S>(
   seeds: readonly Seed<Ts, S>[],
 ): number {
   let tallest = 0;
@@ -717,7 +718,7 @@ function tallestSeed<Ts extends readonly unknown[], S>(
   return tallest;
 }
 
-function buildSeedPlacements<Ts extends readonly unknown[], S>(
+function buildSeedPlacements<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   seeds: readonly Seed<Ts, S>[],
   toParentId: NodeId,
@@ -849,7 +850,7 @@ function buildSeedPlacements<Ts extends readonly unknown[], S>(
 // remove-nodes
 // ---------------------------------------------------------------------------
 
-function applyRemoveNodes<Ts extends readonly unknown[], S>(
+function applyRemoveNodes<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   nodeIds: readonly NodeId[],
   allowUnloaded: boolean,
@@ -956,7 +957,7 @@ type EditPlan<S> = Readonly<{
  * `applyIngest`. Same path, same rejections — the two doors differ only in what
  * they leave behind, never in what they accept.
  */
-function planEdits<Ts extends readonly unknown[], S>(
+function planEdits<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   edits: readonly EditOf<Ts>[],
   ctx: EngineContext<S>,
@@ -1215,7 +1216,7 @@ function planEdits<Ts extends readonly unknown[], S>(
   return ok(plans);
 }
 
-function applyEditNodes<Ts extends readonly unknown[], S>(
+function applyEditNodes<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   edits: readonly EditOf<Ts>[],
   ctx: EngineContext<S>,
@@ -1246,7 +1247,7 @@ function applyEditNodes<Ts extends readonly unknown[], S>(
  * post-commit veto corrupts redo, because the push has already cleared the redo
  * branch and the following undo pushes the refused command onto it.
  */
-export function applyCommand<Ts extends readonly unknown[], S>(
+export function applyCommand<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   command: Command<Ts, S>,
   ctx: EngineContext<S>,
@@ -1302,7 +1303,7 @@ export function applyCommand<Ts extends readonly unknown[], S>(
  * It runs the same validity checks as the command it produces, so an illegal
  * gesture is refused while it is still a gesture.
  */
-export function resolveDrop<Ts extends readonly unknown[], S>(
+export function resolveDrop<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   intent: DropIntent<Ts, S>,
   ctx: EngineContext<S>,
@@ -1375,7 +1376,7 @@ export function resolveDrop<Ts extends readonly unknown[], S>(
   });
 }
 
-function resolveInsertDrop<Ts extends readonly unknown[], S>(
+function resolveInsertDrop<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   seeds: readonly Seed<Ts, S>[],
   toParentId: NodeId,
@@ -1450,7 +1451,7 @@ function resolveInsertDrop<Ts extends readonly unknown[], S>(
  * O(historyLimit x changes) — bounded only when a consumer SET a
  * `historyLimit`, which is not the default. See `EngineConfig.historyLimit`.
  */
-export function applyIngestEdits<Ts extends readonly unknown[], S>(
+export function applyIngestEdits<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   history: History<Ts, S>,
   edits: readonly EditOf<Ts>[],

--- a/packages/keel-core/engine.test.ts
+++ b/packages/keel-core/engine.test.ts
@@ -298,6 +298,39 @@ describe("createEngine end to end", () => {
     expect(engine.serialize(again.value.graph)).toEqual(wire);
   });
 
+  // `Store.load` and `Engine.loadChildren` take `unknown`, not
+  // `SerializedDocument`. They used to take the latter while delegating to an
+  // implementation that took `unknown` and re-validated — so the public type
+  // vouched for an envelope nothing had checked, on the one door a payload
+  // reaches straight from IO.
+  //
+  // Every value below would have needed a cast to get past a `SerializedDocument`
+  // parameter, and every one is REFUSED as a value. That is the property the
+  // widening exists to make expressible: the signature no longer implies a check
+  // that only the body performs.
+  it.each([
+    ["null", null],
+    ["a string", "not a document"],
+    ["an array", [1, 2, 3]],
+    ["an object with no formatVersion", { nodes: [], rootIds: [] }],
+    ["a future formatVersion", { formatVersion: 99, nodes: [], rootIds: [] }],
+    ["nodes that are not an array", { formatVersion: 1, rootIds: [], nodes: "nope" }],
+  ])("refuses %s at the public load door rather than trusting it", (_label, payload) => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize(doc);
+    if (!loaded.ok) throw new Error("fixture failed to load");
+    const store = engine.createStore(loaded.value.graph);
+
+    const result = store.load(subId, payload);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("malformed-document");
+    // A refused load lands nothing: the graph is untouched and undoable state
+    // is unchanged.
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.canUndo()).toBe(false);
+  });
+
   it("loads a lazily-fetched subtree with no patch and no history entry", () => {
     const engine = makeEngine();
     const loaded = engine.deserialize(doc);

--- a/packages/keel-core/folds.ts
+++ b/packages/keel-core/folds.ts
@@ -36,6 +36,7 @@ import type {
   Graph,
   LeafNode,
   NodeId,
+  ErasedNodeType,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -139,7 +140,7 @@ export function summaryFrom<A>(folded: ExactFolded<A>): A {
  * Those three are why `ConsumerDefinedFold` is the primitive and this is the convenience.
  * Write `ConsumerDefinedFold` by hand when you need any of them.
  */
-export function foldMonoid<Ts extends readonly unknown[], S, A>(
+export function foldMonoid<Ts extends readonly ErasedNodeType[], S, A>(
   m: Readonly<{
     key: string;
     empty: A;
@@ -450,7 +451,7 @@ function readCachedFold<A>(
  * make `placeholder` mean two different things at once and leave neither
  * recoverable from the flag.
  */
-function isPlaceholderNode<Ts extends readonly unknown[], S>(
+function isPlaceholderNode<Ts extends readonly ErasedNodeType[], S>(
   node: GraphNode<Ts, S>,
 ): boolean {
   // Discriminate on `quarantined` FIRST: `container` is plain `boolean` on the
@@ -486,7 +487,7 @@ function isPlaceholderNode<Ts extends readonly unknown[], S>(
  * Pass `cache` to memoize; results are keyed by `(fold.key, id, subtreeRev)`,
  * so passing a cache can never change the answer, only the work.
  */
-export function computeFold<Ts extends readonly unknown[], S, A>(
+export function computeFold<Ts extends readonly ErasedNodeType[], S, A>(
   graph: Graph<Ts, S>,
   fold: ConsumerDefinedFold<Ts, S, A>,
   nodeId: NodeId,

--- a/packages/keel-core/graph.ts
+++ b/packages/keel-core/graph.ts
@@ -85,7 +85,7 @@ export function buildRegistry(types: readonly ErasedNodeType[]): NodeTypeRegistr
 // Construction
 // ---------------------------------------------------------------------------
 
-export function emptyGraph<Ts extends readonly unknown[], S>(
+export function emptyGraph<Ts extends readonly ErasedNodeType[], S>(
   engineId: symbol,
 ): Graph<Ts, S> {
   return {
@@ -118,7 +118,7 @@ export function emptyGraph<Ts extends readonly unknown[], S>(
  * `subtreeRevs` carries revisions forward when a graph is rebuilt around
  * existing nodes; a node with no carried revision starts at 0.
  */
-export function buildGraph<Ts extends readonly unknown[], S>(
+export function buildGraph<Ts extends readonly ErasedNodeType[], S>(
   args: Readonly<{
     engineId: symbol;
     nodesById: ReadonlyMap<NodeId, GraphNode<Ts, S>>;
@@ -167,7 +167,7 @@ export function buildGraph<Ts extends readonly unknown[], S>(
 // Queries — all TOTAL, none throw
 // ---------------------------------------------------------------------------
 
-export function getNode<Ts extends readonly unknown[], S>(
+export function getNode<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): GraphNode<Ts, S> | undefined {
@@ -183,7 +183,7 @@ export function getNode<Ts extends readonly unknown[], S>(
  * in its own source, and every downstream uncertainty flag it grew is scar
  * tissue from that one missing bit. Use `childrenStateOf`.
  */
-export function getChildren<Ts extends readonly unknown[], S>(
+export function getChildren<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): readonly NodeId[] {
@@ -200,13 +200,13 @@ export function getChildren<Ts extends readonly unknown[], S>(
  * counted — `deadRevById` is a separate store, and "how big is this document"
  * has never meant "plus everything ever deleted from it".
  */
-export function nodeCount<Ts extends readonly unknown[], S>(
+export function nodeCount<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
 ): number {
   return graph.nodesById.size;
 }
 
-export function getParent<Ts extends readonly unknown[], S>(
+export function getParent<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): NodeId | null {
@@ -215,7 +215,7 @@ export function getParent<Ts extends readonly unknown[], S>(
 
 /** 0 for an unknown node, so a subscriber comparing revisions across a removal
  *  sees a change rather than an exception. */
-export function getSubtreeRev<Ts extends readonly unknown[], S>(
+export function getSubtreeRev<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): number {
@@ -230,7 +230,7 @@ export function getSubtreeRev<Ts extends readonly unknown[], S>(
 /** `null` for a leaf, an unknown node, or a QUARANTINED leaf — the three cases
  *  where "what is this subtree's load state" has no answer, because there is no
  *  subtree. */
-export function childrenStateOf<Ts extends readonly unknown[], S>(
+export function childrenStateOf<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): ChildrenState | null {
@@ -255,13 +255,13 @@ export function childrenStateOf<Ts extends readonly unknown[], S>(
  * sound in both branches, and it reads as "may own children", which is what
  * every call site actually wants to know.
  */
-export function isCollection<Ts extends readonly unknown[], S>(
+export function isCollection<Ts extends readonly ErasedNodeType[], S>(
   node: GraphNode<Ts, S>,
 ): node is CollectionNode<Ts, S> | QuarantinedNode {
   return node.quarantined || node.container;
 }
 
-export function isLoaded<Ts extends readonly unknown[], S>(
+export function isLoaded<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): boolean {
@@ -294,7 +294,7 @@ export function ownsSubtree(state: ChildrenState): boolean {
  * instead of hanging a render loop. `findInvariantViolation` is what names the
  * corruption.
  */
-export function ancestorChain<Ts extends readonly unknown[], S>(
+export function ancestorChain<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): readonly NodeId[] {
@@ -319,7 +319,7 @@ export function ancestorChain<Ts extends readonly unknown[], S>(
  * lookup here would only make an unknown id answer "no relation", which is the
  * more dangerous answer for a cycle test to give.
  */
-export function isSameOrAncestor<Ts extends readonly unknown[], S>(
+export function isSameOrAncestor<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   maybeAncestorId: NodeId,
   id: NodeId,
@@ -348,7 +348,7 @@ export function isSameOrAncestor<Ts extends readonly unknown[], S>(
  * once, so the walk length is exactly the number of reachable nodes. It bounds
  * the damage when the graph is not valid.
  */
-function walkPreOrder<Ts extends readonly unknown[], S>(
+function walkPreOrder<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   roots: readonly NodeId[],
 ): NodeId[] {
@@ -376,7 +376,7 @@ function walkPreOrder<Ts extends readonly unknown[], S>(
 
 /** Pre-order, INCLUDES `id`. `[]` for an unknown node — an id the graph does
  *  not hold has no subtree, not a one-element one. */
-export function subtreeIds<Ts extends readonly unknown[], S>(
+export function subtreeIds<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
 ): readonly NodeId[] {
@@ -387,7 +387,7 @@ export function subtreeIds<Ts extends readonly unknown[], S>(
 /** Pre-order across every root, in `rootIds` order. Backs `selectRange`, which
  *  is inclusive in DOCUMENT order — the reason selection is engine-owned rather
  *  than a consumer concern. */
-export function documentOrder<Ts extends readonly unknown[], S>(
+export function documentOrder<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
 ): readonly NodeId[] {
   return walkPreOrder(graph, graph.rootIds);
@@ -409,7 +409,7 @@ export function documentOrder<Ts extends readonly unknown[], S>(
 // claiming one stored subtree, which is the condition the predecessor's server
 // had to answer with a 409 because nothing upstream enforced it.
 
-export function contentKeyOf<Ts extends readonly unknown[], S>(
+export function contentKeyOf<Ts extends readonly ErasedNodeType[], S>(
   registry: NodeTypeRegistry,
   node: GraphNode<Ts, S>,
 ): string | null {
@@ -419,7 +419,7 @@ export function contentKeyOf<Ts extends readonly unknown[], S>(
   return nodeType.contentKey(node.data);
 }
 
-export function sourceKeyOf<Ts extends readonly unknown[], S>(
+export function sourceKeyOf<Ts extends readonly ErasedNodeType[], S>(
   registry: NodeTypeRegistry,
   node: GraphNode<Ts, S>,
 ): string | null {
@@ -479,7 +479,7 @@ export function sourceKeyOfKindData(
  * for it. Stated here as well so the predicate is total on its own terms rather
  * than relying on a caller having checked first.
  */
-export function ownsItsSubtree<Ts extends readonly unknown[], S>(
+export function ownsItsSubtree<Ts extends readonly ErasedNodeType[], S>(
   node: GraphNode<Ts, S>,
 ): boolean {
   if (node.quarantined) return false;
@@ -509,7 +509,7 @@ export function ownsItsSubtree<Ts extends readonly unknown[], S>(
  * stray revision entry for an id that no longer exists is inert by comparison —
  * nothing reads a revision for a node it cannot find.
  */
-export function bumpSubtreeRevs<Ts extends readonly unknown[], S>(
+export function bumpSubtreeRevs<Ts extends readonly ErasedNodeType[], S>(
   revs: ReadonlyMap<NodeId, number>,
   graph: Graph<Ts, S>,
   fromIds: readonly NodeId[],
@@ -544,7 +544,7 @@ export function bumpSubtreeRevs<Ts extends readonly unknown[], S>(
  * redundant. Breaking at the first already-bumped id makes the cost proportional
  * to the NEW part of each chain.
  */
-export function bumpSubtreeRevsInto<Ts extends readonly unknown[], S>(
+export function bumpSubtreeRevsInto<Ts extends readonly ErasedNodeType[], S>(
   revs: Map<NodeId, number>,
   graph: Graph<Ts, S>,
   fromIds: readonly NodeId[],
@@ -577,7 +577,7 @@ export function bumpSubtreeRevsInto<Ts extends readonly unknown[], S>(
 }
 
 /** The derived pair, as `applyPatch` splices it onto a graph. */
-export type DerivedIndexes<Ts extends readonly unknown[], S> = Pick<
+export type DerivedIndexes<Ts extends readonly ErasedNodeType[], S> = Pick<
   Graph<Ts, S>,
   "placementsByContentKey" | "ownerBySourceKey"
 >;
@@ -618,7 +618,7 @@ export function derivedIndexNeed(registry: NodeTypeRegistry): DerivedIndexNeed {
  * invalid one, indexing an orphan would give a detached subtree a vote on
  * ownership.
  */
-function walkDerivedIndexes<Ts extends readonly unknown[], S>(
+function walkDerivedIndexes<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   registry: NodeTypeRegistry,
   want: DerivedIndexNeed,
@@ -679,7 +679,7 @@ function walkDerivedIndexes<Ts extends readonly unknown[], S>(
  * placement. So the rule is: update only where the patch's own shape PROVES what
  * cannot have moved, and rebuild otherwise.
  */
-export function rebuildDerivedIndexes<Ts extends readonly unknown[], S>(
+export function rebuildDerivedIndexes<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   registry: NodeTypeRegistry,
 ): DerivedIndexes<Ts, S> {
@@ -706,7 +706,7 @@ export function rebuildDerivedIndexes<Ts extends readonly unknown[], S>(
  * `placementsByContentKey` gets no such reprieve: its values are in DOCUMENT
  * order, so a pure reorder moves it even though no data did.
  */
-export function rebuildPlacementIndex<Ts extends readonly unknown[], S>(
+export function rebuildPlacementIndex<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   registry: NodeTypeRegistry,
 ): ReadonlyMap<string, readonly NodeId[]> {
@@ -737,7 +737,7 @@ export function rebuildPlacementIndex<Ts extends readonly unknown[], S>(
  * — nothing here is a rejection the engine reports; it is an optimisation
  * declining to apply.
  */
-export function reindexPlacementsWithinSubtree<Ts extends readonly unknown[], S>(
+export function reindexPlacementsWithinSubtree<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   registry: NodeTypeRegistry,
   previous: ReadonlyMap<string, readonly NodeId[]>,
@@ -823,7 +823,7 @@ export function reindexPlacementsWithinSubtree<Ts extends readonly unknown[], S>
  * costs the same order as the rebuild it replaces. It is never worse than the
  * rebuild, and for every realistic bucket it is not close.
  */
-export function documentOrderComparator<Ts extends readonly unknown[], S>(
+export function documentOrderComparator<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
 ): (a: NodeId, b: NodeId) => number | null {
   const pathCache = new Map<NodeId, readonly NodeId[]>();
@@ -916,7 +916,7 @@ export function documentOrderComparator<Ts extends readonly unknown[], S>(
  * `reindexPlacementsWithinSubtree`: if `previous` disagrees with the graph it
  * was supposedly built from, this refuses to guess and the caller rebuilds.
  */
-export function reindexPlacementsAcrossMove<Ts extends readonly unknown[], S>(
+export function reindexPlacementsAcrossMove<Ts extends readonly ErasedNodeType[], S>(
   post: Graph<Ts, S>,
   registry: NodeTypeRegistry,
   previous: ReadonlyMap<string, readonly NodeId[]>,
@@ -1052,7 +1052,7 @@ export function reindexPlacementsAcrossMove<Ts extends readonly unknown[], S>(
  * cannot rank two ids, or an arriving id already sitting in the bucket, which
  * would mean this was not an insert of new nodes.
  */
-export function placementsAfterInsert<Ts extends readonly unknown[], S>(
+export function placementsAfterInsert<Ts extends readonly ErasedNodeType[], S>(
   post: Graph<Ts, S>,
   registry: NodeTypeRegistry,
   previous: ReadonlyMap<string, readonly NodeId[]>,
@@ -1149,7 +1149,7 @@ export function placementsAfterInsert<Ts extends readonly unknown[], S>(
  * rebuild, the audit already names the real defect rather than a stale-index
  * symptom of it.
  */
-export function ownersAfterInsert<Ts extends readonly unknown[], S>(
+export function ownersAfterInsert<Ts extends readonly ErasedNodeType[], S>(
   registry: NodeTypeRegistry,
   previous: ReadonlyMap<string, NodeId>,
   arrived: readonly GraphNode<Ts, S>[],
@@ -1183,7 +1183,7 @@ export function ownersAfterInsert<Ts extends readonly unknown[], S>(
  * `contentKey` — is no longer what the graph holds. Deleting under the recorded
  * key would leave the real bucket holding a dead id.
  */
-export function derivedIndexesAfterRemoval<Ts extends readonly unknown[], S>(
+export function derivedIndexesAfterRemoval<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   registry: NodeTypeRegistry,
   removedIds: readonly NodeId[],
@@ -1250,7 +1250,7 @@ export function derivedIndexesAfterRemoval<Ts extends readonly unknown[], S>(
  * no key at all (a new folder, in a registry where only clips carry keys) leaves
  * both maps exactly as they were, and both can be handed on by reference.
  */
-export function insertLeavesDerivedIndexesIntact<Ts extends readonly unknown[], S>(
+export function insertLeavesDerivedIndexesIntact<Ts extends readonly ErasedNodeType[], S>(
   registry: NodeTypeRegistry,
   nodes: readonly GraphNode<Ts, S>[],
 ): boolean {
@@ -1316,7 +1316,7 @@ export function dataChangeLeavesDerivedIndexesIntact(
  * performed the IO and already knows. It DOES bump `subtreeRev` along the
  * chain, because every ancestor's rollup just changed meaning.
  */
-export function markMissing<Ts extends readonly unknown[], S>(
+export function markMissing<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
   reason: string,
@@ -1382,7 +1382,7 @@ export function markMissing<Ts extends readonly unknown[], S>(
  * by the reachability walk's re-visit guard, which in a graph that passed 2 and
  * 4 is unreachable, and which exists to TERMINATE rather than to detect.
  */
-export function findInvariantViolation<Ts extends readonly unknown[], S>(
+export function findInvariantViolation<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   registry: NodeTypeRegistry,
 ): Violation | null {
@@ -1615,7 +1615,7 @@ export function findInvariantViolation<Ts extends readonly unknown[], S>(
 }
 
 /** Split out only so `findInvariantViolation` stays readable; it is check 9. */
-function findStaleDerivedIndex<Ts extends readonly unknown[], S>(
+function findStaleDerivedIndex<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   fresh: Pick<Graph<Ts, S>, "placementsByContentKey" | "ownerBySourceKey">,
 ): Violation | null {

--- a/packages/keel-core/history.ts
+++ b/packages/keel-core/history.ts
@@ -39,6 +39,7 @@ import type {
   HistoryEntry,
   NodeId,
   Patch,
+  ErasedNodeType,
 } from "./types";
 import { makeDataChange } from "./types";
 import { scrubPatchForIngest } from "./patches";
@@ -62,7 +63,7 @@ function effectiveLimit(limit: number | undefined): number {
   return Number.isInteger(limit) && limit > 0 ? limit : Number.POSITIVE_INFINITY;
 }
 
-export function createHistory<Ts extends readonly unknown[], S>(
+export function createHistory<Ts extends readonly ErasedNodeType[], S>(
   limit?: number,
 ): History<Ts, S> {
   return { past: [], future: [], limit: effectiveLimit(limit) };
@@ -70,7 +71,7 @@ export function createHistory<Ts extends readonly unknown[], S>(
 
 /** Drops the OLDEST entries — `past` is oldest-first, and the entry a user is
  *  most likely to want back is the newest. */
-function trimPast<Ts extends readonly unknown[], S>(
+function trimPast<Ts extends readonly ErasedNodeType[], S>(
   past: readonly HistoryEntry<Ts, S>[],
   limit: number,
 ): readonly HistoryEntry<Ts, S>[] {
@@ -97,7 +98,7 @@ function trimPast<Ts extends readonly unknown[], S>(
  * `undefined === undefined` counted as a match, every consecutive edit in the
  * whole application would silently collapse into a single undo step.
  */
-export function pushHistory<Ts extends readonly unknown[], S>(
+export function pushHistory<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
   entry: HistoryEntry<Ts, S>,
 ): History<Ts, S> {
@@ -123,13 +124,13 @@ export function pushHistory<Ts extends readonly unknown[], S>(
 // Peek / commit — deliberately separate, see the header
 // ---------------------------------------------------------------------------
 
-export function peekUndo<Ts extends readonly unknown[], S>(
+export function peekUndo<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): HistoryEntry<Ts, S> | null {
   return history.past.at(-1) ?? null;
 }
 
-export function peekRedo<Ts extends readonly unknown[], S>(
+export function peekRedo<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): HistoryEntry<Ts, S> | null {
   return history.future.at(-1) ?? null;
@@ -143,7 +144,7 @@ export function peekRedo<Ts extends readonly unknown[], S>(
  * Returns `null` rather than an empty-ish value when there is nothing to undo,
  * so a caller cannot accidentally apply an undefined patch.
  */
-export function commitUndo<Ts extends readonly unknown[], S>(
+export function commitUndo<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): Readonly<{ history: History<Ts, S>; entry: HistoryEntry<Ts, S> }> | null {
   const entry = history.past.at(-1);
@@ -164,7 +165,7 @@ export function commitUndo<Ts extends readonly unknown[], S>(
  * re-merging a redone entry into the one below it would destroy an undo step
  * that the user has already seen as separate.
  */
-export function commitRedo<Ts extends readonly unknown[], S>(
+export function commitRedo<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): Readonly<{ history: History<Ts, S>; entry: HistoryEntry<Ts, S> }> | null {
   const entry = history.future.at(-1);
@@ -179,13 +180,13 @@ export function commitRedo<Ts extends readonly unknown[], S>(
   };
 }
 
-export function canUndo<Ts extends readonly unknown[], S>(
+export function canUndo<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): boolean {
   return history.past.length > 0;
 }
 
-export function canRedo<Ts extends readonly unknown[], S>(
+export function canRedo<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): boolean {
   return history.future.length > 0;
@@ -195,7 +196,7 @@ export function canRedo<Ts extends readonly unknown[], S>(
 // Clearing
 // ---------------------------------------------------------------------------
 
-export function clearFuture<Ts extends readonly unknown[], S>(
+export function clearFuture<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): History<Ts, S> {
   if (history.future.length === 0) return history;
@@ -207,14 +208,14 @@ export function clearFuture<Ts extends readonly unknown[], S>(
  * order, so one inapplicable entry makes everything beneath it unreachable too —
  * there is no way to skip past a broken entry and keep undoing.
  */
-export function clearPast<Ts extends readonly unknown[], S>(
+export function clearPast<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): History<Ts, S> {
   if (history.past.length === 0) return history;
   return { past: [], future: history.future, limit: history.limit };
 }
 
-export function clearHistory<Ts extends readonly unknown[], S>(
+export function clearHistory<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
 ): History<Ts, S> {
   if (history.past.length === 0 && history.future.length === 0) return history;
@@ -249,7 +250,7 @@ export function clearHistory<Ts extends readonly unknown[], S>(
  * caller that reuses one key across unrelated edits gets a merged entry that
  * skips an intermediate value, which is exactly what coalescing is for.
  */
-export function coalesceEntries<Ts extends readonly unknown[], S>(
+export function coalesceEntries<Ts extends readonly ErasedNodeType[], S>(
   previous: HistoryEntry<Ts, S>,
   next: HistoryEntry<Ts, S>,
 ): HistoryEntry<Ts, S> | null {
@@ -316,7 +317,7 @@ export function coalesceEntries<Ts extends readonly unknown[], S>(
  * consumer SET one — it defaults to unbounded, so by default the bound named
  * here is the one that does not exist.
  */
-export function scrubHistoryForIngest<Ts extends readonly unknown[], S>(
+export function scrubHistoryForIngest<Ts extends readonly ErasedNodeType[], S>(
   history: History<Ts, S>,
   replacements: ReadonlyMap<NodeId, unknown>,
 ): History<Ts, S> {
@@ -330,7 +331,7 @@ export function scrubHistoryForIngest<Ts extends readonly unknown[], S>(
   return { past, future, limit: history.limit };
 }
 
-function scrubStack<Ts extends readonly unknown[], S>(
+function scrubStack<Ts extends readonly ErasedNodeType[], S>(
   stack: readonly HistoryEntry<Ts, S>[],
   replacements: ReadonlyMap<NodeId, unknown>,
 ): readonly HistoryEntry<Ts, S>[] {

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -44,6 +44,7 @@ import {
   type DataChange,
   type EngineContext,
   type Graph,
+  type ErasedNodeType,
   type Move,
   type NodeId,
   type NodeTypeRegistry,
@@ -98,7 +99,7 @@ function replayError(
  * (it comes off the wire), so it is not disjoint from the `true` / `false`
  * literals on the other two and cannot discriminate on its own.
  */
-function containerChildrenState<Ts extends readonly unknown[], S>(
+function containerChildrenState<Ts extends readonly ErasedNodeType[], S>(
   node: GraphNode<Ts, S>,
 ): ChildrenState | null {
   if (node.quarantined) return node.children;
@@ -108,7 +109,7 @@ function containerChildrenState<Ts extends readonly unknown[], S>(
 
 /** `true` when this node owns a `childrenById` entry — i.e. it is a `loaded`
  *  container. Exactly one state has an entry; the other three have none. */
-function isLoadedContainer<Ts extends readonly unknown[], S>(
+function isLoadedContainer<Ts extends readonly ErasedNodeType[], S>(
   node: GraphNode<Ts, S>,
 ): boolean {
   const state = containerChildrenState(node);
@@ -185,7 +186,7 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
  * exactly. `applyCommand` emits moves in document order, which is that
  * ascending order, so the same forward walk serves both directions.
  */
-export function invertPatch<Ts extends readonly unknown[], S>(
+export function invertPatch<Ts extends readonly ErasedNodeType[], S>(
   patch: Patch<Ts, S>,
 ): Patch<Ts, S> {
   switch (patch.type) {
@@ -228,7 +229,7 @@ export function invertPatch<Ts extends readonly unknown[], S>(
  * validates anyway", which is exactly how the dormant-patch corruptions
  * happened.
  */
-export function applyPatch<Ts extends readonly unknown[], S>(
+export function applyPatch<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   patch: Patch<Ts, S>,
   ctx: EngineContext<S>,
@@ -373,7 +374,7 @@ function soleReorderParent(moves: readonly Move[]): NodeId | null {
   return parentId;
 }
 
-function placementsAfterMove<Ts extends readonly unknown[], S>(
+function placementsAfterMove<Ts extends readonly ErasedNodeType[], S>(
   post: Graph<Ts, S>,
   registry: NodeTypeRegistry,
   previous: ReadonlyMap<string, readonly NodeId[]>,
@@ -427,7 +428,7 @@ function placementsAfterMove<Ts extends readonly unknown[], S>(
   return rebuildPlacementIndex(post, registry);
 }
 
-function applyMoved<Ts extends readonly unknown[], S>(
+function applyMoved<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   moves: readonly Move[],
   ctx: EngineContext<S>,
@@ -519,7 +520,7 @@ function applyMoved<Ts extends readonly unknown[], S>(
   };
 }
 
-function applyInserted<Ts extends readonly unknown[], S>(
+function applyInserted<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   placements: readonly Placement<Ts, S>[],
   ctx: EngineContext<S>,
@@ -625,7 +626,7 @@ function applyInserted<Ts extends readonly unknown[], S>(
   return { ...grown, ...derived };
 }
 
-function applyRemoved<Ts extends readonly unknown[], S>(
+function applyRemoved<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   placements: readonly Placement<Ts, S>[],
   ctx: EngineContext<S>,
@@ -741,7 +742,7 @@ function applyRemoved<Ts extends readonly unknown[], S>(
   };
 }
 
-function applyDataChanged<Ts extends readonly unknown[], S>(
+function applyDataChanged<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   changes: readonly DataChange<Ts>[],
   ctx: EngineContext<S>,
@@ -816,7 +817,7 @@ function applyDataChanged<Ts extends readonly unknown[], S>(
  * same patch creates two entries earlier. The removal side needs the same
  * overlay to answer "is this node empty yet".
  */
-function createChildrenOverlay<Ts extends readonly unknown[], S>(
+function createChildrenOverlay<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
 ) {
   const overlay = new Map<NodeId, readonly NodeId[]>();
@@ -861,7 +862,7 @@ function createChildrenOverlay<Ts extends readonly unknown[], S>(
  * naming the recorded node; kind agreement; `before` still matching on the
  * SERIALIZED form; and that a node about to be un-inserted is childless.
  */
-export function verifyPatchApplies<Ts extends readonly unknown[], S>(
+export function verifyPatchApplies<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   patch: Patch<Ts, S>,
   ctx: EngineContext<S>,
@@ -884,7 +885,7 @@ export function verifyPatchApplies<Ts extends readonly unknown[], S>(
   }
 }
 
-function verifyMoved<Ts extends readonly unknown[], S>(
+function verifyMoved<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   moves: readonly Move[],
 ): Result<void, ReplayRejection> {
@@ -948,7 +949,7 @@ function verifyMoved<Ts extends readonly unknown[], S>(
   return VERIFY_OK;
 }
 
-function requireLoadedParent<Ts extends readonly unknown[], S>(
+function requireLoadedParent<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   parentId: NodeId,
 ): Result<void, ReplayRejection> {
@@ -997,7 +998,7 @@ function requireLoadedParent<Ts extends readonly unknown[], S>(
  * A hand-built patch could still reach it, and would be refused rather than
  * applied. A refusal on an exotic hand-built patch is the safe direction.
  */
-function ownershipConflict<Ts extends readonly unknown[], S>(
+function ownershipConflict<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   claims: ReadonlyMap<NodeId, string | null>,
 ): ReplayRejection | null {
@@ -1037,7 +1038,7 @@ function ownershipConflict<Ts extends readonly unknown[], S>(
   return null;
 }
 
-function verifyInserted<Ts extends readonly unknown[], S>(
+function verifyInserted<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   placements: readonly Placement<Ts, S>[],
   ctx: EngineContext<S>,
@@ -1104,7 +1105,7 @@ function verifyInserted<Ts extends readonly unknown[], S>(
   return VERIFY_OK;
 }
 
-function verifyRemoved<Ts extends readonly unknown[], S>(
+function verifyRemoved<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   placements: readonly Placement<Ts, S>[],
 ): Result<void, ReplayRejection> {
@@ -1182,7 +1183,7 @@ function verifyRemoved<Ts extends readonly unknown[], S>(
   return VERIFY_OK;
 }
 
-function verifyDataChanged<Ts extends readonly unknown[], S>(
+function verifyDataChanged<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   changes: readonly DataChange<Ts>[],
   ctx: EngineContext<S>,
@@ -1313,7 +1314,7 @@ function verifyDataChanged<Ts extends readonly unknown[], S>(
  *  included: a move's endpoints and a placement's parent are nodes whose
  *  rollups changed, and a caller notifying only the named nodes reproduces the
  *  "deep move never re-renders any ancestor" hole. */
-export function patchTouchedNodeIds<Ts extends readonly unknown[], S>(
+export function patchTouchedNodeIds<Ts extends readonly ErasedNodeType[], S>(
   patch: Patch<Ts, S>,
 ): readonly NodeId[] {
   const seen = new Set<NodeId>();
@@ -1356,7 +1357,7 @@ export function patchTouchedNodeIds<Ts extends readonly unknown[], S>(
  * either is wrong — the only id in this list that names storage worth deleting
  * is an `unloaded` owner. Read the node's state before acting on the id.
  */
-export function patchDetachedSubtrees<Ts extends readonly unknown[], S>(
+export function patchDetachedSubtrees<Ts extends readonly ErasedNodeType[], S>(
   patch: Patch<Ts, S>,
 ): readonly NodeId[] {
   if (patch.type !== "removed") return EMPTY_IDS;
@@ -1370,7 +1371,7 @@ export function patchDetachedSubtrees<Ts extends readonly unknown[], S>(
   return detached;
 }
 
-export function isEmptyPatch<Ts extends readonly unknown[], S>(
+export function isEmptyPatch<Ts extends readonly ErasedNodeType[], S>(
   patch: Patch<Ts, S>,
 ): boolean {
   switch (patch.type) {
@@ -1412,7 +1413,7 @@ export function isEmptyPatch<Ts extends readonly unknown[], S>(
  *
  * Returns null when the patch is left empty, and the caller drops the entry.
  */
-export function scrubPatchForIngest<Ts extends readonly unknown[], S>(
+export function scrubPatchForIngest<Ts extends readonly ErasedNodeType[], S>(
   patch: Patch<Ts, S>,
   replacements: ReadonlyMap<NodeId, unknown>,
 ): Patch<Ts, S> | null {

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -58,6 +58,7 @@ import {
   type SerializedDocument,
   type SerializedNode,
   type StructuralError,
+  type ErasedNodeType,
 } from "./types";
 
 import {
@@ -639,7 +640,7 @@ function runMigrations(
  * this document's own roots to `null`; `loadChildrenInto` re-points them at
  * the target it is filling.
  */
-type BuiltDocument<Ts extends readonly unknown[], S> = Readonly<{
+type BuiltDocument<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   /** Pre-order, parents first. Also the order the report is written in. */
   order: readonly NodeId[];
   rootIds: readonly NodeId[];
@@ -659,7 +660,7 @@ type BuiltDocument<Ts extends readonly unknown[], S> = Readonly<{
  * sub-document's `rootIds` name the nodes that BECOME some target's children,
  * and a child may perfectly well be a leaf.
  */
-function buildDocument<Ts extends readonly unknown[], S>(
+function buildDocument<Ts extends readonly ErasedNodeType[], S>(
   raw: unknown,
   ctx: EngineContext<S>,
   options: Readonly<{
@@ -1180,7 +1181,7 @@ function buildDocument<Ts extends readonly unknown[], S>(
  * `sourceKeyOf` returns `null` for them, since the key comes from a node type that
  * by definition did not run.
  */
-function findDuplicateOwner<Ts extends readonly unknown[], S>(
+function findDuplicateOwner<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   registry: NodeTypeRegistry,
 ): StructuralError | null {
@@ -1214,7 +1215,7 @@ function findDuplicateOwner<Ts extends readonly unknown[], S>(
  * `StructuralError`; per-node content failures quarantine by default, keeping
  * id, position, children and byte-exact `raw`.
  */
-export function deserializeDocument<Ts extends readonly unknown[], S>(
+export function deserializeDocument<Ts extends readonly ErasedNodeType[], S>(
   raw: unknown,
   ctx: EngineContext<S>,
 ): Result<
@@ -1273,7 +1274,7 @@ export function deserializeDocument<Ts extends readonly unknown[], S>(
  * estimate compounds it on every save, which is how empty collections came to
  * store a duration that was never a measurement.
  */
-export function serializeGraph<Ts extends readonly unknown[], S>(
+export function serializeGraph<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   ctx: EngineContext<S>,
 ): SerializedDocument {
@@ -1444,7 +1445,7 @@ function loadRejection(error: LoadRejection): Result<never, LoadRejection> {
  * what makes `verifyPatchApplies` cheap and dormant history sound: a node that
  * existed when a patch was recorded still exists when it replays.
  */
-export function loadChildrenInto<Ts extends readonly unknown[], S>(
+export function loadChildrenInto<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
   doc: unknown,
@@ -1613,7 +1614,7 @@ export function loadChildrenInto<Ts extends readonly unknown[], S>(
  * that `makeQuarantinedNode` adds itself, and the boundary constructors are
  * the only sanctioned way to mint a node.
  */
-function withLoadedChildren<Ts extends readonly unknown[], S>(
+function withLoadedChildren<Ts extends readonly ErasedNodeType[], S>(
   node: GraphNode<Ts, S>,
   id: NodeId,
 ): GraphNode<Ts, S> {

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -1433,10 +1433,14 @@ function loadRejection(error: LoadRejection): Result<never, LoadRejection> {
  * which meant a subtree loaded on demand was parsed by rules its own document
  * had already outgrown.
  *
- * `doc` is `unknown` because it came from IO. The Engine method's
- * `SerializedDocument` parameter is the consumer's assertion, not a guarantee,
- * and re-validating here is the difference between a typed claim and a checked
- * one.
+ * `doc` is `unknown` because it came from IO, and re-validating here is the
+ * difference between a typed claim and a checked one.
+ *
+ * `Engine.loadChildren` and `Store.load` now say `unknown` too. They used to
+ * say `SerializedDocument` while delegating to this — so the public types
+ * vouched for an envelope nothing had checked, and this comment existed to
+ * apologise for the gap rather than to describe the code. Both doors now agree
+ * with `deserialize`, which has always been honest about taking `unknown`.
  *
  * Produces NO patch, NO history entry, NO change-feed event; bumps
  * `subtreeRev` along the target's chain so ancestor rollups re-render.

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -232,13 +232,45 @@ export type ConsumerDefinedSummaryType<S> = Readonly<{
   serialize(summary: S): unknown;
 }>;
 
+// ---------------------------------------------------------------------------
+// `Ts extends readonly ErasedNodeType[]` — the constraint every generic below
+// carries, and why it is spelled this way
+// ---------------------------------------------------------------------------
+//
+// `Ts` is the consumer's TUPLE of node types, exactly as passed to
+// `createEngine({ types })`. It is the compile-time half of the two-sided
+// correspondence described on `ErasedNodeType`: the tuple remembers that
+// `"clip"` means `Data = Clip`, while the runtime registry has erased that.
+//
+// THIS USED TO READ `Ts extends readonly unknown[]`, which is not a weaker
+// constraint but NO constraint — everything extends `unknown`. Two costs:
+//
+//   1. It read as a claim about TRUST. In value positions `unknown` is this
+//      package's untrusted marker (`data: unknown`, `raw: unknown`, every
+//      ingress door), so `readonly unknown[]` invited the reading "a tuple of
+//      untrusted things" about the single most trusted input there is.
+//   2. It let nonsense through SILENTLY. `Graph<readonly [string, number], S>`
+//      and `Command<readonly ["a","b"], S>` both compiled: the mapped types
+//      below filter with `Ts[I] extends ConsumerDefinedNodeType<...> ? ... :
+//      never`, so a garbage element collapsed to `never` and vanished instead
+//      of erroring at the instantiation site.
+//
+// Tightening it was verified rather than assumed — 139 sites, and every failure
+// was a missing import. Not one assignability error, which is the evidence that
+// the loose form was never load-bearing.
+//
+// The tuple satisfies this constraint at all only because of the
+// method-shorthand rule on `ConsumerDefinedNodeType`: bivariance is what lets a
+// concrete `ConsumerDefinedNodeType<"clip", Clip, ClipEdit>` be assignable to
+// the erased element type.
+
 /** Every kind literal in the registry: `"clip" | "folder" | ...`. */
-export type KindOf<Ts extends readonly unknown[]> = {
+export type KindOf<Ts extends readonly ErasedNodeType[]> = {
   [I in keyof Ts]: Ts[I] extends ConsumerDefinedNodeType<infer K, infer _D, infer _E> ? K : never;
 }[number];
 
 /** The `Data` belonging to one kind — used by the React per-kind views. */
-export type DataForKind<Ts extends readonly unknown[], K extends string> = {
+export type DataForKind<Ts extends readonly ErasedNodeType[], K extends string> = {
   [I in keyof Ts]: Ts[I] extends ConsumerDefinedNodeType<infer NK, infer D, infer _E>
     ? NK extends K
       ? D
@@ -247,7 +279,7 @@ export type DataForKind<Ts extends readonly unknown[], K extends string> = {
 }[number];
 
 /** The `Edit` belonging to one kind. */
-export type EditForKind<Ts extends readonly unknown[], K extends string> = {
+export type EditForKind<Ts extends readonly ErasedNodeType[], K extends string> = {
   [I in keyof Ts]: Ts[I] extends ConsumerDefinedNodeType<infer NK, infer _D, infer E>
     ? NK extends K
       ? E
@@ -302,7 +334,7 @@ export type ChildrenState =
  * `ConsumerDefinedNodeType`, so the tuple cannot be filtered on it. At runtime a container
  * kind never produces a `LeafNode`.
  */
-export type LeafNode<Ts extends readonly unknown[]> = {
+export type LeafNode<Ts extends readonly ErasedNodeType[]> = {
   [I in keyof Ts]: Ts[I] extends ConsumerDefinedNodeType<infer K, infer D, infer _E>
     ? Readonly<{
         id: NodeId;
@@ -315,7 +347,7 @@ export type LeafNode<Ts extends readonly unknown[]> = {
     : never;
 }[number];
 
-export type CollectionNode<Ts extends readonly unknown[], S> = {
+export type CollectionNode<Ts extends readonly ErasedNodeType[], S> = {
   [I in keyof Ts]: Ts[I] extends ConsumerDefinedNodeType<infer K, infer D, infer _E>
     ? Readonly<{
         id: NodeId;
@@ -423,7 +455,7 @@ export type QuarantinedNode = Readonly<{
  * on the other two. That is why `LeafNode` and `CollectionNode` carry an
  * explicit `quarantined: false`.
  */
-export type GraphNode<Ts extends readonly unknown[], S> =
+export type GraphNode<Ts extends readonly ErasedNodeType[], S> =
   | LeafNode<Ts>
   | CollectionNode<Ts, S>
   | QuarantinedNode;
@@ -433,7 +465,7 @@ export type GraphNode<Ts extends readonly unknown[], S> =
  * Nothing here is mutated in place; `applyPatch` is the only code that
  * rewrites the indexes, so undo/redo cannot drift from forward application.
  */
-export type Graph<Ts extends readonly unknown[], S> = Readonly<{
+export type Graph<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   /** Cross-instance guard. Checked on every mutating call and every ingress. */
   engineId: symbol;
   nodesById: ReadonlyMap<NodeId, GraphNode<Ts, S>>;
@@ -515,7 +547,7 @@ export type Graph<Ts extends readonly unknown[], S> = Readonly<{
  * kind is rejected (`"leaf-seed-with-children"`). Omitted on a container means
  * a `loaded` empty collection.
  */
-export type Seed<Ts extends readonly unknown[], S> = {
+export type Seed<Ts extends readonly ErasedNodeType[], S> = {
   [I in keyof Ts]: Ts[I] extends ConsumerDefinedNodeType<infer K, infer D, infer _E>
     ? Readonly<{
         kind: K;
@@ -527,7 +559,7 @@ export type Seed<Ts extends readonly unknown[], S> = {
 }[number];
 
 /** One node's content edit, paired with its own kind's edit type. */
-export type EditOf<Ts extends readonly unknown[]> = {
+export type EditOf<Ts extends readonly ErasedNodeType[]> = {
   [I in keyof Ts]: Ts[I] extends ConsumerDefinedNodeType<infer K, infer _D, infer E>
     ? Readonly<{ nodeId: NodeId; kind: K; edit: E }>
     : never;
@@ -538,7 +570,7 @@ export type EditOf<Ts extends readonly unknown[]> = {
  * every placement of an asset is a single `edit-nodes` over all of them, which
  * is what keeps Ctrl-Z matching what the user thinks they did.
  */
-export type Command<Ts extends readonly unknown[], S> =
+export type Command<Ts extends readonly ErasedNodeType[], S> =
   | Readonly<{
       type: "move-nodes";
       nodeIds: readonly NodeId[];
@@ -580,7 +612,7 @@ export type Command<Ts extends readonly unknown[], S> =
  * concurrent edits, which v1 does not do, so adding them now doubles the
  * intent surface and buys nothing.
  */
-export type DropIntent<Ts extends readonly unknown[], S> =
+export type DropIntent<Ts extends readonly ErasedNodeType[], S> =
   | Readonly<{
       type: "move";
       nodeIds: readonly NodeId[];
@@ -623,14 +655,14 @@ export type Move = Readonly<{
  * `node` is the FULL node, so a removed subtree is restorable exactly —
  * including a quarantined node's byte-exact `raw`.
  */
-export type Placement<Ts extends readonly unknown[], S> = Readonly<{
+export type Placement<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   node: GraphNode<Ts, S>;
   parentId: NodeId;
   index: number;
 }>;
 
 /** One node's DATA change, structure untouched. Whole values, so inverting is a swap. */
-export type DataChange<Ts extends readonly unknown[]> = {
+export type DataChange<Ts extends readonly ErasedNodeType[]> = {
   [I in keyof Ts]: Ts[I] extends ConsumerDefinedNodeType<infer K, infer D, infer _E>
     ? Readonly<{ nodeId: NodeId; kind: K; before: D; after: D }>
     : never;
@@ -648,7 +680,7 @@ export type DataChange<Ts extends readonly unknown[]> = {
  *     `applyPatch` walks it BACKWARD, so children leave before parents and a
  *     later sibling's splice cannot invalidate an earlier one's index.
  */
-export type Patch<Ts extends readonly unknown[], S> =
+export type Patch<Ts extends readonly ErasedNodeType[], S> =
   | Readonly<{ type: "moved"; moves: readonly Move[] }>
   | Readonly<{ type: "inserted"; placements: readonly Placement<Ts, S>[] }>
   | Readonly<{ type: "removed"; placements: readonly Placement<Ts, S>[] }>
@@ -1097,7 +1129,7 @@ export type FoldedChild<A> = Folded<A> &
  * PARAMETER mentioning `A`, so arrow properties would sink the
  * `ConsumerDefinedFold<Ts, S, unknown>` registry constraint.
  */
-export type ConsumerDefinedFold<Ts extends readonly unknown[], S, A> = Readonly<{
+export type ConsumerDefinedFold<Ts extends readonly ErasedNodeType[], S, A> = Readonly<{
   key: string;
   /** A leaf is always `"exact"` — only placeholders and quarantine introduce
    *  uncertainty, so the evaluator wraps this without asking. */
@@ -1123,16 +1155,16 @@ export type ConsumerDefinedFold<Ts extends readonly unknown[], S, A> = Readonly<
  * can only ever return `Folded<unknown>` while `aggregate<K>` promises
  * `Folded<FoldValue<F[K]>>`.
  */
-export type ErasedFold<Ts extends readonly unknown[], S> = ConsumerDefinedFold<Ts, S, unknown>;
+export type ErasedFold<Ts extends readonly ErasedNodeType[], S> = ConsumerDefinedFold<Ts, S, unknown>;
 
-export type FoldRegistry<Ts extends readonly unknown[], S> = Readonly<
+export type FoldRegistry<Ts extends readonly ErasedNodeType[], S> = Readonly<
   Record<string, ErasedFold<Ts, S>>
 >;
 
 /** The `A` of a fold — `Folded<FoldValue<F["duration"]>>` is what `aggregate`
  *  returns. */
 export type FoldValue<X> = X extends ConsumerDefinedFold<
-  infer _Ts extends readonly unknown[],
+  infer _Ts extends readonly ErasedNodeType[],
   infer _S,
   infer A
 >
@@ -1171,7 +1203,7 @@ export type FoldCache = Readonly<{
  * issuing it (currently only a coalesced merge, whose original commands no
  * longer describe the merged patch).
  */
-export type HistoryEntry<Ts extends readonly unknown[], S> = Readonly<{
+export type HistoryEntry<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   command: Command<Ts, S> | null;
   patch: Patch<Ts, S>;
   /** Milliseconds since epoch, for display/inspection only. */
@@ -1187,7 +1219,7 @@ export type HistoryEntry<Ts extends readonly unknown[], S> = Readonly<{
  * new graph, and a mutable history would make that operation unobservable and
  * untestable.
  */
-export type History<Ts extends readonly unknown[], S> = Readonly<{
+export type History<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   /** Oldest first; the newest applied entry is LAST. */
   past: readonly HistoryEntry<Ts, S>[];
   /** The most-recently-undone entry is LAST (it is what `redo` takes next). */
@@ -1205,7 +1237,7 @@ export type History<Ts extends readonly unknown[], S> = Readonly<{
  * `markMissing` emit NOTHING here — they are IO landing, and the consumer
  * already knows about the write it just performed.
  */
-export type Change<Ts extends readonly unknown[], S> = Readonly<{
+export type Change<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   patch: Patch<Ts, S>;
   source: "command" | "undo" | "redo";
   /**
@@ -1235,7 +1267,7 @@ export type SelectionSlice = Readonly<{
 }>;
 
 export type Store<
-  Ts extends readonly unknown[],
+  Ts extends readonly ErasedNodeType[],
   S,
   F extends FoldRegistry<Ts, S>,
 > = Readonly<{
@@ -1275,7 +1307,7 @@ export type Store<
  * one at runtime yields `undefined`; nothing should.
  */
 export type PhantomTypes<
-  Ts extends readonly unknown[],
+  Ts extends readonly ErasedNodeType[],
   S,
   F extends FoldRegistry<Ts, S>,
 > = Readonly<{
@@ -1448,7 +1480,7 @@ export type EngineConfig<
 }>;
 
 export type Engine<
-  Ts extends readonly unknown[],
+  Ts extends readonly ErasedNodeType[],
   S,
   F extends FoldRegistry<Ts, S>,
 > = Readonly<{
@@ -1550,7 +1582,7 @@ export type Engine<
 // out shaped wrong. Casts go through `unknown`, never `any`.
 
 /** Build a leaf whose `data` has already been through `parse`. */
-export function makeLeafNode<Ts extends readonly unknown[]>(
+export function makeLeafNode<Ts extends readonly ErasedNodeType[]>(
   id: NodeId,
   kind: string,
   data: unknown,
@@ -1566,7 +1598,7 @@ export function makeLeafNode<Ts extends readonly unknown[]>(
 }
 
 /** Build a collection whose `data` has already been through `parse`. */
-export function makeCollectionNode<Ts extends readonly unknown[], S>(
+export function makeCollectionNode<Ts extends readonly ErasedNodeType[], S>(
   id: NodeId,
   kind: string,
   data: unknown,
@@ -1634,7 +1666,7 @@ export function makeFolded<A>(folded: Folded<unknown>): Folded<A> {
 }
 
 /** Build a `DataChange` from values the registry erased. Same argument as above. */
-export function makeDataChange<Ts extends readonly unknown[]>(
+export function makeDataChange<Ts extends readonly ErasedNodeType[]>(
   nodeId: NodeId,
   kind: string,
   before: unknown,

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -986,7 +986,15 @@ export type SerializedDocument = Readonly<{
   nodes: readonly SerializedNode[];
 }>;
 
-/** Spec-compat alias. `SerializedDocument` is the name used in every signature. */
+/**
+ * Spec-compat alias for `SerializedDocument`.
+ *
+ * `SerializedDocument` now appears in exactly one signature — as what
+ * `Engine.serialize` RETURNS, which keel constructs and can therefore vouch
+ * for. The ingress doors take `unknown` and check, rather than taking this and
+ * believing. That asymmetry is the point: this type is a guarantee on the way
+ * out and would have been a fiction on the way in.
+ */
 export type SerializedGraph = SerializedDocument;
 
 export type LoadReport = Readonly<{
@@ -1289,7 +1297,10 @@ export type Store<
   canRedo(): boolean;
   /** The non-undoable content write. Returns the ids whose history was scrubbed. */
   ingest(edits: readonly EditOf<Ts>[]): Result<readonly NodeId[], Rejection>;
-  load(id: NodeId, doc: SerializedDocument): Result<void, LoadRejection>;
+  /** `unknown` for the reason `Engine.loadChildren` gives: the payload came from
+   *  IO and is re-validated here, so the signature must not vouch for it. Pass a
+   *  `SerializedDocument`; a structural failure returns `"malformed-document"`. */
+  load(id: NodeId, doc: unknown): Result<void, LoadRejection>;
   markMissing(id: NodeId, reason: string): void;
   /** `undefined` when the node is gone — routine in React, where a card can
    *  outlive its node by a frame. */
@@ -1515,10 +1526,25 @@ export type Engine<
   ): Result<Command<Ts, S>, Rejection>;
 
   // ---- IO landing: no patch, no history entry, no change-feed event ----
+  /**
+   * `doc` is `unknown`, matching `deserialize`, because it is the same kind of
+   * value: a payload that arrived from IO and has been validated by nobody.
+   *
+   * It used to say `SerializedDocument`, which was a promise this signature
+   * could not keep — the implementation has always taken `unknown` and
+   * re-validated, and the comment there said so outright: "the consumer's
+   * assertion, not a guarantee". A type that vouches for an unchecked envelope
+   * invites a cast to stand in for a check, on the one door hostile payloads
+   * arrive through.
+   *
+   * Pass a `SerializedDocument` — that is the shape this reads. It is simply
+   * checked rather than believed, and a structural failure comes back as
+   * `"malformed-document"` with the underlying `StructuralError` as `cause`.
+   */
   loadChildren(
     graph: Graph<Ts, S>,
     id: NodeId,
-    doc: SerializedDocument,
+    doc: unknown,
   ): Result<Graph<Ts, S>, LoadRejection>;
   markMissing(graph: Graph<Ts, S>, id: NodeId, reason: string): Graph<Ts, S>;
   /**

--- a/packages/keel-react/keel.stories.tsx
+++ b/packages/keel-react/keel.stories.tsx
@@ -38,7 +38,6 @@ import {
   type SerializedDocument,
   type SerializedNode,
   type ConsumerDefinedSummaryType,
-  type ErasedNodeType,
 } from "@storyboard/keel-core";
 
 import { createReactBindings } from "./index";

--- a/packages/keel-react/keel.stories.tsx
+++ b/packages/keel-react/keel.stories.tsx
@@ -38,6 +38,7 @@ import {
   type SerializedDocument,
   type SerializedNode,
   type ConsumerDefinedSummaryType,
+  type ErasedNodeType,
 } from "@storyboard/keel-core";
 
 import { createReactBindings } from "./index";

--- a/packages/keel-react/src/bindings.tsx
+++ b/packages/keel-react/src/bindings.tsx
@@ -43,6 +43,7 @@ import {
   type NodeId,
   type SelectionSlice,
   type Store,
+  type ErasedNodeType,
 } from "@storyboard/keel-core";
 import type {
   DispatchFn,
@@ -79,7 +80,7 @@ type ErasedNodeView = FunctionComponent<
  * props parameter is contravariant and `FC<{ data: Clip }>` is genuinely not
  * assignable to `FC<{ data: unknown }>`. Through `unknown`, never `any`.
  */
-function eraseNodeView<Ts extends readonly unknown[], K extends string>(
+function eraseNodeView<Ts extends readonly ErasedNodeType[], K extends string>(
   view: NodeView<Ts, K>,
 ): ErasedNodeView {
   return view as unknown as ErasedNodeView;
@@ -101,7 +102,7 @@ function eraseNodeView<Ts extends readonly unknown[], K extends string>(
  * throws the "must be used inside the Provider" error with no other clue.
  */
 export function createReactBindings<
-  Ts extends readonly unknown[],
+  Ts extends readonly ErasedNodeType[],
   S,
   F extends FoldRegistry<Ts, S>,
 >(engine: Engine<Ts, S, F>): ReactBindings<Ts, S, F> {

--- a/packages/keel-react/src/types.ts
+++ b/packages/keel-react/src/types.ts
@@ -29,6 +29,7 @@ import type {
   Result,
   SelectionSlice,
   Store,
+  ErasedNodeType,
 } from "@storyboard/keel-core";
 
 // ---------------------------------------------------------------------------
@@ -43,7 +44,7 @@ import type {
  * itself. A view that wants its children calls `useChildren(id)`.
  */
 export type NodeViewProps<
-  Ts extends readonly unknown[],
+  Ts extends readonly ErasedNodeType[],
   K extends string,
 > = Readonly<{
   id: NodeId;
@@ -61,7 +62,7 @@ export type NodeViewProps<
  * `memo()` ever sees.
  */
 export type NodeView<
-  Ts extends readonly unknown[],
+  Ts extends readonly ErasedNodeType[],
   K extends string,
 > = FunctionComponent<NodeViewProps<Ts, K>>;
 
@@ -92,20 +93,20 @@ export type QuarantinedView = FunctionComponent<QuarantinedViewProps>;
  * stack is a `Result` rejection, not a throw, but a disabled button beats a
  * rejection nobody reads.
  */
-export type HistoryControls<Ts extends readonly unknown[], S> = Readonly<{
+export type HistoryControls<Ts extends readonly ErasedNodeType[], S> = Readonly<{
   canUndo: boolean;
   canRedo: boolean;
   undo(): Result<Patch<Ts, S>, ReplayRejection>;
   redo(): Result<Patch<Ts, S>, ReplayRejection>;
 }>;
 
-export type DispatchFn<Ts extends readonly unknown[], S> = (
+export type DispatchFn<Ts extends readonly ErasedNodeType[], S> = (
   command: Command<Ts, S>,
   options?: Readonly<{ coalesceKey?: string }>,
 ) => Result<Patch<Ts, S>, Rejection>;
 
 export type ProviderProps<
-  Ts extends readonly unknown[],
+  Ts extends readonly ErasedNodeType[],
   S,
   F extends FoldRegistry<Ts, S>,
 > = Readonly<{
@@ -133,7 +134,7 @@ export type ProviderProps<
  * is reachable from the one returned object.
  */
 export type ReactBindings<
-  Ts extends readonly unknown[],
+  Ts extends readonly ErasedNodeType[],
   S,
   F extends FoldRegistry<Ts, S>,
 > = Readonly<{


### PR DESCRIPTION
Two changes to the public type surface, both about the same thing: **making the types say what has actually been checked.** Neither is cosmetic, which is why they are separated from the rename PRs (#597, #598).

---

## 1. `Ts extends readonly unknown[]` → `readonly ErasedNodeType[]` (139 sites)

`Ts` is the consumer's tuple of node types, exactly as passed to `createEngine({ types })`. Constraining it as `readonly unknown[]` is not a *loose* bound — everything extends `unknown`, so it is **no bound at all**.

**It read as a claim about trust.** In *value* positions `unknown` is this package's untrusted marker, and an enforced one — `data: unknown`, `raw: unknown`, `parse(raw: unknown)`, none of them touchable without narrowing. In *constraint* position the same keyword means nothing. So `Command<Ts extends readonly unknown[], S>` invited the reading "a command over untrusted things" about the single most trusted input in the system.

**It let nonsense through silently.** All three of these compiled before:

```ts
Graph<readonly [string, number], never>
Command<readonly ["not", "node", "types"], never>
LeafNode<readonly [{ nope: true }]>
```

The mapped types filter with `Ts[I] extends ConsumerDefinedNodeType<…> ? … : never`, so a garbage element collapsed to `never` and vanished instead of erroring at the instantiation site. All three now fail.

`EngineConfig` and `createEngine` already used the honest constraint; this propagates it to the other 139 sites.

**Verified, not assumed:** every failure during the change was a missing import — seven files needed `ErasedNodeType` added. Not one assignability error, which is the evidence the loose form was never load-bearing.

---

## 2. `loadChildren` / `load` now take `unknown`

`Engine.loadChildren` and `Store.load` took `doc: SerializedDocument` and delegated to `loadChildrenInto`, which takes `doc: unknown` and re-validates. The public types vouched for an envelope nothing had checked — on the one door a payload reaches straight from IO. The comment in `serialize.ts` said so outright: *"the consumer's assertion, not a guarantee"* — a comment apologising for a signature rather than describing code.

Both doors now agree with `deserialize`, which has always been honest.

**This one is a widening, so it is non-breaking** — every existing call still compiles. What changes is that a cast can no longer stand in for a check. The shape to pass is still `SerializedDocument`; it is now checked rather than believed.

`SerializedDocument` now appears in exactly one signature: what `Engine.serialize` **returns**, which keel constructs and can vouch for. A guarantee on the way out, a fiction on the way in.

### The six new tests are a compile-time guard

`null`, a string, an array, a missing `formatVersion`, a future `formatVersion`, a non-array `nodes`. Every one needed a cast to get past the old parameter, so **the test file does not compile against the old signature** — verified by restoring it and watching `TS2345` fire. Each is refused as a value, with the graph left untouched.

---

## Compatibility

Change 1 tightens: a consumer who hand-instantiated `Graph<SomethingElse, S>` with a non-node-type tuple now gets an error. In practice `Ts` is always inferred from `createEngine`. Change 2 only widens.

keel-react, ui and all 74 test files compile untouched.

## Verification

- `tsc --noEmit` clean: keel-core, keel-react, ui
- 1454/1454 tests pass (six new)
- `npm run lint` — 0 errors (11 pre-existing warnings in files not touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)