### PR TITLE
Two ceilings that took NaN, and a refused undo with no way out

### DIFF
--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -76,6 +76,9 @@ import {
 import {
   canRedo as historyCanRedo,
   canUndo as historyCanUndo,
+  clearFuture as historyClearFuture,
+  clearHistory as historyClearHistory,
+  clearPast as historyClearPast,
   commitRedo,
   commitUndo,
   createHistory,
@@ -323,6 +326,36 @@ export function createEngine<
         `Omit it entirely for unbounded history — a fractional or non-positive value ` +
         `would silently mean unbounded, which is the opposite of what naming a limit asks for.`,
     );
+  }
+
+  // THE SAME ARGUMENT, for the two ceilings that were not making it.
+  //
+  // `historyLimit` refuses a value that would silently mean unbounded. These
+  // two accepted one. `maxNodes: NaN` and `maxNodes: Infinity` both make every
+  // `count > ctx.maxNodes` comparison false, so the ingress trust boundary and
+  // all three growth doors stop refusing anything — and `NaN` arrives for free
+  // from `Number(fromEnv)` or a `parseInt` of a missing setting, which is
+  // exactly how a production ceiling goes missing without a line of code
+  // looking wrong. The failure is silent in the unsafe direction: the consumer
+  // asked to bound the graph and got no bound.
+  //
+  // `maxDepth` takes `null`/omitted as unbounded BY DESIGN — see its doc on
+  // `EngineConfig` — so the check is on values that are present and not null.
+  // Omitting either field stays silent, which is how a consumer asks for the
+  // default and for unbounded respectively.
+  for (const [name, value] of [
+    ["maxNodes", config.maxNodes],
+    ["maxDepth", config.maxDepth],
+  ] as const) {
+    if (value === undefined || value === null) continue;
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new Error(
+        `keel: ${name} must be a positive integer, received ${String(value)}. ` +
+          `NaN and Infinity make every ceiling comparison false, which disables ` +
+          `the limit entirely — the opposite of what naming one asks for. Omit ` +
+          `the field to take the default.`,
+      );
+    }
   }
 
   // A fresh symbol per call is the whole cross-instance guard: `NodeId` is
@@ -1084,6 +1117,55 @@ export function createEngine<
 
       canUndo: () => historyCanUndo(history),
       canRedo: () => historyCanRedo(history),
