### PR TITLE
The last two consumer hooks that could still throw

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -46,6 +46,8 @@ import {
 } from "./types";
 import {
   dataChangeLeavesDerivedIndexesIntact,
+  KeyHookFailure,
+  keyHookMessage,
   ownsItsSubtree,
   ancestorChain,
   bumpSubtreeRevs,
@@ -1260,7 +1262,7 @@ function applyEditNodes<Ts extends readonly ErasedNodeType[], S>(
  * post-commit veto corrupts redo, because the push has already cleared the redo
  * branch and the following undo pushes the refused command onto it.
  */
-export function applyCommand<Ts extends readonly ErasedNodeType[], S>(
+function applyCommandUnguarded<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   command: Command<Ts, S>,
   ctx: EngineContext<S>,
@@ -1464,7 +1466,7 @@ function resolveInsertDrop<Ts extends readonly ErasedNodeType[], S>(
  * O(historyLimit x changes) — bounded only when a consumer SET a
  * `historyLimit`, which is not the default. See `EngineConfig.historyLimit`.
  */
-export function applyNonUndoableWriteEdits<Ts extends readonly ErasedNodeType[], S>(
+function applyNonUndoableWriteEditsUnguarded<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   history: History<Ts, S>,
   edits: readonly EditOf<Ts>[],
@@ -1583,4 +1585,70 @@ export function applyNonUndoableWriteEdits<Ts extends readonly ErasedNodeType[],
     history: scrubHistoryForWrite(history, replacements),
     scrubbed,
   });
+}
+
+// ---------------------------------------------------------------------------
+// The key-hook guard
+// ---------------------------------------------------------------------------
+
+/**
+ * `contentKey` / `sourceKey` are the two consumer hooks this module reads
+ * without a wrapper of their own, because ./graph deliberately refuses to
+ * swallow their throw into `null` — see the block comment above `contentKeyOf`.
+ * `null` means "no key", and a node type that threw has not said that.
+ *
+ * So it arrives here as `KeyHookFailure` and becomes a REFUSAL, which is what
+ * both halves of this file's header promise: "Nothing here throws; every
+ * failure is Result-shaped", and "nothing is ever partially applied". Measured
+ * before the guard: a throwing `contentKey` escaped `dispatch` for edit, insert
+ * AND remove, which is precisely the failure review3 describes — "an unhandled
+ * exception out of a React event handler, at every call site that correctly
+ * wrote `if (!result.ok)`".
+ *
+ * `instanceof` the private tag, never a bare `catch`. A bare catch would report
+ * a bug inside this engine as the consumer's fault and hide it behind a
+ * rejection the consumer cannot act on; anything that is not the tag still
+ * crashes loudly.
+ */
+function guardKeyHooks<T>(run: () => Result<T, Rejection>): Result<T, Rejection> {
+  try {
+    return run();
+  } catch (thrown) {
+    if (thrown instanceof KeyHookFailure) {
+      return fail("node-type-threw", keyHookMessage(thrown), {
+        kind: thrown.kind,
+        ...(thrown.nodeId === null ? {} : { nodeIds: [thrown.nodeId] }),
+      });
+    }
+    throw thrown;
+  }
+}
+
+export function applyCommand<Ts extends readonly ErasedNodeType[], S>(
+  graph: Graph<Ts, S>,
+  command: Command<Ts, S>,
+  ctx: EngineContext<S>,
+): Result<Readonly<{ graph: Graph<Ts, S>; patch: Patch<Ts, S> }>, Rejection> {
+  return guardKeyHooks(() => applyCommandUnguarded<Ts, S>(graph, command, ctx));
+}
+
+export function applyNonUndoableWriteEdits<
+  Ts extends readonly ErasedNodeType[],
+  S,
+>(
+  graph: Graph<Ts, S>,
+  history: History<Ts, S>,
+  edits: readonly EditOf<Ts>[],
+  ctx: EngineContext<S>,
+): Result<
+  Readonly<{
+    graph: Graph<Ts, S>;
+    history: History<Ts, S>;
+    scrubbed: readonly NodeId[];
+  }>,
+  Rejection
+> {
+  return guardKeyHooks(() =>
+    applyNonUndoableWriteEditsUnguarded<Ts, S>(graph, history, edits, ctx),
+  );
 }

--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -49,6 +49,8 @@ import {
   findInvariantViolation as findInvariantViolationIn,
   getNode,
   getSubtreeRev,
+  KeyHookFailure,
+  keyHookMessage,
   markMissing as markMissingIn,
 } from "./graph";
 import {
@@ -764,6 +766,37 @@ export function createEngine<
       }
     };
 
+    /**
+     * `applyPatch` returns a `Graph`, not a `Result`, and is documented as
+     * deliberately re-checking nothing because verify ran first. But verify does
+     * NOT read the two key hooks on every path `applyPatch` does — measured, a
+     * throwing `contentKey` cleared `verifyPatchApplies` and then threw out of
+     * `applyPatch`, so `undo()` broke its own `Result` contract even after the
+     * verify door was guarded.
+     *
+     * `instanceof` the private tag, like every other guard here.
+     */
+    const applyReplayPatch = (
+      from: Graph<Ts, S>,
+      patch: Patch<Ts, S>,
+    ): Result<Graph<Ts, S>, ReplayRejection> => {
+      try {
+        return { ok: true, value: applyPatchTo(from, patch, ctx) };
+      } catch (thrown) {
+        if (thrown instanceof KeyHookFailure) {
+          return {
+            ok: false,
+            error: {
+              code: "node-type-threw",
+              message: keyHookMessage(thrown),
+              ...(thrown.nodeId === null ? {} : { nodeId: thrown.nodeId }),
+            },
+          };
+        }
+        throw thrown;
+      }
+    };
+
     const notifyAll = (
       label: string,
       listeners: ReadonlySet<() => void>,
@@ -1075,10 +1108,20 @@ export function createEngine<
         if (committed === null) {
           return { ok: false, error: nothingToReplay("undo") };
         }
+        // APPLIED BEFORE THE STACK MOVES, and that order is the fix rather than
+        // a detail. `history = committed.history` used to run first, so an
+        // `applyPatch` that threw left the entry CONSUMED and the graph
+        // untouched: the change is gone, and so is the record of how to make
+        // it. Computing the next graph first makes the whole call atomic —
+        // either the stack moves and the graph moves with it, or neither does
+        // and the entry is still there to retry.
+        const applied = applyReplayPatch(graph, inverse);
+        if (!applied.ok) return applied;
+
         history = committed.history;
 
         const at = ctx.now();
-        commitGraph(applyPatchTo(graph, inverse, ctx), "undo");
+        commitGraph(applied.value, "undo");
         emitChange({
           patch: inverse,
           source: "undo",
@@ -1124,10 +1167,14 @@ export function createEngine<
         if (committed === null) {
           return { ok: false, error: nothingToReplay("redo") };
         }
+        // Applied before the stack moves, for the reason `undo` gives.
+        const applied = applyReplayPatch(graph, forward);
+        if (!applied.ok) return applied;
+
         history = committed.history;
 
         const at = ctx.now();
-        commitGraph(applyPatchTo(graph, forward, ctx), "redo");
+        commitGraph(applied.value, "redo");
         emitChange({
           patch: forward,
           source: "redo",

--- a/packages/keel-core/graph.ts
+++ b/packages/keel-core/graph.ts
@@ -35,6 +35,7 @@ import type {
   ErasedNodeType,
   Violation,
 } from "./types";
+import { describeThrown } from "./types";
 
 // ---------------------------------------------------------------------------
 // Shared empties
@@ -403,11 +404,75 @@ export function documentOrder<Ts extends readonly ErasedNodeType[], S>(
 // `Data` to read something that failed to become `Data`. A node whose content
 // could not be understood has no content identity.
 //
-// Neither wraps the call in try/catch. A throwing `contentKey` is a
-// consumer bug, and swallowing it into `null` would silently disable the
-// single-owner rule — the invariant that stops two placements from both
-// claiming one stored subtree, which is the condition the predecessor's server
-// had to answer with a 409 because nothing upstream enforced it.
+// Neither swallows the call into `null`, and that part of the original
+// decision stands: swallowing would silently disable the single-owner rule —
+// the invariant that stops two placements from both claiming one stored
+// subtree, which is the condition the predecessor's server had to answer with
+// a 409 because nothing upstream enforced it. `null` means "this node has no
+// key", and a node type that threw has not said that.
+//
+// But letting the throw travel RAW was the other half of a choice with only
+// two options in it, and it is the half review3 already ruled out for every
+// other consumer hook: "dispatch promises a `Result`. A node type that throws
+// ... turned that into an unhandled exception out of a React event handler, at
+// every call site that correctly wrote `if (!result.ok)`." Measured before this
+// change, one throwing `contentKey`:
+//
+//   deserialize                     THREW
+//   dispatch (edit / insert / remove)  THREW
+//   undo, through verifyPatchApplies   THREW
+//   store.load                      THREW
+//   findInvariantViolation          THREW
+//   serializeGraph                  survived (it does not read these keys)
+//
+// Seven of eight doors, five of them promising a `Result` and one promising to
+// be total.
+//
+// THE THIRD OPTION: refuse. The consumer's throw is caught here and re-thrown
+// as `KeyHookFailure`, a private tag no consumer can construct, and each
+// Result-typed door catches THAT TAG ONLY and turns it into a rejection naming
+// the node and the hook. Nothing is swallowed, nothing silently loses a key,
+// and — because the catch is `instanceof` a private class rather than a bare
+// `catch` around a door — a genuine bug inside this engine still crashes
+// loudly instead of being reported as a consumer's fault.
+
+/**
+ * A consumer `contentKey`/`sourceKey` threw.
+ *
+ * PRIVATE BY CONSTRUCTION: not exported from ./index, so a consumer cannot
+ * construct one and a door catching it cannot be spoofed into reporting an
+ * engine bug as a node-type failure.
+ */
+export class KeyHookFailure extends Error {
+  readonly kind: string;
+  readonly hook: "contentKey" | "sourceKey";
+  readonly nodeId: NodeId | null;
+  readonly cause: unknown;
+
+  constructor(
+    kind: string,
+    hook: "contentKey" | "sourceKey",
+    nodeId: NodeId | null,
+    cause: unknown,
+  ) {
+    super(
+      `keel: ${JSON.stringify(kind)}.${hook} threw` +
+        (nodeId === null ? "" : ` for node ${JSON.stringify(nodeId)}`) +
+        `. ${describeThrown(cause)}`,
+    );
+    this.name = "KeyHookFailure";
+    this.kind = kind;
+    this.hook = hook;
+    this.nodeId = nodeId;
+    this.cause = cause;
+  }
+}
+
+/** The rejection message every door reports this failure with, so the consumer
+ *  reads the same sentence whichever door refused. */
+export function keyHookMessage(failure: KeyHookFailure): string {
+  return failure.message;
+}
 
 export function contentKeyOf<Ts extends readonly ErasedNodeType[], S>(
   registry: NodeTypeRegistry,
@@ -416,7 +481,11 @@ export function contentKeyOf<Ts extends readonly ErasedNodeType[], S>(
   if (node.quarantined) return null;
   const nodeType = registry.get(node.kind);
   if (nodeType === undefined || nodeType.contentKey === undefined) return null;
-  return nodeType.contentKey(node.data);
+  try {
+    return nodeType.contentKey(node.data);
+  } catch (thrown) {
+    throw new KeyHookFailure(node.kind, "contentKey", node.id, thrown);
+  }
 }
 
 export function sourceKeyOf<Ts extends readonly ErasedNodeType[], S>(
@@ -424,7 +493,7 @@ export function sourceKeyOf<Ts extends readonly ErasedNodeType[], S>(
   node: GraphNode<Ts, S>,
 ): string | null {
   if (node.quarantined) return null;
-  return sourceKeyOfKindData(registry, node.kind, node.data);
+  return sourceKeyOfKindData(registry, node.kind, node.data, node.id);
 }
 
 /**
@@ -443,10 +512,17 @@ export function sourceKeyOfKindData(
   registry: NodeTypeRegistry,
   kind: string,
   data: unknown,
+  /** Only for the failure message — this overload exists precisely for a caller
+   *  holding a value no node holds yet, so there may be no id to name. */
+  nodeId: NodeId | null = null,
 ): string | null {
   const nodeType = registry.get(kind);
   if (nodeType === undefined || nodeType.sourceKey === undefined) return null;
-  return nodeType.sourceKey(data);
+  try {
+    return nodeType.sourceKey(data);
+  } catch (thrown) {
+    throw new KeyHookFailure(kind, "sourceKey", nodeId, thrown);
+  }
 }
 
 /**
@@ -1281,10 +1357,31 @@ export function dataChangeLeavesDerivedIndexesIntact(
 ): boolean {
   const nodeType = registry.get(kind);
   if (nodeType === undefined) return true;
-  if (nodeType.contentKey !== undefined && nodeType.contentKey(before) !== nodeType.contentKey(after)) {
+  // TAGGED like the two key accessors above, because these are the same two
+  // consumer hooks and this was the ONE place that called them directly rather
+  // than through `contentKeyOf`/`sourceKeyOfKindData`. That is exactly why it
+  // was still leaking after those were wrapped: measured, a throwing
+  // `contentKey` reached here from `applyPatch` and escaped BOTH `dispatch` and
+  // `undo` — the two doors review3 names — while every other door was already
+  // refusing cleanly.
+  //
+  // No `nodeId`: this predicate is handed a kind and two data values by a
+  // caller comparing a `data-changed` patch, and the node it belongs to is not
+  // in scope. The kind and the hook name are what the consumer needs.
+  const compare = (
+    hook: "contentKey" | "sourceKey",
+    read: (data: unknown) => string | null,
+  ): boolean => {
+    try {
+      return read(before) === read(after);
+    } catch (thrown) {
+      throw new KeyHookFailure(kind, hook, null, thrown);
+    }
+  };
+  if (nodeType.contentKey !== undefined && !compare("contentKey", nodeType.contentKey)) {
     return false;
   }
-  if (nodeType.sourceKey !== undefined && nodeType.sourceKey(before) !== nodeType.sourceKey(after)) {
+  if (nodeType.sourceKey !== undefined && !compare("sourceKey", nodeType.sourceKey)) {
     return false;
   }
   return true;
@@ -1382,7 +1479,7 @@ export function markMissing<Ts extends readonly ErasedNodeType[], S>(
  * by the reachability walk's re-visit guard, which in a graph that passed 2 and
  * 4 is unreachable, and which exists to TERMINATE rather than to detect.
  */
-export function findInvariantViolation<Ts extends readonly ErasedNodeType[], S>(
+function findInvariantViolationUnguarded<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   registry: NodeTypeRegistry,
 ): Violation | null {
@@ -1665,4 +1762,38 @@ function findStaleDerivedIndex<Ts extends readonly ErasedNodeType[], S>(
   }
 
   return null;
+}
+
+/**
+ * The audit, guarded.
+ *
+ * It returns `Violation | null` rather than a `Result`, so the guard has a
+ * different job here than at the mutation doors: this function is a
+ * DIAGNOSTIC, and a diagnostic that crashes on the graph it was asked to
+ * inspect is the least useful failure available. Checks 8 and 9 read the
+ * consumer's key hooks over every node, so a throwing hook took out the one
+ * tool a consumer has for asking "is my document sound?" — including inside a
+ * dev-check, where it turned an advisory into a crash.
+ *
+ * Reported AS a violation, not swallowed: the graph genuinely cannot be audited
+ * while a node type refuses to answer for one of its nodes, and saying so with
+ * the node's id is the honest answer. `instanceof` the private tag, so a real
+ * bug in the audit still surfaces as itself.
+ */
+export function findInvariantViolation<Ts extends readonly ErasedNodeType[], S>(
+  graph: Graph<Ts, S>,
+  registry: NodeTypeRegistry,
+): Violation | null {
+  try {
+    return findInvariantViolationUnguarded<Ts, S>(graph, registry);
+  } catch (thrown) {
+    if (thrown instanceof KeyHookFailure) {
+      return {
+        code: "node-type-threw",
+        message: keyHookMessage(thrown),
+        ...(thrown.nodeId === null ? {} : { nodeId: thrown.nodeId }),
+      };
+    }
+    throw thrown;
+  }
 }

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -61,6 +61,8 @@ import {
   ownsItsSubtree,
   sourceKeyOf,
   sourceKeyOfKindData,
+  KeyHookFailure,
+  keyHookMessage,
   bumpSubtreeRevsInto,
   dataChangeLeavesDerivedIndexesIntact,
   derivedIndexNeed,
@@ -1160,7 +1162,7 @@ function createChildrenOverlay<Ts extends readonly ErasedNodeType[], S>(
  * naming the recorded node; kind agreement; `before` still matching on the
  * SERIALIZED form; and that a node about to be un-inserted is childless.
  */
-export function verifyPatchApplies<Ts extends readonly ErasedNodeType[], S>(
+function verifyPatchAppliesUnguarded<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   patch: Patch<Ts, S>,
   ctx: EngineContext<S>,
@@ -1865,5 +1867,32 @@ export function scrubPatchForWrite<Ts extends readonly ErasedNodeType[], S>(
         ? { type: "inserted", placements: next }
         : { type: "removed", placements: next };
     }
+  }
+}
+
+/**
+ * The key-hook guard, for the same reason ./commands has one and with the same
+ * `instanceof` discipline — see `guardKeyHooks` there.
+ *
+ * This door in particular: undo runs the consumer's key hooks to prove a
+ * recorded `before` still stands, so a throwing `contentKey` took out undo
+ * exactly the way it took out `dispatch`. review3 names both by name.
+ */
+export function verifyPatchApplies<Ts extends readonly ErasedNodeType[], S>(
+  graph: Graph<Ts, S>,
+  patch: Patch<Ts, S>,
+  ctx: EngineContext<S>,
+): Result<void, ReplayRejection> {
+  try {
+    return verifyPatchAppliesUnguarded<Ts, S>(graph, patch, ctx);
+  } catch (thrown) {
+    if (thrown instanceof KeyHookFailure) {
+      return replayError(
+        "node-type-threw",
+        keyHookMessage(thrown),
+        thrown.nodeId === null ? undefined : { nodeId: thrown.nodeId },
+      );
+    }
+    throw thrown;
   }
 }

--- a/packages/keel-core/review4-a-throwing-key-hook-cannot-escape-either.test.ts
+++ b/packages/keel-core/review4-a-throwing-key-hook-cannot-escape-either.test.ts
@@ -1,0 +1,371 @@
+// Fourth review round — the last two consumer hooks that could still throw.
+//
+// review3 established the rule and wrapped every consumer hook it found:
+// "dispatch promises a `Result`. A node type that throws while the reducer
+// round-trips its own output turned that into an unhandled exception out of a
+// React event handler, at every call site that correctly wrote
+// `if (!result.ok)`." It named `verifyPatchApplies` for the same reason and
+// `serializeGraph` for being documented TOTAL.
+//
+// `contentKey` and `sourceKey` were left out, and NOT by oversight — ./graph
+// argues the case in prose: swallowing a throwing key hook into `null` would
+// silently disable the single-owner rule, because `null` means "this node has
+// no key" and a node type that threw has not said that.
+//
+// Both comments are right, and between them they had assumed the only two
+// options were `null` and a raw throw. Measured before this change:
+//
+//                                     contentKey   sourceKey
+//   deserialize                        THREW        THREW
+//   dispatch (edit / insert / remove)  THREW        returned
+//   undo                               THREW        returned
+//   store.load                         THREW        THREW
+//   findInvariantViolation             THREW        THREW
+//   serializeGraph                     returned     returned
+//
+// Seven of eight doors for `contentKey`, five of them promising a `Result`.
+//
+// THE THIRD OPTION IS REFUSAL. The throw is caught at the hook, re-thrown as a
+// private `KeyHookFailure` tag, and each door converts THAT TAG ONLY into its
+// own rejection shape. Nothing is swallowed, no key is silently lost, and a
+// genuine bug inside the engine still crashes as itself rather than being
+// reported as the consumer's fault.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+/** Which hook detonates. Flipped per test; the throw is realistic — a key
+ *  function meeting a shape it did not expect, not a synthetic panic. */
+const explode = { contentKey: false, sourceKey: false };
+
+function resetExplosions(): void {
+  explode.contentKey = false;
+  explode.sourceKey = false;
+}
+
+type Clip = Readonly<{ title: string; asset: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const asset = record["asset"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    if (typeof asset !== "string") {
+      return { ok: false, error: [{ path: "$.asset", message: "asset" }] };
+    }
+    return { ok: true, value: { title, asset } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, asset: data.asset };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+  contentKey(data) {
+    if (explode.contentKey) throw new Error("contentKey exploded");
+    return data.asset;
+  },
+});
+
+type Folder = Readonly<{ name: string; source: string | null }>;
+type FolderEdit = Readonly<{ name?: string; source?: string | null }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const name = record["name"];
+    const source = record["source"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    if (source !== null && source !== undefined && typeof source !== "string") {
+      return { ok: false, error: [{ path: "$.source", message: "source" }] };
+    }
+    return { ok: true, value: { name, source: (source as string) ?? null } };
+  },
+  serialize(data): unknown {
+    return { name: data.name, source: data.source };
+  },
+  applyEdit(data, edit) {
+    return {
+      ok: true,
+      value: {
+        ...data,
+        name: edit.name ?? data.name,
+        source: edit.source === undefined ? data.source : edit.source,
+      },
+    };
+  },
+  sourceKey(data) {
+    if (explode.sourceKey) throw new Error("sourceKey exploded");
+    return data.source;
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const makeEngine = () =>
+  createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+
+const rootId = parseNodeId("root");
+const clipId = parseNodeId("c1");
+const lazyId = parseNodeId("lazy");
+
+const doc = {
+  formatVersion: 1 as const,
+  schemaVersions: { clip: 1, folder: 1 },
+  rootIds: ["root"],
+  nodes: [
+    {
+      id: "root",
+      kind: "folder",
+      data: { name: "Root", source: null },
+      children: ["box", "c1", "lazy"],
+    },
+    {
+      id: "box",
+      kind: "folder",
+      data: { name: "Box", source: "s-a" },
+      children: [],
+    },
+    { id: "c1", kind: "clip", data: { title: "One", asset: "a-1" } },
+    {
+      id: "lazy",
+      kind: "folder",
+      data: { name: "Lazy", source: null },
+      childrenState: "unloaded" as const,
+    },
+  ],
+};
+
+/** A live store built with both hooks behaving. */
+function calmStore() {
+  resetExplosions();
+  const engine = makeEngine();
+  const loaded = engine.deserialize(doc);
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+const HOOKS = ["contentKey", "sourceKey"] as const;
+
+describe("a throwing contentKey/sourceKey refuses rather than escaping", () => {
+  for (const hook of HOOKS) {
+    describe(`${hook} throws`, () => {
+      it("deserialize refuses", () => {
+        resetExplosions();
+        const engine = makeEngine();
+        explode[hook] = true;
+        const loaded = engine.deserialize(doc);
+        resetExplosions();
+        expect(loaded.ok).toBe(false);
+        if (loaded.ok) return;
+        expect(loaded.error.code).toBe("node-type-threw");
+        // The message names the kind and the hook, so the consumer can find it.
+        expect(loaded.error.message).toContain(hook);
+      });
+
+      it("dispatch refuses, for an edit, an insert and a removal", () => {
+        for (const command of [
+          {
+            type: "edit-nodes" as const,
+            edits: [
+              { nodeId: clipId, kind: "clip" as const, edit: { title: "Two" } },
+            ],
+          },
+          {
+            type: "insert-nodes" as const,
+            toParentId: rootId,
+            toIndex: 0,
+            seeds: [
+              { kind: "clip" as const, data: { title: "N", asset: "a-9" } },
+            ],
+          },
+          { type: "remove-nodes" as const, nodeIds: [clipId] },
+        ]) {
+          const { store } = calmStore();
+          explode[hook] = true;
+          const result = store.dispatch(command);
+          resetExplosions();
+          // Some commands do not consult a given key hook at all, and that is
+          // fine — what must never happen is a THROW out of a door that
+          // promises a `Result`. Reaching this line at all is the assertion.
+          if (!result.ok) {
+            expect(result.error.code).toBe("node-type-threw");
+          }
+        }
+      });
+
+      it("undo refuses, and does not eat the entry", () => {
+        const { store } = calmStore();
+        expect(
+          store.dispatch({
+            type: "edit-nodes",
+            edits: [{ nodeId: clipId, kind: "clip", edit: { title: "Two" } }],
+          }).ok,
+        ).toBe(true);
+
+        explode[hook] = true;
+        const undone = store.undo();
+        const stillThere = store.canUndo();
+        resetExplosions();
+
+        if (!undone.ok) {
+          expect(undone.error.code).toBe("node-type-threw");
+          // THE ORDERING. `history` used to advance before `applyPatch` ran, so
+          // a throw there consumed the entry and left the graph untouched — the
+          // change gone AND the record of how to make it gone. Applying first
+          // makes the call atomic: refused means nothing moved.
+          expect(stillThere).toBe(true);
+          // And the entry is still replayable once the consumer's bug is fixed.
+          expect(store.undo().ok).toBe(true);
+        }
+      });
+
+      it("store.load refuses", () => {
+        const { store } = calmStore();
+        explode[hook] = true;
+        const loaded = store.load(lazyId, {
+          formatVersion: 1,
+          schemaVersions: { clip: 1, folder: 1 },
+          rootIds: ["p1"],
+          nodes: [{ id: "p1", kind: "clip", data: { title: "P", asset: "a-2" } }],
+        });
+        resetExplosions();
+        if (!loaded.ok) {
+          expect(loaded.error.code).toBe("node-type-threw");
+        }
+      });
+
+      it("findInvariantViolation reports it instead of crashing", () => {
+        // The audit returns `Violation | null`, not a `Result`, so the guard has
+        // a different job: a diagnostic that crashes on the graph it was asked
+        // to inspect is the least useful failure available.
+        const { engine, store } = calmStore();
+        explode[hook] = true;
+        const violation = engine.findInvariantViolation(store.getGraph());
+        resetExplosions();
+        expect(violation).not.toBeNull();
+        expect(violation?.code).toBe("node-type-threw");
+      });
+
+      it("serializeGraph stays total", () => {
+        // It was already total for these two — it does not read them — and the
+        // guard must not change that. A save path that throws loses the
+        // document.
+        const { engine, store } = calmStore();
+        explode[hook] = true;
+        expect(() => engine.serialize(store.getGraph())).not.toThrow();
+        resetExplosions();
+      });
+    });
+  }
+
+  it("a genuine engine bug is NOT reported as a node-type failure", () => {
+    // The guards catch `instanceof KeyHookFailure` and nothing else, on purpose:
+    // a bare `catch` around these doors would blame the consumer for the
+    // engine's mistakes and bury them behind a rejection nobody can act on.
+    // A node type throwing from a DIFFERENT hook must still surface as itself.
+    resetExplosions();
+    const exploding = defineNodeType<Clip, ClipEdit>()({
+      kind: "clip",
+      container: false,
+      schemaVersion: 1,
+      parse: clipType.parse,
+      serialize(): unknown {
+        throw new Error("serialize exploded");
+      },
+      applyEdit: clipType.applyEdit,
+    });
+    const engine = createEngine<
+      readonly [typeof exploding, typeof folderType],
+      Summary,
+      {}
+    >({ types: [exploding, folderType] as const, summary, folds: {} });
+    // A CONTAINER root — `deserialize` requires one, which is why this fixture
+    // cannot just be the leaf on its own.
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "Root", source: null },
+          children: ["c1"],
+        },
+        { id: "c1", kind: "clip", data: { title: "One", asset: "a" } },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    // `serialize` has its OWN guard (review3) which degrades rather than
+    // refusing, so this must not come back as `node-type-threw`.
+    expect(() => engine.serialize(loaded.value.graph)).not.toThrow();
+  });
+
+  it("both hooks behaving is completely unaffected", () => {
+    // The whole guard must be invisible on the happy path.
+    resetExplosions();
+    const { engine, store } = calmStore();
+    expect(
+      store.dispatch({
+        type: "edit-nodes",
+        edits: [{ nodeId: clipId, kind: "clip", edit: { title: "Two" } }],
+      }).ok,
+    ).toBe(true);
+    expect(store.undo().ok).toBe(true);
+    expect(store.redo().ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(
+      store.load(lazyId, {
+        formatVersion: 1,
+        schemaVersions: { clip: 1, folder: 1 },
+        rootIds: ["p1"],
+        nodes: [{ id: "p1", kind: "clip", data: { title: "P", asset: "a-2" } }],
+      }).ok,
+    ).toBe(true);
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -72,6 +72,8 @@ import {
   getNode,
   rebuildDerivedIndexes,
   sourceKeyOf,
+  KeyHookFailure,
+  keyHookMessage,
 } from "./graph";
 
 // ---------------------------------------------------------------------------
@@ -1215,7 +1217,7 @@ function findDuplicateOwner<Ts extends readonly ErasedNodeType[], S>(
  * `StructuralError`; per-node content failures quarantine by default, keeping
  * id, position, children and byte-exact `raw`.
  */
-export function deserializeDocument<Ts extends readonly ErasedNodeType[], S>(
+function deserializeDocumentUnguarded<Ts extends readonly ErasedNodeType[], S>(
   raw: unknown,
   ctx: EngineContext<S>,
 ): Result<
@@ -1449,7 +1451,7 @@ function loadRejection(error: LoadRejection): Result<never, LoadRejection> {
  * what makes `verifyPatchApplies` cheap and dormant history sound: a node that
  * existed when a patch was recorded still exists when it replays.
  */
-export function loadChildrenInto<Ts extends readonly ErasedNodeType[], S>(
+function loadChildrenIntoUnguarded<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,
   id: NodeId,
   doc: unknown,
@@ -1666,4 +1668,67 @@ function withLoadedChildren<Ts extends readonly ErasedNodeType[], S>(
   // Unreachable: the caller established a non-null ChildrenState, which a leaf
   // never has.
   return node;
+}
+
+// ---------------------------------------------------------------------------
+// The key-hook guard
+// ---------------------------------------------------------------------------
+//
+// The two ingress doors, guarded for the reason ./commands and ./patches are —
+// see `guardKeyHooks` there. These two are the ones a HOSTILE payload reaches:
+// both run the consumer's key hooks over the merged graph to find a duplicate
+// owner, so a node type that throws on some shape of data turned a refusable
+// document into a thrown load. Measured before the guard, a throwing
+// `contentKey` OR `sourceKey` escaped both.
+//
+// `instanceof` the private tag, never a bare `catch`: a bare catch here would
+// turn every genuine bug in this module into "malformed-document" and blame the
+// payload for the engine's mistake, on the one door whose whole job is telling
+// those two apart.
+
+export function deserializeDocument<Ts extends readonly ErasedNodeType[], S>(
+  raw: unknown,
+  ctx: EngineContext<S>,
+): Result<
+  Readonly<{ graph: Graph<Ts, S>; report: LoadReport }>,
+  StructuralError
+> {
+  try {
+    return deserializeDocumentUnguarded<Ts, S>(raw, ctx);
+  } catch (thrown) {
+    if (thrown instanceof KeyHookFailure) {
+      return {
+        ok: false,
+        error: {
+          code: "node-type-threw",
+          message: keyHookMessage(thrown),
+          ...(thrown.nodeId === null ? {} : { nodeId: thrown.nodeId }),
+        },
+      };
+    }
+    throw thrown;
+  }
+}
+
+export function loadChildrenInto<Ts extends readonly ErasedNodeType[], S>(
+  graph: Graph<Ts, S>,
+  id: NodeId,
+  doc: unknown,
+  ctx: EngineContext<S>,
+): Result<
+  Readonly<{ graph: Graph<Ts, S>; report: LoadReport }>,
+  LoadRejection
+> {
+  try {
+    return loadChildrenIntoUnguarded<Ts, S>(graph, id, doc, ctx);
+  } catch (thrown) {
+    if (thrown instanceof KeyHookFailure) {
+      return loadRejection({
+        code: "node-type-threw",
+        message: keyHookMessage(thrown),
+        nodeId: thrown.nodeId ?? id,
+      });
+    }
+    throw thrown;
+  }
 }

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -734,6 +734,15 @@ export type RejectionCode =
   | "edit-rejected"
   /** A seed's data failed its own `parse`. See `issues`. */
   | "parse-failed"
+  /**
+   * A consumer `contentKey`/`sourceKey` threw.
+   *
+   * NOT swallowed into `null` — that would silently disable the single-owner
+   * rule — and no longer allowed to travel raw out of a door that promises a
+   * `Result`. Named identically on every rejection family for the reason
+   * `duplicate-owner` is: a consumer handling one handles them all.
+   */
+  | "node-type-threw"
   | "leaf-seed-with-children"
   /**
    * A gesture that would push the graph past `EngineConfig.maxNodes` or
@@ -826,6 +835,8 @@ export type ReplayRejectionCode =
    * forever with `unreachable-node`.
    */
   | "would-create-cycle"
+  /** A consumer `contentKey`/`sourceKey` threw. See `RejectionCode`. */
+  | "node-type-threw"
   /**
    * Replaying this insert patch would take the graph past `maxNodes`.
    *
@@ -864,6 +875,8 @@ export type LoadRejectionCode =
   | "target-not-unloaded"
   /** The incoming document reuses an id the host graph already holds. */
   | "id-collision"
+  /** A consumer `contentKey`/`sourceKey` threw. See `RejectionCode`. */
+  | "node-type-threw"
   | "malformed-document"
   /** The store was destroyed. Every mutating call refuses rather than writing
    *  into a graph nothing is listening to — see `Store.destroy`. */
@@ -902,7 +915,9 @@ export type StructuralErrorCode =
   /** More nodes than `EngineConfig.maxNodes`. See `DEFAULT_MAX_NODES`. */
   | "document-too-large"
   /** Nested deeper than `EngineConfig.maxDepth`, which is opt-in. */
-  | "document-too-deep";
+  | "document-too-deep"
+  /** A consumer `contentKey`/`sourceKey` threw. See `RejectionCode`. */
+  | "node-type-threw";
 
 export type StructuralError = Readonly<{
   code: StructuralErrorCode;
@@ -951,7 +966,10 @@ export type ViolationCode =
   | "missing-parent-entry"
   | "missing-subtree-rev"
   | "duplicate-owner"
-  | "derived-index-stale";
+  | "derived-index-stale"
+  /** A consumer `contentKey`/`sourceKey` threw while the audit read it. See
+   *  `RejectionCode`. */
+  | "node-type-threw";
 
 export type Violation = Readonly<{
   code: ViolationCode;


### PR DESCRIPTION
Fourth from the `keel-core` review, after #605, #606 and #607. This is the one I stopped on last time and said deserved its own argument.

## The tension, and the option neither side considered

review3 established the rule and wrapped every consumer hook it found — *"dispatch promises a `Result`. A node type that throws … turned that into an unhandled exception out of a React event handler, at every call site that correctly wrote `if (!result.ok)`."*

`contentKey` and `sourceKey` were left out, and **not by oversight**. `graph.ts` argues the case in prose: swallowing a throwing key hook into `null` would silently disable the single-owner rule, because `null` means *"this node has no key"* and a node type that threw has not said that.

Both comments are right. Between them they had assumed the only two options were `null` and a raw throw. Measured before this change:

| door | `contentKey` | `sourceKey` |
|---|---|---|
| `deserialize` | **THREW** | **THREW** |
| `dispatch` (edit / insert / remove) | **THREW** | returned |
| `undo` | **THREW** | returned |
| `store.load` | **THREW** | **THREW** |
| `findInvariantViolation` | **THREW** | **THREW** |
| `serializeGraph` | returned | returned |

Seven of eight doors for `contentKey`, five of them promising a `Result` and one promising to be total.

**The third option is refusal.** The throw is caught at the hook and re-thrown as `KeyHookFailure` — a private tag no consumer can construct — and each door converts *that tag only* into its own rejection shape. `node-type-threw` is named identically on all five rejection families, for the reason `duplicate-owner` already is.

Nothing is swallowed, no key is silently lost, and because every catch is `instanceof` a private class rather than a bare catch around a door, **a genuine bug inside the engine still crashes as itself** instead of being reported as the consumer's fault. There's a test for exactly that.

The audit is the one exception: it returns `Violation | null`, not a `Result`, so it reports the failure *as a violation*. A diagnostic that crashes on the graph it was asked to inspect is the least useful failure available.

## Two things the measurement found that reading could not

**`dataChangeLeavesDerivedIndexesIntact` calls both hooks directly** rather than through `contentKeyOf`/`sourceKeyOfKindData` — the only site that does. So it kept leaking after the accessors were wrapped, and it's reached from `applyPatch`, which is precisely why `dispatch` and `undo` were the two doors still failing when everything else was already refusing cleanly.

**`applyPatch` isn't a `Result`**, so `undo` needed a guard at its own level — and that surfaced an ordering bug underneath it. `history = committed.history` ran *before* `applyPatchTo`, so a throw there left the entry **consumed** and the graph untouched: the change gone, and the record of how to make it gone with it. The patch is now applied first and the stack moves only on success, so the call is atomic — refused means nothing moved, and the entry is still there to retry. Same for `redo`.

That ordering was filed in the original review and **refuted** by a verifier on the grounds that verify would catch it first. The measurement says otherwise: verify does not read these hooks on every path `applyPatch` does.

## Tests

14 cases, **8 failing before the guards** with the raw consumer error escaping. The 6 that pass are controls — the happy path, `serializeGraph` staying total, and one asserting a node type throwing from a *different* hook is still not reported as `node-type-threw`.

## Verification

- `tsc --noEmit` clean for `keel-core` and `keel-react` (and under `--noUnusedLocals`)
- keel-core: **713 passing**, up from 699
- full `unit` project: **1,529 passing**, up from 1,515
- `npm run lint`: 0 errors (11 pre-existing warnings, untouched files)

Five rejection enums gain one member each. Additive, and any consumer already handling an unknown code keeps working — but a consumer with an exhaustive `switch` over `RejectionCode` will now get a compile error, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)