### PR TITLE
The replay gate did not enforce what the forward door does

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -55,7 +55,6 @@ import {
   getNode,
   getParent,
   isSameOrAncestor,
-  ownsSubtree,
   rebuildDerivedIndexes,
   sourceKeyOf,
   subtreeIds,
@@ -1176,8 +1175,22 @@ function planEdits<Ts extends readonly ErasedNodeType[], S>(
       ? { children: node.children, summary: node.summary }
       : null;
 
-    // A `reference` owns nothing, so its key cannot collide with anyone.
-    if (collection === null || ownsSubtree(collection.children)) {
+    // DELEGATED, not re-derived — the same correction `owningSourceKey` above
+    // already carries. This used to read
+    // `collection === null || ownsSubtree(collection.children)`, and
+    // `collection === null` IS the leaf case, so it made a leaf an owner. That
+    // is verbatim the predicate review3 deleted from ./graph, and it left this
+    // door disagreeing with the other four: `walkDerivedIndexes`, invariant
+    // check 8, `findDuplicateOwner` in ./serialize, and `owningSourceKey` 900
+    // lines above. Both edit doors share `planEdits`, so a leaf sharing a key
+    // with an owning container could not be edited through `applyEditNodes`
+    // OR `applyNonUndoableWriteEdits` — uneditable on a graph
+    // `findInvariantViolation` returns null for, which is exactly the
+    // unrepairable state `ownsItsSubtree` was made THE SINGLE ANSWER to end.
+    //
+    // Total on its own terms: false for quarantined, for a leaf, and for a
+    // `reference` — subsuming the `ownsSubtree` branch this replaced.
+    if (ownsItsSubtree<Ts, S>(node)) {
       const nextKey = nodeType.sourceKey?.(nextData) ?? null;
       if (nextKey !== null) {
         const owner = graph.ownerBySourceKey.get(nextKey);

--- a/packages/keel-core/folds.ts
+++ b/packages/keel-core/folds.ts
@@ -378,6 +378,39 @@ export function createFoldCache(
   let misses = 0;
   let evictions = 0;
 
+  /**
+   * ONE long-lived eviction cursor, advanced rather than re-created.
+   *
+   * `entries.keys().next()` per eviction reads as O(1) and is not. V8 backs a
+   * Map with an ordered entry array and `delete` writes a TOMBSTONE into it,
+   * compacting only on rehash. This LRU always deletes from the FRONT, so
+   * tombstones pile up there and every fresh iterator has to scan past all of
+   * them to reach the first live entry — the cost of one eviction scales with
+   * the cache LIMIT, and the default limit (131,072) is the worst case.
+   *
+   * MEASURED, 50,000 evictions in every row, so the work is identical:
+   *     limit   1,000     25 ms
+   *     limit  10,000    274 ms
+   *     limit  50,000    400 ms
+   *     limit 131,072    682 ms      <- the DEFAULT
+   *
+   * This also re-attributes the number in ./engine's cache-pressure comment,
+   * which treated the eviction loop as a constant and blamed refold work: an
+   * over-capacity cache reading 8 root rollups measured 8,220 ms with 0 hits,
+   * and 295 ms with this cursor and byte-identical eviction/hit/miss counts.
+   * A correctly-sized cache pays too — 8 folds x 8,000 nodes under the default
+   * limit still stranded 92,928 stale-rev entries over 2,000 edits, 2,304 ms
+   * of pure loop overhead against 55 ms.
+   *
+   * SAFE because a Map iterator is live: an entry deleted before the cursor
+   * reaches it is skipped rather than yielded, and one promoted by `get`
+   * (delete + re-set) is re-appended BEHIND the cursor, so it is offered again
+   * only after everything older — which is exactly LRU order. Once a Map
+   * iterator reports `done` it detaches permanently, so it is re-created then,
+   * and on `clear()`.
+   */
+  let evictionCursor: Iterator<string> | null = null;
+
   return {
     get(foldKey, nodeId, subtreeRev) {
       const key = cacheKey(foldKey, nodeId, subtreeRev);
@@ -403,12 +436,19 @@ export function createFoldCache(
       entries.delete(key);
       entries.set(key, value);
       while (entries.size > max) {
-        const oldestKey: string | undefined = entries.keys().next().value;
-        // Keys are never `undefined` (every one starts with a length digit), so
-        // this only fires on an exhausted iterator — impossible while size > 0,
-        // but it is what keeps the loop provably terminating without a `!`.
-        if (oldestKey === undefined) break;
-        entries.delete(oldestKey);
+        if (evictionCursor === null) evictionCursor = entries.keys();
+        let step = evictionCursor.next();
+        if (step.done === true) {
+          // Exhausted, which is permanent for a Map iterator. Everything it
+          // ever held has been evicted, so start again from the current front —
+          // rare by construction, and the only path that pays the scan.
+          evictionCursor = entries.keys();
+          step = evictionCursor.next();
+          // Nothing left to evict. Unreachable while `size > max >= 0`, but it
+          // is what keeps the loop provably terminating without a `!`.
+          if (step.done === true) break;
+        }
+        entries.delete(step.value);
         evictions += 1;
       }
     },
@@ -419,6 +459,8 @@ export function createFoldCache(
     },
     clear() {
       entries.clear();
+      // The cursor belongs to the emptied map and would report `done` forever.
+      evictionCursor = null;
     },
     size() {
       return entries.size;

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -81,7 +81,10 @@ const VERIFY_OK: Result<void, ReplayRejection> = { ok: true, value: undefined };
 function replayError(
   code: ReplayRejectionCode,
   message: string,
-  detail?: Readonly<{ nodeId?: NodeId; parentId?: NodeId; index?: number }>,
+  // Derived from `ReplayRejection` rather than re-spelled: this used to list
+  // the three fields by hand, so adding `limit`/`actual` to the rejection made
+  // the type that CONSTRUCTS it reject them. One shape, one place.
+  detail?: Omit<ReplayRejection, "code" | "message">,
 ): Result<void, ReplayRejection> {
   return { ok: false, error: { code, message, ...detail } };
 }
@@ -1109,6 +1112,32 @@ function createChildrenOverlay<Ts extends readonly ErasedNodeType[], S>(
     insert: (parentId: NodeId, index: number, id: NodeId): void => {
       mutable(parentId).splice(index, 0, id);
     },
+    /**
+     * By KNOWN index — the fourth O(siblings) operation, and the one the block
+     * comment above missed when it listed the three it had removed.
+     *
+     * `verifyRemoved` proves the exact slot two lines before it removes
+     * (`siblings[index] !== node.id`, against this same overlay), so the
+     * `indexOf` in `remove` below was re-deriving an index the caller already
+     * held. Removal placements are built in ascending document order and
+     * `verifyRemoved` walks them BACKWARD, so each target sat at the tail of a
+     * shrinking array and `indexOf` rescanned it front-to-back: K^2/2, the
+     * exact quadratic `spliceOutMany` fixes on the applying side.
+     *
+     * MEASURED, undo of a bulk insert through `store.undo()`:
+     *     k =  4,000     19.8 ms  ->   1.1 ms
+     *     k =  8,000    134.5 ms  ->   1.9 ms
+     *     k = 16,000    319.4 ms  ->   2.4 ms
+     *     k = 32,000  1,580.3 ms  ->   4.3 ms
+     * Redo, which takes the `insert` path that was already linear, was 17.5 ms
+     * at k = 32,000 throughout — the 90x gap between the two directions is what
+     * said the removal side had been missed.
+     *
+     * For the backward document-order walk this splice is a `pop`.
+     */
+    removeAt: (parentId: NodeId, index: number): void => {
+      mutable(parentId).splice(index, 1);
+    },
     remove: (parentId: NodeId, id: NodeId): void => {
       const current = mutable(parentId);
       const at = current.indexOf(id);
@@ -1215,6 +1244,50 @@ function verifyMoved<Ts extends readonly ErasedNodeType[], S>(
     overlay.insert(move.toParentId, move.toIndex, move.nodeId);
   }
 
+  // Phase 3: no node may become its own ancestor.
+  //
+  // The forward door has this as `isSameOrAncestor` (./commands), and the
+  // replay door had no twin for it. `applyPatch` is documented above as
+  // deliberately re-checking nothing, so there was no second line of defence:
+  // an accepted cyclic move detaches the ring from every root, `serializeGraph`
+  // emits unreachable nodes rather than dropping them, and the saved document
+  // then fails `deserialize` with `unreachable-node` for good.
+  //
+  // AGAINST THE POST-STATE, not the graph. The reachable case is a converging
+  // swap — A moves Y into X while B moves X into Y — and there neither node is
+  // the other's ancestor BEFORE the patch. A check against `graph.parentById`
+  // answers "no cycle" and waves it through. So this walks the parent map the
+  // whole patch would produce, which is also why it runs once at the end
+  // rather than per move: the moves are atomic, and an intermediate state that
+  // rings is fine as long as the result does not.
+  const nextParent = new Map<NodeId, NodeId | null>(graph.parentById);
+  for (const move of moves) nextParent.set(move.nodeId, move.toParentId);
+
+  for (const move of moves) {
+    // Bounded by the map rather than trusted to terminate: a pre-state cycle
+    // would already be an invariant violation, but a verify door that can hang
+    // on a malformed graph is worse than one that refuses it.
+    let steps = 0;
+    let cursor: NodeId | null | undefined = move.toParentId;
+    while (cursor !== null && cursor !== undefined) {
+      if (cursor === move.nodeId) {
+        return replayError(
+          "would-create-cycle",
+          `Moving ${move.nodeId} into ${move.toParentId} would make it its own ancestor.`,
+          { nodeId: move.nodeId, parentId: move.toParentId },
+        );
+      }
+      if (++steps > nextParent.size) {
+        return replayError(
+          "would-create-cycle",
+          `The parent chain above ${move.toParentId} does not terminate.`,
+          { nodeId: move.nodeId, parentId: move.toParentId },
+        );
+      }
+      cursor = nextParent.get(cursor);
+    }
+  }
+
   return VERIFY_OK;
 }
 
@@ -1312,6 +1385,31 @@ function verifyInserted<Ts extends readonly ErasedNodeType[], S>(
   placements: readonly Placement<Ts, S>[],
   ctx: EngineContext<S>,
 ): Result<void, ReplayRejection> {
+  // THE CEILING, before the per-placement work — the same position and the
+  // same reason as ./serialize's, which calls it "the EARLIEST honest point".
+  //
+  // This is the third growth door and it was the one without the check. The
+  // reducer refuses at `would-exceed-max-nodes`, ingress folds
+  // `existingNodeCount` into the same comparison, and replay counted nothing.
+  // `Store.load` does not touch history, so a lazy page can legitimately spend
+  // the headroom a delete just freed while that removal patch sleeps on the
+  // undo stack; undoing it then walked a `maxNodes: 12` graph to 14, 16, 18 —
+  // the "no single call is ever the one that is too big" shape ingress already
+  // closed. The result is a graph the audit calls valid, `serializeGraph`
+  // writes happily, and `deserialize` refuses at that config forever.
+  //
+  // Refusing the undo is the safe direction and matches the other three doors.
+  // Bounding `loadChildren` more tightly instead would make the ceiling depend
+  // on how deep the undo stack happens to be, which is worse.
+  const wouldHold = graph.nodesById.size + placements.length;
+  if (wouldHold > ctx.maxNodes) {
+    return replayError(
+      "would-exceed-max-nodes",
+      `Replaying this insert would take the graph to ${wouldHold} nodes, past the ${ctx.maxNodes} ceiling.`,
+      { limit: ctx.maxNodes, actual: wouldHold },
+    );
+  }
+
   const overlay = createChildrenOverlay(graph);
   const willExist = new Set<NodeId>();
 
@@ -1445,7 +1543,10 @@ function verifyRemoved<Ts extends readonly ErasedNodeType[], S>(
       }
     }
 
-    overlay.remove(parentId, node.id);
+    // BY INDEX — `siblings[index] === node.id` was just proved against this
+    // same overlay, so scanning for the id again is pure re-derivation, and a
+    // quadratic one on the shape this arm exists to serve.
+    overlay.removeAt(parentId, index);
     removed.add(node.id);
   }
 

--- a/packages/keel-core/performance.test.ts
+++ b/packages/keel-core/performance.test.ts
@@ -2046,3 +2046,66 @@ describe("depth", () => {
     });
   }, 180_000);
 });
+
+// ---------------------------------------------------------------------------
+// 12. The axis the suite used to hold constant
+// ---------------------------------------------------------------------------
+//
+// Every cost gate above varies GRAPH SIZE. The one below varies the thing the
+// operation is actually proportional to — the cache LIMIT — and the suite was
+// blind to a live 27x regression until it did, because every fold fixture here
+// either never evicts or uses `createFoldCache(512)`, where the scaling cannot
+// show.
+//
+// It asserts a RATIO rather than a wall-clock budget, for the reason section 10
+// gives: a ratio survives a loaded CI box.
+//
+// THE MISSING SIBLING, written down because the next person will reach for it.
+// `verifyRemoved`'s overlay had the same shape of defect (an `indexOf` making
+// undo of a K-placement patch quadratic, 1,836 ms against 37 ms at k = 32,000),
+// and it has no gate here. A 2K-vs-K growth ratio DOES separate the two
+// implementations — 2.19 quadratic against ~1.0 linear — but only on a registry
+// whose node types declare no content or source key. This file's engine
+// declares both and mints a unique `assetId` per clip, and that per-node index
+// work dominates: the same ratio reads 0.57 on the quadratic code, which passes
+// any threshold that the fixed code also passes. A gate that cannot fail on the
+// defect it names is worse than none, so this one was written, measured,
+// and removed rather than left green. Reinstating it needs its own minimal
+// registry, not a lower threshold.
+describe("cost scales with the work, not with what is nearby", () => {
+  it("evicting from the fold cache costs the same at the default limit as at a small one", () => {
+    // The LRU always deletes from the FRONT, and V8 leaves a tombstone per
+    // delete, so a fresh `entries.keys()` per eviction scans past every one of
+    // them: the cost of ONE eviction scaled with the LIMIT. The default limit
+    // is the worst case, and every existing fold fixture either never evicts or
+    // uses `createFoldCache(512)`, where the scaling is invisible.
+    //
+    // Measured before the fix, 50,000 evictions in every row: 25ms at limit
+    // 1,000 against 682ms at the default. After: 11ms against 26ms.
+    const EVICTIONS = 20_000;
+
+    const cost = (limit: number): number => {
+      const cache = createFoldCache(limit);
+      for (let i = 0; i < limit; i += 1) {
+        cache.set("k", parseNodeId(`fill-${i}`), 0, i);
+      }
+      expect(cache.size()).toBe(limit);
+      const started = performance.now();
+      for (let i = 0; i < EVICTIONS; i += 1) {
+        cache.set("k", parseNodeId(`evict-${i}`), 0, i);
+      }
+      const elapsed = performance.now() - started;
+      // The work is identical in both runs; only the limit differs.
+      expect(cache.stats().evictions).toBe(EVICTIONS);
+      return elapsed;
+    };
+
+    const small = cost(1_000);
+    const atDefault = cost(DEFAULT_FOLD_CACHE_LIMIT);
+
+    // Guard against a clock too coarse to divide by.
+    const ratio = small <= 0 ? 1 : atDefault / small;
+    noteCount("eviction, default vs 1k limit", "cache", EVICTIONS, "ratio", ratio);
+    expect(ratio).toBeLessThan(5);
+  }, 120_000);
+});

--- a/packages/keel-core/review4-the-replay-gate-enforces-what-the-forward-door-does.test.ts
+++ b/packages/keel-core/review4-the-replay-gate-enforces-what-the-forward-door-does.test.ts
@@ -1,0 +1,556 @@
+// Fourth review round — a rule enforced at one door is a habit, not a rule.
+//
+// `applyCommand` is the forward door and it is well guarded. `verifyPatchApplies`
+// is the REPLAY door — undo, redo, and a peer's patch arriving over the wire —
+// and three of the forward door's checks had no twin there. Every serious defect
+// this round found was that one shape, so the tests are grouped by it rather
+// than by module.
+//
+//   forward (commands.ts)                    replay (patches.ts)      was
+//   ---------------------------------------  ----------------------  --------
+//   isSameOrAncestor -> would-create-cycle    verifyMoved             MISSING
+//   nodesById.size + n > maxNodes             verifyInserted          MISSING
+//   ownsItsSubtree (leaf owns nothing)        planEdits re-derived it  WRONG
+//
+// The first is the one that destroys documents, and it needs NO hand-built
+// patch — two ordinary reducer-produced move patches converge into it. Measured
+// before the fix, through the public surface:
+//
+//   A: move Y into X                          -> ok
+//   B: move X into Y (same start document)    -> ok
+//   verifyPatchApplies(B-graph, A-patch)      -> {"ok":true}
+//   applyPatch                                -> root children [], X<->Y cycle
+//   findInvariantViolation                    -> unreachable-node "Y"
+//   serialize                                 -> ok, 5 nodes
+//   deserialize(that wire)                    -> unreachable-node, FOREVER
+//
+// A document that saves without error and can never be opened again. The
+// invariant audit catches it, but nothing on the write path runs the audit, and
+// `applyPatch` is documented (patches.ts:283-289) as deliberately re-checking
+// nothing because verify is supposed to have done it.
+//
+// The cycle check must run against the POST-REMOVAL overlay, not the raw graph:
+// in the converging-swap case neither X nor Y is the other's ancestor in the
+// pre-state, so a check against `graph.parentById` answers "no cycle" and lets
+// it through. That is why this walks the parent map the moves WOULD produce.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+// ---------------------------------------------------------------------------
+// Fixture: a leaf and a container that BOTH declare `sourceKey`, which is what
+// makes the leaf-ownership case reachable at all.
+// ---------------------------------------------------------------------------
+
+type Clip = Readonly<{ title: string; source: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const source = record["source"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof source !== "string") {
+      return { ok: false, error: [{ path: "$.source", message: "source" }] };
+    }
+    return { ok: true, value: { title, source } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+  sourceKey(data) {
+    return data.source;
+  },
+});
+
+type Folder = Readonly<{ name: string; source: string | null }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    const source = record["source"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    if (source !== null && source !== undefined && typeof source !== "string") {
+      return { ok: false, error: [{ path: "$.source", message: "source" }] };
+    }
+    return { ok: true, value: { name, source: (source as string) ?? null } };
+  },
+  serialize(data): unknown {
+    return { name: data.name, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+  sourceKey(data) {
+    return data.source;
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const n = record["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+function makeEngine(maxNodes?: number) {
+  return createEngine<Types, Summary, {}>(
+    maxNodes === undefined
+      ? { types, summary, folds: {} }
+      : { types, summary, folds: {}, maxNodes },
+  );
+}
+
+const rootId = parseNodeId("root");
+
+// ---------------------------------------------------------------------------
+// 1. A move patch that would create a cycle
+// ---------------------------------------------------------------------------
+
+describe("the replay gate refuses a move that would create a cycle", () => {
+  /** root -> [Y(folder,[y1]), X(folder,[x1])]. Two sibling folders. */
+  const twoSiblingFolders = {
+    formatVersion: 1 as const,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      {
+        id: "root",
+        kind: "folder",
+        data: { name: "Root", source: null },
+        children: ["Y", "X"],
+      },
+      {
+        id: "Y",
+        kind: "folder",
+        data: { name: "Y", source: null },
+        children: ["y1"],
+      },
+      { id: "y1", kind: "clip", data: { title: "y1", source: "a1" } },
+      {
+        id: "X",
+        kind: "folder",
+        data: { name: "X", source: null },
+        children: ["x1"],
+      },
+      { id: "x1", kind: "clip", data: { title: "x1", source: "a2" } },
+    ],
+  };
+
+  it("refuses two ordinary reducer patches that converge into a swap", () => {
+    const engine = makeEngine();
+
+    // Peer A moves Y into X. Legal on its own.
+    const a = engine.deserialize(twoSiblingFolders);
+    // ASSERTED, not just guarded: an early return on a refused load would make
+    // this pass vacuously under the very mutation it exists to catch.
+    expect(a.ok).toBe(true);
+    if (!a.ok) return;
+    const storeA = engine.createStore(a.value.graph);
+    const moveA = storeA.dispatch({
+      type: "move-nodes",
+      nodeIds: [parseNodeId("Y")],
+      toParentId: parseNodeId("X"),
+      toIndex: 0,
+    });
+    expect(moveA.ok).toBe(true);
+    if (!moveA.ok) return;
+
+    // Peer B, from the SAME starting document, moves X into Y. Also legal.
+    const b = engine.deserialize(twoSiblingFolders);
+    expect(b.ok).toBe(true);
+    if (!b.ok) return;
+    const storeB = engine.createStore(b.value.graph);
+    const moveB = storeB.dispatch({
+      type: "move-nodes",
+      nodeIds: [parseNodeId("X")],
+      toParentId: parseNodeId("Y"),
+      toIndex: 0,
+    });
+    expect(moveB.ok).toBe(true);
+
+    // B gates A's patch the sanctioned way. Neither node is the other's
+    // ancestor in B's PRE-state, so only a post-removal walk sees the cycle.
+    const verdict = engine.verifyPatchApplies(storeB.getGraph(), moveA.value);
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.error.code).toBe("would-create-cycle");
+  });
+
+  it("refuses a move directly into the moved node's own subtree", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["outer", "spare"],
+        },
+        {
+          id: "outer",
+          kind: "folder",
+          data: { name: "Outer", source: null },
+          children: ["inner"],
+        },
+        {
+          id: "inner",
+          kind: "folder",
+          data: { name: "Inner", source: null },
+          children: [],
+        },
+        {
+          id: "spare",
+          kind: "folder",
+          data: { name: "Spare", source: null },
+          children: [],
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    // Hand-built, because the reducer will not produce this one — which is the
+    // point: the replay door must refuse it without relying on the reducer.
+    const verdict = engine.verifyPatchApplies(loaded.value.graph, {
+      type: "moved",
+      moves: [
+        {
+          nodeId: parseNodeId("outer"),
+          fromParentId: rootId,
+          fromIndex: 0,
+          toParentId: parseNodeId("inner"),
+          toIndex: 0,
+        },
+      ],
+    });
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.error.code).toBe("would-create-cycle");
+  });
+
+  it("still accepts an ordinary move and its own inverse", () => {
+    // The guard must not refuse the legal traffic it sits in front of: a plain
+    // move, then the undo of that move, both through the replay door.
+    const engine = makeEngine();
+    const loaded = engine.deserialize(twoSiblingFolders);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const moved = store.dispatch({
+      type: "move-nodes",
+      nodeIds: [parseNodeId("x1")],
+      toParentId: parseNodeId("Y"),
+      toIndex: 0,
+    });
+    expect(moved.ok).toBe(true);
+    expect(store.undo().ok).toBe(true);
+    expect(store.redo().ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. An insert patch that would breach the node ceiling
+// ---------------------------------------------------------------------------
+
+describe("the replay gate refuses an insert that would breach maxNodes", () => {
+  it("refuses the undo that would grow the graph past the ceiling", () => {
+    // The reachable shape: a lazy load legitimately consumes the headroom a
+    // delete just freed, while the removal patch sleeps on the undo stack.
+    // `store.load` does not touch history, so nothing reconciles the two.
+    const engine = makeEngine(6);
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["lazy", "c1", "c2", "c3", "c4"],
+        },
+        {
+          id: "lazy",
+          kind: "folder",
+          data: { name: "Lazy", source: null },
+          childrenState: "unloaded",
+        },
+        { id: "c1", kind: "clip", data: { title: "c1", source: "s1" } },
+        { id: "c2", kind: "clip", data: { title: "c2", source: "s2" } },
+        { id: "c3", kind: "clip", data: { title: "c3", source: "s3" } },
+        { id: "c4", kind: "clip", data: { title: "c4", source: "s4" } },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+    expect(store.getGraph().nodesById.size).toBe(6);
+
+    // Free two slots.
+    const removed = store.dispatch({
+      type: "remove-nodes",
+      nodeIds: [parseNodeId("c3"), parseNodeId("c4")],
+    });
+    expect(removed.ok).toBe(true);
+    expect(store.getGraph().nodesById.size).toBe(4);
+
+    // Spend them on a lazy page. Legal — this is exactly at the ceiling.
+    const load = store.load(parseNodeId("lazy"), {
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["L1", "L2"],
+      nodes: [
+        { id: "L1", kind: "clip", data: { title: "L1", source: "s5" } },
+        { id: "L2", kind: "clip", data: { title: "L2", source: "s6" } },
+      ],
+    });
+    expect(load.ok).toBe(true);
+    expect(store.getGraph().nodesById.size).toBe(6);
+
+    // The forward door refuses to grow further, correctly.
+    const insert = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "clip", data: { title: "extra", source: "s7" } }],
+    });
+    expect(insert.ok).toBe(false);
+
+    // So must the replay door. Before the fix this returned ok and took the
+    // graph to 8 nodes against a ceiling of 6 — a document that then refuses
+    // to deserialize, permanently, at that config.
+    const undone = store.undo();
+    expect(undone.ok).toBe(false);
+    if (undone.ok) return;
+    expect(undone.error.code).toBe("would-exceed-max-nodes");
+    expect(store.getGraph().nodesById.size).toBe(6);
+
+    // And the document it holds is still loadable, which is the actual point.
+    const roundTrip = engine.deserialize(engine.serialize(store.getGraph()));
+    expect(roundTrip.ok).toBe(true);
+  });
+
+  it("still accepts an undo that fits", () => {
+    const engine = makeEngine(6);
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["c1", "c2"],
+        },
+        { id: "c1", kind: "clip", data: { title: "c1", source: "s1" } },
+        { id: "c2", kind: "clip", data: { title: "c2", source: "s2" } },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    expect(
+      store.dispatch({ type: "remove-nodes", nodeIds: [parseNodeId("c2")] }).ok,
+    ).toBe(true);
+    expect(store.undo().ok).toBe(true);
+    expect(store.getGraph().nodesById.size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. A leaf owns no sourceKey — at the EDIT door too
+// ---------------------------------------------------------------------------
+
+describe("a leaf owns no sourceKey when it is edited", () => {
+  // review3-a-leaf-owns-no-subtree.test.ts fixed three sites and this was the
+  // fourth: `planEdits` spelled the rule out again as
+  // `collection === null || ownsSubtree(collection.children)`, and
+  // `collection === null` IS the leaf case. That is verbatim the predicate
+  // review3 deleted. Both edit doors share `planEdits`, so a server-side
+  // `applyNonUndoableWrite` could not repair it either.
+
+  it("accepts ONE edit-nodes carrying two leaves that share a source", () => {
+    // review3 already covers editing them one at a time. The batch is the
+    // gesture types.ts documents as the reason edits are plural: "a rename
+    // across every placement of an asset is a single `edit-nodes` over all of
+    // them, which is what keeps Ctrl-Z matching what the user thinks they did."
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["c1", "c2"],
+        },
+        { id: "c1", kind: "clip", data: { title: "One", source: "asset-A" } },
+        { id: "c2", kind: "clip", data: { title: "Two", source: "asset-A" } },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(engine.findInvariantViolation(loaded.value.graph)).toBeNull();
+    const store = engine.createStore(loaded.value.graph);
+
+    const edited = store.dispatch({
+      type: "edit-nodes",
+      edits: [
+        { nodeId: parseNodeId("c1"), kind: "clip", edit: { title: "A!" } },
+        { nodeId: parseNodeId("c2"), kind: "clip", edit: { title: "B!" } },
+      ],
+    });
+    expect(edited.ok).toBe(true);
+  });
+
+  it("accepts editing a leaf whose source equals an owning container's", () => {
+    // Strictly worse than the batch case and needs no batch: the container
+    // legitimately OWNS the key, the leaf legitimately does not, and the edit
+    // does not even touch `sourceKey` — `planEdits` re-derives `nextKey` from
+    // `nextData` unconditionally. Before the fix this node could not be edited
+    // through any write door for as long as the container held that key, on a
+    // graph the engine's own audit calls valid.
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["box", "c1"],
+        },
+        {
+          id: "box",
+          kind: "folder",
+          data: { name: "Box", source: "asset-A" },
+          children: ["k1"],
+        },
+        { id: "k1", kind: "clip", data: { title: "k1", source: "other" } },
+        { id: "c1", kind: "clip", data: { title: "One", source: "asset-A" } },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(engine.findInvariantViolation(loaded.value.graph)).toBeNull();
+    // The container is the owner, and that is correct.
+    expect(loaded.value.graph.ownerBySourceKey.get("asset-A")).toBe("box");
+    const store = engine.createStore(loaded.value.graph);
+
+    const edited = store.dispatch({
+      type: "edit-nodes",
+      edits: [
+        { nodeId: parseNodeId("c1"), kind: "clip", edit: { title: "renamed" } },
+      ],
+    });
+    expect(edited.ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+  });
+
+  it("still refuses a CONTAINER edit that would install a second owner", () => {
+    // The rule is real for containers, and relaxing it for leaves must not
+    // relax it here — a second owning container on one key is the incoherent
+    // state the whole mechanism exists to prevent.
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["one", "two"],
+        },
+        {
+          id: "one",
+          kind: "folder",
+          data: { name: "One", source: "asset-A" },
+          children: [],
+        },
+        {
+          id: "two",
+          kind: "folder",
+          data: { name: "Two", source: "asset-B" },
+          children: [],
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    // `applyEdit` on folder only writes `name`, so drive the collision through
+    // a fresh placement instead: a second owning container on "asset-A".
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [
+        {
+          kind: "folder",
+          data: { name: "Three", source: "asset-A" },
+          children: [],
+        },
+      ],
+    });
+    expect(inserted.ok).toBe(false);
+    if (inserted.ok) return;
+    expect(inserted.error.code).toBe("duplicate-owner");
+  });
+});

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -810,6 +810,33 @@ export type ReplayRejectionCode =
    * member of the same name so a consumer handling one handles the other.
    */
   | "duplicate-owner"
+  /**
+   * Replaying this move patch would make a node its own ancestor.
+   *
+   * Mirrors `RejectionCode`'s member of the same name, and needs no exotic
+   * hand-built patch to reach: two ORDINARY reducer-produced moves converge
+   * into it. Peer A moves Y into X and peer B moves X into Y, each legal
+   * against its own graph; A's patch arriving at B closes the ring. Neither
+   * node is the other's ancestor in B's pre-state, so the check that catches
+   * this must run against the post-removal overlay, not `parentById`.
+   *
+   * The cost of not having it: the cycle detaches from every root, and
+   * `serializeGraph` deliberately emits unreachable nodes rather than dropping
+   * them, so the document saves cleanly and `deserialize` then refuses it
+   * forever with `unreachable-node`.
+   */
+  | "would-create-cycle"
+  /**
+   * Replaying this insert patch would take the graph past `maxNodes`.
+   *
+   * Reachable because `Store.load` does not touch history: a lazy page can
+   * legitimately spend the headroom a delete just freed while that removal
+   * patch still sleeps on the undo stack, and undoing it then grows the graph
+   * into a document `deserialize` refuses at the same config. Mirrors
+   * `RejectionCode`'s member of the same name, and carries `limit`/`actual`
+   * for the same reason it does.
+   */
+  | "would-exceed-max-nodes"
   /** The store was destroyed. Every mutating call refuses rather than writing
    *  into a graph nothing is listening to — see `Store.destroy`. */
   | "store-destroyed";
@@ -820,6 +847,12 @@ export type ReplayRejection = Readonly<{
   nodeId?: NodeId;
   parentId?: NodeId;
   index?: number;
+  /** The ceiling that was hit, on `"would-exceed-max-nodes"`. Named the same as
+   *  `Rejection`'s pair so a consumer reporting a limit to the user reads it the
+   *  same way whichever door refused. */
+  limit?: number;
+  /** What the graph WOULD have reached. */
+  actual?: number;
 }>;
 
 export type LoadRejectionCode =


### PR DESCRIPTION
Found by a multi-lens review of `packages/keel-core` (12 lenses, one adversarial refuter per finding; 52 filed, 32 survived). Every serious defect had one shape: **`verifyPatchApplies` does not mirror the checks `applyCommand` makes.** Undo, redo, and a peer's patch off the wire all go through that door.

## The three

**Cycles — `verifyMoved` had no ancestry check** where the reducer has `isSameOrAncestor`. Needs no hand-built patch: peer A moves Y into X, peer B moves X into Y, each legal against its own graph, and A's patch arriving at B closes the ring. Neither node is the other's ancestor in B's *pre*-state, so the check must run against the parent map the moves would produce. Reproduced through the public surface:

```
VERIFY A-patch against B graph -> {"ok":true}
  root children : []
  parent(X)     : Y      parent(Y) : X
  INVARIANT     : {"code":"unreachable-node","nodeId":"Y"}
  serialize     : ok, 5 nodes
  RELOAD        : {"ok":false,"error":{"code":"unreachable-node", ...}}
```

The document detaches from every root, saves cleanly, and can never be opened again. `applyPatch` is documented as deliberately re-checking nothing, so there was no second line of defence.

**The ceiling — `verifyInserted` counted nothing.** `maxNodes` appeared nowhere in the module. `store.load` does not touch history, so a lazy page can spend the headroom a delete just freed while that removal patch sleeps on the undo stack; undoing it walked a `maxNodes: 12` graph to 14, 16, 18. Same "no single call is ever the one that is too big" shape ingress already closed with `existingNodeCount`.

**Leaf ownership — `planEdits` re-derived the rule** as `collection === null || ownsSubtree(...)`, and `collection === null` *is* the leaf case. That is verbatim the predicate review3 deleted, making this a fourth site while the other four delegate to `ownsItsSubtree`. A leaf sharing a `sourceKey` with an owning container was uneditable through both write doors, on a graph `findInvariantViolation` returns null for — so a server write could not repair it either.

## Two costs on the way past

Measured on one box, interleaved (stash / run / unstash / run), not branch-now against main-an-hour-ago:

| | before | after |
|---|---|---|
| undo of a bulk insert, k=32,000 | 1,836 ms | 37 ms |
| fold eviction, 50k evictions at the default limit | 682 ms | 26 ms |

`verifyRemoved` removed from its overlay by `indexOf`, re-deriving an index it had proved two lines earlier, against an array its backward walk kept shrinking: K²/2 — the quadratic `spliceOutMany` already fixes on the applying side. And the LRU always deletes from the *front*, so V8's tombstones accumulate there and a fresh `entries.keys()` per eviction scanned past all of them; the cost scaled with the *limit*, whose default is the worst case. One long-lived cursor fixes it, and a differential over 80,000 randomized ops at caps 1/3/8/64 gives identical surviving order and eviction counts.

## Tests

Eight regression cases in a new `review4-*` file, each proven to fail before its fix, plus three "still accepts" controls that pass throughout. One eviction cost gate in `performance.test.ts` (8.6–11.6× broken, 1.8× fixed, threshold 5).

A ninth gate is deliberately **not** here. A 2K-vs-K growth ratio does separate the undo implementations — 2.19 quadratic against ~1.0 linear — but only on a registry declaring no content or source key. On `performance.test.ts`'s engine, which mints a unique `assetId` per clip, that per-node index work dominates and the same ratio reads 0.57 on the *broken* code: it passes any threshold the fixed code also passes. A gate that cannot fail on the defect it names is worse than none, so it was written, measured, and removed — with the reason and what reinstating it needs left where it would have gone.

## Verification

- `tsc --noEmit` clean (and clean under `--noUnusedLocals` for every touched file)
- keel-core: **674 passing**, up from 665
- full `unit` project across all packages: **1,490 passing**
- `npm run lint`: 0 errors

## Not in this PR

The review found 23 more, none critical: `NaN`/`Infinity` silently disabling `maxNodes`, a re-subscribing node listener looping `commitGraph`, `loadChildrenInto` discarding the `LoadReport` it already builds, `destroy()` not releasing history, and — found by the completeness pass — `clearPast`/`clearFuture`/`clearHistory` being exported but unreachable through `Store`, so a rejected undo deadlocks the stack permanently. Happy to take any of them next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)