+
+      // THE HISTORY DOOR. ./history has exported these three since it was
+      // written — `clearPast` documented as "the only recovery for a dormant
+      // entry whose world moved" — and nothing could reach them: `history` is a
+      // closure variable and no accessor returns a `History`. A consumer could
+      // import the pure function and had nothing to pass it.
+      //
+      // What that cost: `undo()` deliberately leaves the stack intact when
+      // replay is refused, so the entry is not destroyed by a transient
+      // failure. But replay is ordered, so a permanently inapplicable entry
+      // buries everything under it, `canUndo()` keeps answering true, and the
+      // only escape was `destroy()` plus a serialize/deserialize round trip
+      // into a fresh store — losing selection and every subscription.
+      //
+      // THEY NOTIFY GRAPH SUBSCRIBERS, which is not the exception to
+      // `SelectionSlice`'s rule that it looks like. There is no history
+      // subscription, so `canUndo`/`canRedo` are re-read by graph subscribers,
+      // and every history change until now HAS notified them because every one
+      // accompanied a commit. These are the first history changes without one;
+      // staying silent would leave the stale enabled button that is the whole
+      // symptom being cleared. A history slice with its own subscription is the
+      // larger, later change — this keeps the existing invariant true.
+      //
+      // No notify when nothing moved: ./history returns the SAME object when
+      // the stack it would clear is already empty, so identity is the test.
+      // A destroyed store is a silent no-op, matching the subscribe methods
+      // rather than the write ones — there is nothing here to refuse, only
+      // state to drop that no one is listening to.
+      clearPast() {
+        if (destroyed) return;
+        const next = historyClearPast(history);
+        if (next === history) return;
+        history = next;
+        notifyAll("graph", graphListeners);
+      },
+      clearFuture() {
+        if (destroyed) return;
+        const next = historyClearFuture(history);
+        if (next === history) return;
+        history = next;
+        notifyAll("graph", graphListeners);
+      },
+      clearHistory() {
+        if (destroyed) return;
+        const next = historyClearHistory(history);
+        if (next === history) return;
+        history = next;
+        notifyAll("graph", graphListeners);
+      },
 
       /**
        * IO landing. No patch, no history entry, NO change-feed event — the

--- a/packages/keel-core/review4-a-refused-undo-must-not-be-a-dead-end.test.ts
+++ b/packages/keel-core/review4-a-refused-undo-must-not-be-a-dead-end.test.ts
@@ -1,0 +1,422 @@
+// Fourth review round — two doors that were open and one that was not there.
+//
+// 1. THE CEILINGS TOOK NaN. `historyLimit` refuses a value that would silently
+//    mean unbounded, and argues for refusing at length. `maxNodes` and
+//    `maxDepth` accepted one. `Number(process.env.MAX_NODES)` on an unset
+//    variable is `NaN`, every `count > NaN` is false, and the ingress trust
+//    boundary plus all three growth doors stop refusing anything — with no line
+//    of code looking wrong.
+//
+// 2. A REFUSED UNDO WAS A DEAD END. `undo()` leaves the stack intact when
+//    replay is refused, deliberately, so a transient failure does not destroy
+//    the entry. But replay is ordered: one permanently inapplicable entry
+//    buries every entry beneath it, and `canUndo()` goes on answering true.
+//    review3-replay-cannot-install-a-duplicate-owner.test.ts already pins that
+//    `canUndo()` stays true after such a refusal — correct in isolation, and
+//    the reason this needed a door.
+//
+//    ./history exported `clearPast` from the start, documented as "the only
+//    recovery for a dormant entry whose world moved". Nothing could reach it:
+//    the engine holds `History` in a closure and no accessor returns one, so a
+//    consumer could import the pure function and had nothing to pass it. The
+//    only escape was `destroy()` plus a serialize/deserialize round trip into a
+//    fresh store, losing selection and every subscription.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+type Clip = Readonly<{ title: string; source: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const source = record["source"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof source !== "string") {
+      return { ok: false, error: [{ path: "$.source", message: "source" }] };
+    }
+    return { ok: true, value: { title, source } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string; source: string | null }>;
+type FolderEdit = Readonly<{ name?: string; source?: string | null }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    const source = record["source"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    if (source !== null && source !== undefined && typeof source !== "string") {
+      return { ok: false, error: [{ path: "$.source", message: "source" }] };
+    }
+    return { ok: true, value: { name, source: (source as string) ?? null } };
+  },
+  serialize(data): unknown {
+    return { name: data.name, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return {
+      ok: true,
+      value: {
+        ...data,
+        name: edit.name ?? data.name,
+        // `source` is editable so the deadlock fixture can hand a freed key to
+        // a live node — the same shape review3 gives its `box` type.
+        source: edit.source === undefined ? data.source : edit.source,
+      },
+    };
+  },
+  sourceKey(data) {
+    return data.source;
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const n = record["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const rootId = parseNodeId("root");
+
+// ---------------------------------------------------------------------------
+// 1. The ceilings refuse a value that would disable them
+// ---------------------------------------------------------------------------
+
+describe("a ceiling that cannot bound anything is refused at construction", () => {
+  // Each of these makes every `count > ceiling` comparison false, which is the
+  // ceiling being absent — and absent in the unsafe direction, since the
+  // consumer asked for a bound and would get none.
+  const disabling = [
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["zero", 0],
+    ["negative", -1],
+    ["fractional", 2.5],
+  ] as const;
+
+  for (const [label, value] of disabling) {
+    it(`refuses maxNodes: ${label}`, () => {
+      expect(() =>
+        createEngine<Types, Summary, {}>({
+          types,
+          summary,
+          folds: {},
+          maxNodes: value,
+        }),
+      ).toThrow(/maxNodes must be a positive integer/);
+    });
+
+    it(`refuses maxDepth: ${label}`, () => {
+      expect(() =>
+        createEngine<Types, Summary, {}>({
+          types,
+          summary,
+          folds: {},
+          maxDepth: value,
+        }),
+      ).toThrow(/maxDepth must be a positive integer/);
+    });
+  }
+
+  it("still accepts an omitted ceiling, and a large named one", () => {
+    // Omitting is how a consumer asks for the default (`maxNodes`) and for
+    // unbounded (`maxDepth`), and that must stay silent.
+    expect(() =>
+      createEngine<Types, Summary, {}>({ types, summary, folds: {} }),
+    ).not.toThrow();
+    // A ceiling ABOVE the default is a legitimate choice — see the `??` comment
+    // on `ctx.maxNodes`, which is deliberately not a `Math.min`.
+    expect(() =>
+      createEngine<Types, Summary, {}>({
+        types,
+        summary,
+        folds: {},
+        maxNodes: 5_000_000,
+        maxDepth: 64,
+      }),
+    ).not.toThrow();
+  });
+
+  it("a named ceiling actually refuses, which is what the guard protects", () => {
+    const engine = createEngine<Types, Summary, {}>({
+      types,
+      summary,
+      folds: {},
+      maxNodes: 2,
+    });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["c1"],
+        },
+        { id: "c1", kind: "clip", data: { title: "One", source: "s1" } },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const insert = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "clip", data: { title: "Two", source: "s2" } }],
+    });
+    expect(insert.ok).toBe(false);
+    if (insert.ok) return;
+    expect(insert.error.code).toBe("would-exceed-max-nodes");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. A refused undo has a way out
+// ---------------------------------------------------------------------------
+
+describe("a permanently refused undo entry can be cleared", () => {
+  /**
+   * The reachable deadlock, built the way review3 builds it: remove the node
+   * that owns a `sourceKey`, then use the NON-undoable write door to hand that
+   * key to a live node. The sleeping removal patch would re-install the original
+   * owner beside the new one, so replay refuses — and will refuse forever,
+   * because nothing about the graph is going to take the key back.
+   */
+  function deadlockedStore() {
+    const engine = createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["x", "z"],
+        },
+        {
+          id: "x",
+          kind: "folder",
+          data: { name: "X", source: "asset-a" },
+          children: [],
+        },
+        {
+          id: "z",
+          kind: "folder",
+          data: { name: "Z", source: null },
+          children: [],
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) throw new Error("fixture failed to load");
+    const store = engine.createStore(loaded.value.graph);
+
+    // An earlier, perfectly good edit sits BENEATH the one that will jam, so
+    // the test can show that it is buried too.
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: parseNodeId("z"), kind: "folder", edit: { name: "Zed" } }],
+      }).ok,
+    ).toBe(true);
+
+    expect(
+      store.dispatch({ type: "remove-nodes", nodeIds: [parseNodeId("x")] }).ok,
+    ).toBe(true);
+
+    // The non-undoable door moves the freed key onto a live node. Legitimate —
+    // nothing owns "asset-a" right now. The sleeping removal patch still does.
+    const written = store.applyNonUndoableWrite([
+      { nodeId: parseNodeId("z"), kind: "folder", edit: { source: "asset-a" } },
+    ]);
+    expect(written.ok).toBe(true);
+
+    return { engine, store };
+  }
+
+  it("the entry is genuinely stuck, and buries the entry beneath it", () => {
+    const { store } = deadlockedStore();
+
+    // Refused, and refused again — this is not a transient condition.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const undone = store.undo();
+      expect(undone.ok).toBe(false);
+      // The stack is deliberately NOT popped, so the button stays enabled.
+      expect(store.canUndo()).toBe(true);
+    }
+  });
+
+  it("clearPast releases it, and the store keeps working", () => {
+    const { engine, store } = deadlockedStore();
+    expect(store.undo().ok).toBe(false);
+    expect(store.canUndo()).toBe(true);
+
+    store.clearPast();
+
+    expect(store.canUndo()).toBe(false);
+    // And the document is untouched — this forgets how it got here, nothing
+    // more. `z` still holds the name the non-undoable write gave it.
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.getGraph().nodesById.has(parseNodeId("z"))).toBe(true);
+
+    // The store is not poisoned: a new command records a new, undoable entry.
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: parseNodeId("z"), kind: "folder", edit: { name: "Z2" } }],
+      }).ok,
+    ).toBe(true);
+    expect(store.canUndo()).toBe(true);
+    expect(store.undo().ok).toBe(true);
+  });
+
+  it("notifies graph subscribers, so a stale enabled button re-renders", () => {
+    // The whole symptom is a Ctrl-Z control that is lit and inert. Clearing the
+    // stack without telling anyone leaves it lit.
+    const { store } = deadlockedStore();
+    expect(store.undo().ok).toBe(false);
+
+    const listener = vi.fn();
+    const unsubscribe = store.subscribeToGraph(listener);
+    store.clearPast();
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("says nothing when there is nothing to clear", () => {
+    const engine = createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: [],
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const listener = vi.fn();
+    store.subscribeToGraph(listener);
+    store.clearPast();
+    store.clearFuture();
+    store.clearHistory();
+    // ./history returns the same object when the stack is already empty, and
+    // identity is what suppresses the notification.
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("clearFuture drops the redo branch and keeps the undo stack", () => {
+    const engine = createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["z"],
+        },
+        {
+          id: "z",
+          kind: "folder",
+          data: { name: "Z", source: null },
+          children: [],
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: parseNodeId("z"), kind: "folder", edit: { name: "Zed" } }],
+      }).ok,
+    ).toBe(true);
+    expect(store.undo().ok).toBe(true);
+    expect(store.canRedo()).toBe(true);
+
+    store.clearFuture();
+    expect(store.canRedo()).toBe(false);
+    expect(store.canUndo()).toBe(false);
+
+    store.clearHistory();
+    expect(store.canUndo()).toBe(false);
+    expect(store.canRedo()).toBe(false);
+  });
+
+  it("is a silent no-op on a destroyed store", () => {
+    const { store } = deadlockedStore();
+    store.destroy();
+    expect(() => {
+      store.clearPast();
+      store.clearFuture();
+      store.clearHistory();
+    }).not.toThrow();
+  });
+});

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1328,6 +1328,29 @@ export type Store<
   redo(): Result<Patch<Ts, S>, ReplayRejection>;
   canUndo(): boolean;
   canRedo(): boolean;
