### PR TITLE
One notification loop read a live map, and a lazy load threw its report away

### DIFF
--- a/packages/keel-core/commands.fuzz.test.ts
+++ b/packages/keel-core/commands.fuzz.test.ts
@@ -1000,7 +1000,7 @@ describe("fuzz: undo/redo to arbitrary depth", () => {
               );
               if (loaded.ok) {
                 journal.push(`load ${targetId} <- ${payload.nodeCount} node(s) => ok`);
-                graph = loaded.value;
+                graph = loaded.value.graph;
                 expectValid(graph, "post-load graph");
                 // Every shape recorded so far predates these nodes.
                 shapeFloor = shapes.length - 1;
@@ -1300,18 +1300,18 @@ describe("fuzz: four-state children invariants under load / markMissing", () => 
             } else {
               loadsAccepted += 1;
               expect(stateBefore?.status).toBe("unloaded");
-              expect(childrenStateOf(loaded.value, targetId)?.status).toBe("loaded");
-              expect(loaded.value.childrenById.get(targetId)).toEqual(
+              expect(childrenStateOf(loaded.value.graph, targetId)?.status).toBe("loaded");
+              expect(loaded.value.graph.childrenById.get(targetId)).toEqual(
                 payload.document.rootIds,
               );
-              expect(loaded.value.nodesById.size).toBe(
+              expect(loaded.value.graph.nodesById.size).toBe(
                 graph.nodesById.size + payload.nodeCount,
               );
               // Nothing already resident may be displaced by a load.
               for (const id of graph.nodesById.keys()) {
-                expect(loaded.value.nodesById.has(id)).toBe(true);
+                expect(loaded.value.graph.nodesById.has(id)).toBe(true);
               }
-              graph = loaded.value;
+              graph = loaded.value.graph;
             }
           } else {
             // --- structural churn ---------------------------------------------
@@ -1462,7 +1462,7 @@ describe("fuzz: quarantined nodes under structural churn", () => {
           const payload = randomPayload(rand, ids);
           const loaded = loadChildrenInto<Types, Summary>(graph, targetId, payload.document, ctx);
           journal.push(`load ${targetId} => ${loaded.ok ? "ok" : `reject:${loaded.error.code}`}`);
-          if (loaded.ok) graph = loaded.value;
+          if (loaded.ok) graph = loaded.value.graph;
           expectValid(graph, `load ${load}`);
           checkBytes(graph, `load ${load}`);
         }

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -844,7 +844,29 @@ export function createEngine<
       // The rule this loop actually depends on, and the only one to preserve:
       // EVERY MUTATION MOVES THE REVISION OF EVERY NODE IT AFFECTS, including a
       // node it affects by deleting.
-      for (const [id, listeners] of nodeListeners) {
+      // SNAPSHOT, for the reason `notifyAll` copies its set — this was the one
+      // notification loop that read a LIVE collection while calling consumer
+      // code allowed to mutate it, and the map is the half where that does not
+      // merely skip an entry but fails to terminate.
+      //
+      // A listener that re-subscribes to its own id during notification (the
+      // ordinary `useSyncExternalStore` teardown-and-resubscribe, which React
+      // runs whenever the subscribe callback identity changes) unsubscribes
+      // first: the set empties and `subscribeToNode`'s cleanup DELETES the map
+      // entry to keep this loop proportional to what is mounted. Re-subscribing
+      // then re-inserts that id at the END of the map's iteration order, where
+      // the live iterator has not been yet. Its rev still differs across the
+      // commit, so it is notified again, and re-subscribes again. The commit
+      // never finishes and the tab locks up.
+      //
+      // Snapshotting also settles what a subscription created DURING a commit
+      // observes, and settles it the same way the flat sets already do: it was
+      // not subscribed when the change happened, so it is not told about it.
+      //
+      // One array per commit, sized by MOUNTED CARDS rather than by the graph —
+      // the same order this loop already costs, and the inner `[...listeners]`
+      // already pays it per changed node.
+      for (const [id, listeners] of [...nodeListeners]) {
         if (getSubtreeRev(previous, id) === getSubtreeRev(next, id)) continue;
         for (const listener of [...listeners]) notifyOne("node", listener);
       }
@@ -1203,8 +1225,11 @@ export function createEngine<
         }
         const loaded = loadChildrenInto<Ts, S>(graph, id, doc, ctx);
         if (!loaded.ok) return loaded;
-        commitGraph(loaded.value, "load");
-        return { ok: true, value: undefined };
+        commitGraph(loaded.value.graph, "load");
+        // The report is handed BACK rather than swallowed. Quarantine is a
+        // success path, so `ok: true` does not mean the page arrived intact —
+        // see `Store.load`.
+        return { ok: true, value: loaded.value.report };
       },
 
       markMissing(id, reason) {

--- a/packages/keel-core/review4-notification-and-the-report-a-lazy-load-throws-away.test.ts
+++ b/packages/keel-core/review4-notification-and-the-report-a-lazy-load-throws-away.test.ts
@@ -1,0 +1,311 @@
+// Fourth review round — the live collection, and the report nobody got.
+//
+// 1. ONE NOTIFICATION LOOP READ A LIVE COLLECTION. `notifyAll` copies its set
+//    before iterating, and says why: "a listener that unsubscribes itself (the
+//    normal React teardown) mutates the set mid-iteration otherwise." The node
+//    loop in `commitGraph` iterated `nodeListeners` — a MAP — directly. On a
+//    set the consequence is a skipped listener; on this map it is a commit that
+//    never finishes, because `subscribeToNode`'s cleanup DELETES an emptied
+//    entry and re-subscribing re-inserts it at the END of the iteration order,
+//    where the live iterator has not been yet.
+//
+//    The test below is bounded rather than a hang: it stops re-subscribing
+//    after a fixed number of rounds and asserts the count, so a regression
+//    fails the assertion instead of wedging the suite.
+//
+// 2. A LAZY LOAD COMPUTED A REPORT AND DROPPED IT. `buildDocument` produces the
+//    same `LoadReport` `deserialize` returns — nodeCount, quarantined, migrated,
+//    warnings — and `loadChildrenInto` used every other field of its result and
+//    discarded that one, so `Store.load` answered `Result<void>`. Quarantine is
+//    a SUCCESS path, so a page in which every node quarantined was
+//    indistinguishable from a clean one, on the door that runs repeatedly
+//    against a live document rather than once at startup.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+type Clip = Readonly<{ title: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const title = ({ ...raw } as Record<string, unknown>)["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const makeEngine = () =>
+  createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+
+const rootId = parseNodeId("root");
+const clipId = parseNodeId("c1");
+
+function loadedStore() {
+  const engine = makeEngine();
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      {
+        id: "root",
+        kind: "folder",
+        data: { name: "Root" },
+        children: ["c1", "lazy"],
+      },
+      { id: "c1", kind: "clip", data: { title: "One" } },
+      {
+        id: "lazy",
+        kind: "folder",
+        data: { name: "Lazy" },
+        childrenState: "unloaded",
+      },
+    ],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+// ---------------------------------------------------------------------------
+// 1. A listener that re-subscribes during notification
+// ---------------------------------------------------------------------------
+
+describe("notification reads a snapshot, not a live collection", () => {
+  it("a listener that re-subscribes to its own id is notified once", () => {
+    // The ordinary `useSyncExternalStore` teardown-and-resubscribe: React runs
+    // it whenever the subscribe callback identity changes, which for a card
+    // keyed on its own node id is every render it triggers.
+    const { store } = loadedStore();
+
+    let notifications = 0;
+    let unsubscribe = (): void => {};
+    // BOUNDED: without the bound this test does not fail, it hangs — and a
+    // hanging test in CI reads as a timeout, not as this defect.
+    const RESUBSCRIBE_LIMIT = 50;
+
+    const listener = (): void => {
+      notifications += 1;
+      if (notifications > RESUBSCRIBE_LIMIT) return;
+      // Tear down and re-establish, exactly as the React teardown does.
+      unsubscribe();
+      unsubscribe = store.subscribeToNode(clipId, listener);
+    };
+    unsubscribe = store.subscribeToNode(clipId, listener);
+
+    const edited = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipId, kind: "clip", edit: { title: "Two" } }],
+    });
+    expect(edited.ok).toBe(true);
+
+    // ONE commit, one notification. Before the fix the re-inserted map entry
+    // landed behind the live iterator, its rev still differed across the commit,
+    // and the loop kept finding it: 51 here, and unbounded in real code.
+    expect(notifications).toBe(1);
+    unsubscribe();
+  });
+
+  it("a subscription created during a commit is not told about that commit", () => {
+    // The other half of what snapshotting settles, and settled the same way the
+    // flat sets already settle it: the new subscriber was not listening when
+    // the change happened.
+    const { store } = loadedStore();
+    const late = vi.fn();
+
+    const unsubscribeFirst = store.subscribeToNode(clipId, () => {
+      store.subscribeToNode(rootId, late);
+    });
+
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipId, kind: "clip", edit: { title: "Two" } }],
+      }).ok,
+    ).toBe(true);
+
+    expect(late).not.toHaveBeenCalled();
+    unsubscribeFirst();
+  });
+
+  it("still notifies every ordinary subscriber, including one that unsubscribes", () => {
+    // The guard must not cost the traffic it sits in front of.
+    const { store } = loadedStore();
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const dropFirst = store.subscribeToNode(clipId, () => {
+      first();
+      dropFirst();
+    });
+    const dropSecond = store.subscribeToNode(clipId, second);
+
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipId, kind: "clip", edit: { title: "Two" } }],
+      }).ok,
+    ).toBe(true);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    dropSecond();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The lazy load hands back its report
+// ---------------------------------------------------------------------------
+
+describe("a lazy load reports what it quarantined", () => {
+  const lazyId = parseNodeId("lazy");
+
+  it("a clean page reports no quarantine", () => {
+    const { store } = loadedStore();
+    const loaded = store.load(lazyId, {
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["p1", "p2"],
+      nodes: [
+        { id: "p1", kind: "clip", data: { title: "P1" } },
+        { id: "p2", kind: "clip", data: { title: "P2" } },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.value.quarantined).toEqual([]);
+    expect(loaded.value.nodeCount).toBe(2);
+  });
+
+  it("a page where EVERY node quarantined is not reported as clean", () => {
+    // This is the whole defect. `ok: true` is right — quarantine is a success
+    // path, the nodes are in the graph holding their raw bytes — but the
+    // consumer had no way to learn that nothing it asked for is readable.
+    const { store, engine } = loadedStore();
+    const loaded = store.load(lazyId, {
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["b1", "b2"],
+      nodes: [
+        // `title` must be a string; a number fails `parse` and quarantines.
+        { id: "b1", kind: "clip", data: { title: 1 } },
+        { id: "b2", kind: "clip", data: { title: 2 } },
+      ],
+    });
+
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.value.nodeCount).toBe(2);
+    expect(loaded.value.quarantined).toHaveLength(2);
+    expect(loaded.value.quarantined.map((q) => q.nodeId).sort()).toEqual([
+      parseNodeId("b1"),
+      parseNodeId("b2"),
+    ]);
+    for (const failure of loaded.value.quarantined) {
+      expect(failure.reason).toBe("parse-failed");
+    }
+
+    // The graph is still valid and the nodes are still there — quarantine
+    // preserves bytes rather than dropping the subtree.
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.getGraph().nodesById.has(parseNodeId("b1"))).toBe(true);
+  });
+
+  it("the engine door returns the graph and the report together", () => {
+    // Shaped like `deserialize`'s result on purpose: the two are the same
+    // operation against a different destination.
+    const { engine, store } = loadedStore();
+    const loaded = engine.loadChildren(store.getGraph(), lazyId, {
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["p1"],
+      nodes: [{ id: "p1", kind: "clip", data: { title: "P1" } }],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.value.graph.nodesById.has(parseNodeId("p1"))).toBe(true);
+    expect(loaded.value.report.nodeCount).toBe(1);
+    expect(loaded.value.report.quarantined).toEqual([]);
+    expect(engine.findInvariantViolation(loaded.value.graph)).toBeNull();
+  });
+
+  it("a rejected load still rejects, and reports nothing", () => {
+    const { store } = loadedStore();
+    const loaded = store.load(lazyId, {
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["c1"],
+      // `c1` is already resident, so this is an id collision, not a quarantine.
+      nodes: [{ id: "c1", kind: "clip", data: { title: "dup" } }],
+    });
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    expect(loaded.error.code).toBe("id-collision");
+  });
+});

--- a/packages/keel-core/serialize.test.ts
+++ b/packages/keel-core/serialize.test.ts
@@ -1513,7 +1513,7 @@ describe("loadChildrenInto", () => {
   it("fills an unloaded owner and keeps every invariant", () => {
     const ctx = makeCtx();
     const graph = loadSimple(ctx);
-    const next = expectOk(loadChildrenInto<Types, Summary>(graph, id("sub"), simplePayload(), ctx));
+    const next = expectOk(loadChildrenInto<Types, Summary>(graph, id("sub"), simplePayload(), ctx)).graph;
 
     const sub = nodeIn(next, "sub");
     if (sub.quarantined || !sub.container) throw new Error("expected a collection");
@@ -1537,7 +1537,7 @@ describe("loadChildrenInto", () => {
     // re-render an ancestor's rollup.
     const ctx = makeCtx();
     const graph = loadSimple(ctx);
-    const next = expectOk(loadChildrenInto<Types, Summary>(graph, id("sub"), simplePayload(), ctx));
+    const next = expectOk(loadChildrenInto<Types, Summary>(graph, id("sub"), simplePayload(), ctx)).graph;
     expect(next.subtreeRevById.get(id("sub"))).toBe(1);
     expect(next.subtreeRevById.get(id("root"))).toBe(1);
     expect(next.subtreeRevById.get(id("a"))).toBe(0);
@@ -1554,7 +1554,7 @@ describe("loadChildrenInto", () => {
         payload([{ id: "p1", kind: "clip", data: { name: "P1", asset: null } }], ["p1"]),
         ctx,
       ),
-    );
+    ).graph;
     expect(next.childrenById.get(id("sub"))).toEqual([id("p1")]);
   });
 
@@ -1571,7 +1571,7 @@ describe("loadChildrenInto", () => {
         payload([{ id: "n", kind: "note", data: { body: "lazy" } }], ["n"]),
         ctx,
       ),
-    );
+    ).graph;
     expect(migrationLog).toEqual([2, 3]);
     const note = nodeIn(next, "n");
     if (note.quarantined) throw new Error("note should not have quarantined");
@@ -1587,7 +1587,7 @@ describe("loadChildrenInto", () => {
         payload([{ id: "bad", kind: "clip", data: { name: 1 } }], ["bad"]),
         ctx,
       ),
-    );
+    ).graph;
     const node = nodeIn(next, "bad");
     if (!node.quarantined) throw new Error("expected quarantine");
     expect(node.reason).toBe("parse-failed");
@@ -1618,7 +1618,7 @@ describe("loadChildrenInto", () => {
         payload([{ id: "p1", kind: "clip", data: { name: "P1", asset: null } }], ["p1"]),
         ctx,
       ),
-    );
+    ).graph;
     const q = nodeIn(next, "q");
     if (!q.quarantined) throw new Error("expected the node to stay quarantined");
     expect(q.children).toEqual({ status: "loaded" });
@@ -1769,7 +1769,7 @@ describe("loadChildrenInto", () => {
     const ctx = makeCtx();
     const next = expectOk(
       loadChildrenInto<Types, Summary>(loadSimple(ctx), id("sub"), simplePayload(), ctx),
-    );
+    ).graph;
     const wire = serializeGraph(next, ctx);
     expect(wireNode(wire, "sub").children).toEqual(["p1", "p2"]);
     expect(wire.nodes).toHaveLength(5);
@@ -1970,7 +1970,7 @@ describe("the size bound across lazy loads", () => {
     const graph = loadSimple(ctx);
     const next = expectOk(
       loadChildrenInto<Types, Summary>(graph, id("sub"), clips("p", 2), ctx),
-    );
+    ).graph;
     expect(next.nodesById.size).toBe(BASE_NODES + 2);
     expect(findInvariantViolation(next, ctx.registry)).toBeNull();
   });

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -1454,7 +1454,10 @@ export function loadChildrenInto<Ts extends readonly ErasedNodeType[], S>(
   id: NodeId,
   doc: unknown,
   ctx: EngineContext<S>,
-): Result<Graph<Ts, S>, LoadRejection> {
+): Result<
+  Readonly<{ graph: Graph<Ts, S>; report: LoadReport }>,
+  LoadRejection
+> {
   if (graph.engineId !== ctx.engineId) {
     return loadRejection({
       code: "foreign-graph",
@@ -1606,9 +1609,25 @@ export function loadChildrenInto<Ts extends readonly ErasedNodeType[], S>(
     });
   }
 
+  // THE REPORT IS RETURNED, not recomputed and not dropped.
+  //
+  // `buildDocument` has always produced one — the same one `deserialize`
+  // returns — and this door threw it away, so `Store.load` answered
+  // `Result<void>` and a lazy page in which EVERY node quarantined was
+  // indistinguishable from a clean one. The consumer's own retry, telemetry and
+  // "some items could not be read" affordances all hang off `report.quarantined`
+  // on the eager door and had nothing to hang off here, on the door that runs
+  // repeatedly against a live document rather than once at startup.
+  //
+  // Shaped like `deserialize`'s `{ graph, report }` deliberately: the two are
+  // the same operation against a different destination, and a consumer handling
+  // one should not have to learn a second shape for the other.
   return {
     ok: true,
-    value: { ...base, ...rebuildDerivedIndexes(base, ctx.registry) },
+    value: {
+      graph: { ...base, ...rebuildDerivedIndexes(base, ctx.registry) },
+      report: payload.report,
+    },
   };
 }
 

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1355,8 +1355,15 @@ export type Store<
   applyNonUndoableWrite(edits: readonly EditOf<Ts>[]): Result<readonly NodeId[], Rejection>;
   /** `unknown` for the reason `Engine.loadChildren` gives: the payload came from
    *  IO and is re-validated here, so the signature must not vouch for it. Pass a
-   *  `SerializedDocument`; a structural failure returns `"malformed-document"`. */
-  load(id: NodeId, doc: unknown): Result<void, LoadRejection>;
+   *  `SerializedDocument`; a structural failure returns `"malformed-document"`.
+   *
+   *  Returns the `LoadReport`, because `ok: true` is not the same as "every node
+   *  arrived intact" — quarantine is a success path. This used to be
+   *  `Result<void>` while the report was computed and discarded one call below,
+   *  so a page in which every single node quarantined looked exactly like a
+   *  clean one. Check `report.quarantined` before telling the user the folder
+   *  loaded. */
+  load(id: NodeId, doc: unknown): Result<LoadReport, LoadRejection>;
   markMissing(id: NodeId, reason: string): void;
   /** `undefined` when the node is gone — routine in React, where a card can
    *  outlive its node by a frame. */
@@ -1601,7 +1608,15 @@ export type Engine<
     graph: Graph<Ts, S>,
     id: NodeId,
     doc: unknown,
-  ): Result<Graph<Ts, S>, LoadRejection>;
+  ): Result<
+    // Shaped like `deserialize`'s result, and for the same reason it has one:
+    // quarantine is a SUCCESS path, so `ok: true` alone does not mean every
+    // node arrived intact. This door used to return the bare graph and drop the
+    // report `buildDocument` had already computed, which made a lazy page where
+    // every node quarantined indistinguishable from a clean one.
+    Readonly<{ graph: Graph<Ts, S>; report: LoadReport }>,
+    LoadRejection
+  >;
   markMissing(graph: Graph<Ts, S>, id: NodeId, reason: string): Graph<Ts, S>;
   /**
    * THE NON-UNDOABLE CONTENT WRITE — the door no competing design had, and the


### PR DESCRIPTION
Third from the `keel-core` review, after #605 and #606. Two consumer-facing doors, both quiet.

## The live map

`notifyAll` copies its set before iterating and says why — *"a listener that unsubscribes itself (the normal React teardown) mutates the set mid-iteration otherwise."* The node loop in `commitGraph` was the one notification path that didn't; it iterated `nodeListeners` directly.

On a set that costs a skipped listener. On this map it is **a commit that never finishes**. `subscribeToNode`'s cleanup deletes an emptied entry — deliberately, to keep the loop proportional to what's mounted — and re-subscribing re-inserts that id at the *end* of the map's iteration order, where the live iterator hasn't been yet. Its rev still differs across the commit, so it's notified again, and re-subscribes again.

That's the ordinary `useSyncExternalStore` teardown-and-resubscribe, which React runs whenever the subscribe callback identity changes — for a card keyed on its own node id, every render it triggers. Measured with a bound in place: **51 notifications for one commit**, unbounded without one.

Snapshotting also settles what a subscription created *during* a commit observes, and settles it the way the flat sets already do: it wasn't subscribed when the change happened, so it isn't told. Cost is one array per commit sized by mounted cards — the order this loop already had, and the inner `[...listeners]` already pays it per changed node.

## The discarded report

`buildDocument` produces the same `LoadReport` `deserialize` returns. `loadChildrenInto` used every other field of its result and dropped that one, so `Store.load` answered `Result<void>`.

Quarantine is a **success** path. So a lazy page in which *every* node quarantined was indistinguishable from a clean one — on the door that runs repeatedly against a live document rather than once at startup, and the door whose consumer's retry, telemetry and "some items could not be read" affordances all hang off `report.quarantined`.

`loadChildrenInto` and `Engine.loadChildren` now return `{ graph, report }`, shaped like `deserialize`'s result because the two are the same operation against a different destination. `Store.load` returns the report. Call sites in `serialize.test.ts` and `commands.fuzz.test.ts` updated to `.graph`.

## What I did not do, and why

A throwing consumer `contentKey`/`sourceKey` still escapes the `Result`-typed ingress and mutation doors while every sibling node-type hook is wrapped. **Two comments in this package disagree about it**, and both are right:

- `graph.ts:406-409` argues at length against swallowing the throw into `null`, because that silently disables the single-owner rule.
- `review3-a-throwing-node-type-cannot-escape-as-an-exception.test.ts` states that a throwing node type must not escape as an exception from a door promising a `Result` — naming `dispatch` and `verifyPatchApplies` specifically.

The option satisfying both is neither: catch and convert to a **refusal**. That is not a small change — `contentKeyOf`/`sourceKeyOf` have 14 call sites across four modules, most inside index-rebuild loops that return plain values on hot paths (`walkDerivedIndexes`, `rebuildDerivedIndexes`, `findInvariantViolation`). It deserves its own change and its own argument rather than riding along on this one. Happy to take it next if you want it.

## Tests

7 cases. The notification test is **bounded rather than a hang** — it stops re-subscribing after 50 rounds and asserts the count, so a regression fails an assertion instead of wedging CI as a timeout. Verified failing before the fix at `expected 51 to be 1`. The `LoadReport` cases could not compile before it.

## Verification

- `tsc --noEmit` clean for `keel-core` and `keel-react` (and under `--noUnusedLocals`)
- keel-core: **699 passing**, up from 691
- full `unit` project: **1,515 passing**, up from 1,508
- `npm run lint`: 0 errors (11 pre-existing warnings, untouched files)

`Engine.loadChildren` and `Store.load` change shape. Both are produced by the engine, never implemented by a consumer, and `keel-react` needed no change — but this is the first return-type change in the three PRs, so worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)