### PR TITLE
A cyclic serialize output killed the process from inside a function contracted to return a Result

### DIFF
--- a/packages/keel-core/patches.test.ts
+++ b/packages/keel-core/patches.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   defineNodeType,
   makeCollectionNode,
+  makeDataChange,
   makeLeafNode,
   makeQuarantinedNode,
   parseNodeId,
@@ -30,6 +31,8 @@ import {
   type Patch,
   type Placement,
   type ErasedNodeType,
+  type Issue,
+  type Result,
   type ConsumerDefinedSummaryType,
 } from "./types";
 import { DEFAULT_MAX_NODES } from "./serialize";
@@ -2055,4 +2058,132 @@ describe("batched insertion equals sequential splicing", () => {
     ]));
     expect(kids(next, "b")).toEqual(sequentially(["b0"], [{ index: 1, id: "y" }]));
   });
+});
+
+// ---------------------------------------------------------------------------
+// deepEqual — a cyclic `serialize` output must not take the process with it
+// ---------------------------------------------------------------------------
+//
+// `verifyDataChanged` compares `nodeType.serialize(change.before)` against
+// `nodeType.serialize(node.data)`. Those are two FRESH objects, so `Object.is`
+// cannot short-circuit them, and if the node type's `serialize` returns a value
+// holding a back-reference the walk used to push two frames for every one it
+// popped. Measured before the fix: heap exhaustion at 4 GB and a killed process
+// in 23 seconds — not a hang, a crash, out of a function contracted to return a
+// `Result`.
+//
+// Reaching it takes a node type whose `serialize` returns a cycle, which is a
+// consumer bug on the same footing as the throwing `serialize` this module
+// already wraps. Wire data cannot carry one; an in-memory value handed to
+// `deserialize` can.
+//
+// The fix is a co-inductive pair memo, NOT a step budget: a budget would refuse
+// a legitimately large value as `data-mismatch`, which is the failure ./types
+// argues production must not have. So these assert a DEFINITE verdict in both
+// directions, not merely that it terminated.
+describe("a cyclic serialize output is compared, not fatal", () => {
+  type Cyclic = Readonly<{ n: number }>;
+
+  /** `serialize` returns a fresh object that points at itself. Conforming
+   *  enough to run; not something that could ever reach the wire. */
+  function cyclicType(shape: (n: number) => Record<string, unknown>) {
+    return defineNodeType<Cyclic, Readonly<{ n: number }>>()({
+      kind: "cyc",
+      container: false,
+      schemaVersion: 1,
+      parse(raw): Result<Cyclic, readonly Issue[]> {
+        if (!isRecord(raw) || typeof raw["n"] !== "number") {
+          return { ok: false, error: [{ path: "$.n", message: "n" }] };
+        }
+        return { ok: true, value: { n: raw["n"] } };
+      },
+      serialize(data): unknown {
+        const out = shape(data.n);
+        out["self"] = out;
+        return out;
+      },
+      applyEdit(_data, edit) {
+        return { ok: true, value: { n: edit.n } };
+      },
+    });
+  }
+
+  function ctxWithCyclic(shape: (n: number) => Record<string, unknown>) {
+    const nodeType = cyclicType(shape);
+    const reg = new Map<string, ErasedNodeType>([["cyc", nodeType as ErasedNodeType]]);
+    return { ...makeCtx(), registry: reg };
+  }
+
+  /** A `data-changed` patch whose `before` is a DIFFERENT object holding the
+   *  same value — so the `Object.is` fast path cannot fire and the comparison
+   *  really runs. That is the save/reload shape: a dormant patch replayed
+   *  against a graph deserialized separately. */
+  function patchAgainst(before: Cyclic): Patch<TestTypes, Summary> {
+    return {
+      type: "data-changed",
+      changes: [
+        makeDataChange<TestTypes>(nid("c"), "cyc", before, { n: 99 }),
+      ],
+    };
+  }
+
+  function graphHolding(n: number): Graph<TestTypes, Summary> {
+    const g = buildGraph([folder("root", [clip("c")])]);
+    const node = makeLeafNode<TestTypes>(nid("c"), "cyc", { n });
+    return { ...g, nodesById: new Map(g.nodesById).set(nid("c"), node) };
+  }
+
+  it("terminates with a verdict when both sides cycle identically", () => {
+    const ctx = ctxWithCyclic((n) => ({ n }));
+    // before and live hold EQUAL values in DIFFERENT objects.
+    const verdict = verifyPatchApplies<TestTypes, Summary>(
+      graphHolding(7),
+      patchAgainst({ n: 7 }),
+      ctx,
+    );
+    // Structurally identical cycles compare EQUAL, so the patch still applies.
+    expect(verdict.ok).toBe(true);
+  }, 5000);
+
+  it("still refuses when the cyclic values genuinely differ", () => {
+    const ctx = ctxWithCyclic((n) => ({ n }));
+    const verdict = verifyPatchApplies<TestTypes, Summary>(
+      graphHolding(7),
+      patchAgainst({ n: 8 }),
+      ctx,
+    );
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.error.code).toBe("data-mismatch");
+  }, 5000);
+
+  it("refuses when one side cycles and the other does not", () => {
+    // `n` decides the shape, so the two serialize outputs disagree in structure
+    // as well as in their back-reference.
+    const ctx = ctxWithCyclic((n) => (n === 7 ? { n } : { n, extra: [1, 2, 3] }));
+    const verdict = verifyPatchApplies<TestTypes, Summary>(
+      graphHolding(7),
+      patchAgainst({ n: 8 }),
+      ctx,
+    );
+    expect(verdict.ok).toBe(false);
+  }, 5000);
+
+  it("compares a deeply shared acyclic value without exploding", () => {
+    // A DAG, not a cycle: the same subobject reachable by many paths. The memo
+    // is what keeps this linear rather than exponential in the sharing depth.
+    const ctx = ctxWithCyclic((n) => {
+      let level: Record<string, unknown> = { n };
+      for (let i = 0; i < 24; i += 1) level = { a: level, b: level };
+      return level;
+    });
+    const started = Date.now();
+    const verdict = verifyPatchApplies<TestTypes, Summary>(
+      graphHolding(7),
+      patchAgainst({ n: 7 }),
+      ctx,
+    );
+    expect(verdict.ok).toBe(true);
+    expect(Date.now() - started).toBeLessThan(2000);
+  }, 5000);
 });

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -131,11 +131,69 @@ function deepEqual(a: unknown, b: unknown): boolean {
   const stack: Readonly<{ left: unknown; right: unknown }>[] = [
     { left: a, right: b },
   ];
+  /**
+   * Object pairs this walk has already taken on, so a cyclic value terminates.
+   *
+   * WITHOUT THIS THE PROCESS DIES, and not slowly. Two DISTINCT values that
+   * each hold a back-reference — `out.self = out` from either side of the
+   * comparison below — make the walk push two frames for every one it pops, so
+   * the stack grows without bound. Measured: heap exhaustion at 4 GB and a
+   * killed process in 23 seconds. `Object.is` is no help, because the two
+   * `serialize` calls return two different objects.
+   *
+   * A PARSED value may legitimately hold a back-pointer, and this compares
+   * `serialize` OUTPUT rather than parsed data — so reaching it takes a node
+   * type whose `serialize` returns a cycle, which is a consumer bug on the same
+   * footing as the throwing `serialize` the caller already wraps. Wire data
+   * cannot carry one; an in-memory `raw` handed to `deserialize` can.
+   *
+   * NOT A STEP BUDGET, and that distinction is the whole design. ./types argues
+   * that `verifyPatchApplies` needs a comparator that CANNOT abstain, because a
+   * budget bail surfaces as a spurious `data-mismatch` — a legitimate undo
+   * refused for being large. That argument is right, and a budget would have
+   * broken exactly the case it was meant to protect: a clip with a few hundred
+   * keyframes is big, not cyclic. A memo changes no verdict on any acyclic
+   * value; it only makes the cyclic ones finish.
+   *
+   * CO-INDUCTIVE, which is the standard rule and the only one that stays
+   * definite: a pair already under comparison is ASSUMED equal. The assumption
+   * costs nothing, because any concrete disagreement anywhere in the walk
+   * returns `false` immediately, and `true` is only reached once every pair has
+   * been discharged. `a.self = a` against `b.self = b` compares equal — which is
+   * correct, they are structurally identical — while `a.self = a` against
+   * `b.self = {}` still returns `false` on the key-count check.
+   *
+   * Allocated lazily and only for object-vs-object pairs, so a comparison that
+   * never reaches two objects never builds one. The residual bound is the
+   * number of DISTINCT pairs the walk reaches, which for the wire-shaped values
+   * this shares with the rest of the package is the size of the value.
+   */
+  let seen: Map<object, Set<object>> | null = null;
+
   while (stack.length > 0) {
     const frame = stack.pop();
     if (frame === undefined) break;
     const { left, right } = frame;
     if (Object.is(left, right)) continue;
+
+    // Both sides are objects, so this pair can recur. Record it before
+    // descending, which is what makes a cycle terminate rather than repeat.
+    if (
+      typeof left === "object" &&
+      left !== null &&
+      typeof right === "object" &&
+      right !== null
+    ) {
+      if (seen === null) seen = new Map<object, Set<object>>();
+      let against = seen.get(left);
+      if (against === undefined) {
+        against = new Set<object>();
+        seen.set(left, against);
+      }
+      // Already taken on higher in the walk: assume equal and stop descending.
+      if (against.has(right)) continue;
+      against.add(right);
+    }
 
     const leftIsArray = Array.isArray(left);
     if (leftIsArray || Array.isArray(right)) {

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1803,11 +1803,20 @@ export const DEV_CHECK_BUDGET = 20_000;
  * audit needs a comparator that can abstain; production needs one that cannot.
  * They are different functions and must stay so.
  *
- * BOUNDED, and that is the whole point. A PARSED value may legitimately hold a
- * back-pointer, and the unbounded walk does not terminate on one — measured, a
- * verbatim transcription of `deepEqual` ran 2,000,000 iterations on `a.self=a`
- * vs `b.self=b` without finishing. The step counter is simultaneously the cycle
- * guard and the cost bound.
+ * BOUNDED, and that is the whole point — but the cycle is no longer why. A
+ * PARSED value may legitimately hold a back-pointer, and a verbatim
+ * transcription of `deepEqual` once ran 2,000,000 iterations on `a.self=a` vs
+ * `b.self=b` without finishing. `deepEqual` now carries a co-inductive pair
+ * memo and terminates on exactly that input, so the two functions no longer
+ * differ in whether they can survive a cycle — only in whether they may ABSTAIN.
+ *
+ * The step counter here remains the COST bound, which is the reason a dev check
+ * needs one and production does not: this runs on every parsed value at every
+ * ingress under `devChecks`, where a 40,000-node document with 200 keyframes a
+ * clip reached 2.67 seconds unbudgeted. `verifyPatchApplies` runs its
+ * comparison once per changed node on the undo path, and must answer rather
+ * than shrug — a budget bail there would be a spurious `data-mismatch`
+ * refusing a legitimate undo for being large.
  *
  * `"unknown"` is SILENCE at every call site, never a report. A check that
  * cannot see the whole value has not found a violation.


### PR DESCRIPTION
> **Stacked on #601** — based on `pl16-048` so the diff shows only this change. GitHub retargets to `main` when #601 merges.

## The bug

`verifyDataChanged` compares `serialize(change.before)` against `serialize(node.data)`. Those are two **fresh** objects, so the `Object.is` fast path cannot fire — and if the node type's `serialize` returns a value holding a back-reference, the walk pushed two frames for every one it popped.

Measured: **heap exhaustion at 4 GB and a killed process in 23 seconds.** Not a hang. A crash, out of `undo`, from a function whose entire contract is that it returns a `Result`.

**How it is reached.** It takes a node type whose `serialize` returns a cycle — a consumer bug on the same footing as the throwing `serialize` this module already wraps. Wire data cannot carry one; an in-memory value handed to `deserialize` can. And the door is the ordinary one: the comparison only runs where `before` is not reference-identical to the live data, which is precisely a dormant patch replayed against a separately deserialized graph. Save, reload, Ctrl-Z.

## A co-inductive pair memo, not a step budget

The distinction is the whole design, and `types.ts` had already made the argument:

> *"`verifyPatchApplies` … needs a DEFINITE verdict: a budget bail there would surface as a spurious `data-mismatch` refusal of a legitimate undo."*

That argument is right, and a budget would have broken the very case it was meant to protect — **a clip with a few hundred keyframes is big, not cyclic.** The memo changes no verdict on any acyclic value. It only makes the cyclic ones finish.

The rule is the standard one: a pair already under comparison is **assumed equal**. Sound because any concrete disagreement returns `false` immediately, and `true` is only reached once every pair has been discharged.

- `a.self = a` vs `b.self = b` → **equal**, which is correct; they are structurally identical
- `a.self = a` vs `b.self = {}` → still **false**, on the key-count check

It also makes a heavily shared DAG linear rather than exponential in its sharing depth — pinned by the fourth test.

## A comment that had become false

`types.ts` justified ~35 lines of deliberate duplication partly on the claim that the unbounded walk *"does not terminate"* on a back-pointer. That is no longer true, so it is rewritten rather than left to rot.

The two comparators still differ, in the thing that actually matters: the dev-check one may **abstain** and carries a **cost** bound, because it runs on every parsed value at every ingress (2.67 s unbudgeted on a 40,000-node document). This one runs once per changed node on undo and must answer.

## Tests proven to fail first

Four tests. With the memo removed and the heap capped at 512 MB:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
Worker exited unexpectedly
```

With it, all four pass in milliseconds — and they assert a **definite verdict in both directions**, not merely that it terminated.

## Verification

- `npm run typecheck:packages` — 7/7 clean
- `npm run lint:packages` — 0 errors (14 pre-existing warnings)
- 1470/1470 tests pass (four new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)