+  /**
+   * Drop the undo stack. THE ONLY RECOVERY from a dormant entry whose world
+   * moved, and until it existed there was none.
+   *
+   * `undo()` deliberately leaves the stack untouched when replay is refused, so
+   * a rejection does not destroy the entry — but entries replay in order, so
+   * one permanently inapplicable entry makes everything beneath it unreachable
+   * too. Reachable through `applyNonUndoableWrite`, which is a NON-undoable
+   * write: it can move a live node onto a `sourceKey` a sleeping patch still
+   * carries, and the replay then refuses with `"duplicate-owner"` forever while
+   * `canUndo()` keeps answering true. The button stays lit and does nothing for
+   * the rest of the session.
+   *
+   * ./history has exported `clearPast` since it was written and documented it
+   * as exactly this recovery; nothing could reach it, because the engine holds
+   * `History` in a closure and no accessor returned one. The pure function is
+   * still there for a consumer composing history values directly.
+   */
+  clearPast(): void;
+  /** Drop the redo branch, keeping the undo stack. */
+  clearFuture(): void;
+  /** Both stacks. The document is untouched — this forgets how it got here. */
+  clearHistory(): void;
   /** The non-undoable content write. Returns the ids whose history was scrubbed. */
   applyNonUndoableWrite(edits: readonly EditOf<Ts>[]): Result<readonly NodeId[], Rejection>;
   /** `unknown` for the reason `Engine.loadChildren` gives: the payload came from


### PR DESCRIPTION
Follow-on to #605, same `keel-core` review.

## The ceilings took NaN

`historyLimit` refuses a value that would silently mean unbounded, and spends a paragraph on why: choosing INFINITY hides a typo *"in the one direction that is unsafe: the consumer asked to bound memory and got no bound."*

`maxNodes` and `maxDepth` sat 25 lines below it accepting exactly that. `maxNodes: NaN` makes every `count > ctx.maxNodes` comparison false, so the ingress trust boundary and all three growth doors stop refusing anything — and `NaN` arrives for free from `Number(process.env.MAX_NODES)` on an unset variable, which is how a production ceiling goes missing with no line of code looking wrong. `Infinity`, `0`, negatives and fractions all land the same way.

Same check, same throw, same reasoning, now applied to all three. Omitting a field stays silent — that is how a consumer asks for the default (`maxNodes`) and for unbounded (`maxDepth`) — and a ceiling *above* the default is still accepted, per the deliberate `??`-not-`Math.min` on `ctx.maxNodes`.

## A refused undo had no way out

`undo()` deliberately leaves the stack intact when replay is refused, so a transient failure does not destroy the entry, and `review3-replay-cannot-install-a-duplicate-owner.test.ts:176` pins that `canUndo()` stays true afterwards. Correct in isolation.

But replay is **ordered**, so a permanently inapplicable entry buries every entry beneath it. Reachable through `applyNonUndoableWrite`, which is non-undoable by design: it can move a live node onto a `sourceKey` a sleeping patch still carries, and the replay then refuses with `duplicate-owner` forever while the Ctrl-Z control stays lit and inert for the rest of the session.

`./history` has exported `clearPast` since it was written, documented as *"the only recovery for a dormant entry whose world moved"*. **Nothing could reach it.** The engine holds `History` in a closure and no accessor returns one, so a consumer could import the pure function and had nothing to pass it; `clearFuture` and `clearHistory` were unreachable the same way. The only escape was `destroy()` plus a serialize/deserialize round trip into a fresh store, losing selection and every subscription.

All three are now on `Store`.

### Why they notify graph subscribers

This looks like a violation of `SelectionSlice`'s "a selection change must never notify graph subscribers" and isn't. There is no history subscription, so `canUndo`/`canRedo` are re-read by graph subscribers — and *every* history change until now has notified them, because every one accompanied a commit. These are the first history changes without one, and staying silent would leave exactly the stale enabled button being cleared. A history slice with its own subscription is the larger, later change; this keeps the existing invariant true.

No notification fires when nothing moved: `./history` returns the *same object* when the stack it would clear is already empty, so identity is the test. A destroyed store is a silent no-op, matching the subscribe methods rather than the write ones — there is nothing to refuse, only state to drop that no one is listening to.

## Tests

18 cases, **15 failing before the fix**. The 3 that pass are controls — one of them asserts the deadlock itself: a refused undo, three times over, with `canUndo()` still true each time.

## Verification

- `tsc --noEmit` clean for `keel-core` and `keel-react` (and clean under `--noUnusedLocals`)
- full `unit` project: **1,508 passing**, up from 1,490
- `npm run lint`: 0 errors (11 pre-existing warnings, untouched files)

`Store` gains three methods. That is additive — `Store` is produced by the engine, never implemented by a consumer — and `keel-react` needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)