### PR TITLE
Four comments that assert a check, audited against the code

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -1315,8 +1315,25 @@ function applyCommandUnguarded<Ts extends readonly ErasedNodeType[], S>(
  * shift its indices. Re-deriving this arithmetic anywhere else is how the
  * predecessor came to silently append on cut+paste.
  *
- * It runs the same validity checks as the command it produces, so an illegal
- * gesture is refused while it is still a gesture.
+ * IT RUNS THE STRUCTURAL CHECKS, NOT THE BUDGETS, and the distinction matters
+ * because an earlier version of this line claimed both: "It runs the same
+ * validity checks as the command it produces, so an illegal gesture is refused
+ * while it is still a gesture." The first half is what it does — unknown node,
+ * unknown parent, not-a-container, target-not-loaded, cycle, root moves — and
+ * those really are refused while the drag is still a drag.
+ *
+ * The CEILINGS are not among them. Measured, `maxNodes: 3` on a 3-node graph:
+ *
+ *   resolveDrop(insert intent)   -> ok
+ *   dispatch(that command)       -> would-exceed-max-nodes
+ *
+ * So a drop that cannot commit still reads as a legal drop target, and the
+ * refusal arrives one step later than the sentence above promised. That is a
+ * gap in the gesture layer rather than a correctness bug — the command door
+ * still refuses, nothing is written, and `maxNodes` is a trust boundary whose
+ * job is bounding the graph, not shaping a drag. Closing it means teaching this
+ * function the budgets, which is a deliberate UX change and not a comment fix;
+ * until someone makes that call, this says what is true.
  */
 export function resolveDrop<Ts extends readonly ErasedNodeType[], S>(
   graph: Graph<Ts, S>,

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -1086,6 +1086,22 @@ function createChildrenOverlay<Ts extends readonly ErasedNodeType[], S>(
   // the inverted patch inserts at 0, 1, 2, ... into an emptied array — every
   // one of those splices is an APPEND, so the pass becomes linear rather than
   // merely cheaper.
+  //
+  // WHICH ARM IS WHICH, because this comment listed `indexOf` among the costs
+  // it had removed while `indexOf` was still running, and that reading cost a
+  // later round a second look at an already-"fixed" quadratic:
+  //
+  //   removed  ->  `removeAt`, by the index `verifyRemoved` just proved. LINEAR.
+  //   inserted ->  `insert`, appending into an emptied array.        LINEAR.
+  //   moved    ->  `remove`, which still SCANS with `indexOf`.
+  //
+  // The move arm is deliberate, not missed. Its `fromIndex` is a PRE-state
+  // index checked against the untouched graph (see `verifyMoved`), so it is not
+  // an index into the overlay and cannot be spliced by. Making that arm linear
+  // means grouping by source parent and doing one filtering pass each, mirroring
+  // `spliceOutMany` — worth doing if a patch is ever measured moving thousands
+  // of nodes out of ONE parent, which no gesture produces today: a multi-select
+  // drag is bounded by what is on screen, where a select-all delete is not.
   const owned = new Map<NodeId, NodeId[]>();
   const read = (id: NodeId): readonly NodeId[] => {
     const local = owned.get(id);

--- a/packages/keel-core/review4-comments-that-assert-a-check-must-be-true.test.ts
+++ b/packages/keel-core/review4-comments-that-assert-a-check-must-be-true.test.ts
@@ -1,0 +1,259 @@
+// Fourth review round — the prose is load-bearing, so a false line in it is a
+// defect.
+//
+// This package documents WHY, records the measurement behind each decision, and
+// names the rejected alternative. A reader is meant to be able to trust it, and
+// review3 already caught this exact failure mode once:
+// review3-consumers-go-through-the-accessors.test.ts opens on "comments
+// describing checks that did not exist, three of which caused the bug beneath
+// them."
+//
+// Three more were found by auditing every comment that asserts a CHECK or a
+// BOUND against the code. Two were false and one was stale; a fourth candidate
+// turned out to be TRUE and was left alone (see the note at the end).
+//
+// The tests below pin the ACTUAL behaviour, so the corrected comments cannot
+// drift back: if someone makes `deadRevById` disjoint, or teaches `resolveDrop`
+// the budgets, these fail and point at the prose that has to change with it.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+import { getSubtreeRev } from "./graph";
+
+type Clip = Readonly<{ title: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const title = ({ ...raw } as Record<string, unknown>)["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const rootId = parseNodeId("root");
+const c1 = parseNodeId("c1");
+
+function twoClips(maxNodes?: number) {
+  const engine = createEngine<Types, Summary, {}>(
+    maxNodes === undefined
+      ? { types, summary, folds: {} }
+      : { types, summary, folds: {}, maxNodes },
+  );
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { clip: 1, folder: 1 },
+    rootIds: ["root"],
+    nodes: [
+      { id: "root", kind: "folder", data: { name: "R" }, children: ["c1", "c2"] },
+      { id: "c1", kind: "clip", data: { title: "One" } },
+      { id: "c2", kind: "clip", data: { title: "Two" } },
+    ],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+// ---------------------------------------------------------------------------
+// 1. deadRevById is NOT disjoint, and no check says otherwise
+// ---------------------------------------------------------------------------
+
+describe("the tombstone store overlaps the live one, inertly", () => {
+  it("a removed id that comes back is in BOTH maps", () => {
+    // The comment on `Graph.deadRevById` used to say "an id is live or dead,
+    // never both", and cite invariant check 6 as asserting it. Check 6 requires
+    // every LIVE node to have a rev and never reads `deadRevById`; the overlap
+    // needs nothing more exotic than remove-then-undo.
+    const { store } = twoClips();
+
+    expect(store.dispatch({ type: "remove-nodes", nodeIds: [c1] }).ok).toBe(true);
+    const removed = store.getGraph();
+    expect(removed.subtreeRevById.has(c1)).toBe(false);
+    expect(removed.deadRevById.has(c1)).toBe(true);
+
+    expect(store.undo().ok).toBe(true);
+    const restored = store.getGraph();
+    expect(restored.subtreeRevById.has(c1)).toBe(true);
+    // THE OVERLAP. Asserted, not merely observed — the tombstone is left in
+    // place on purpose, because `applyInserted` seeds the returning id ABOVE it
+    // and that is what the high-water rule requires.
+    expect(restored.deadRevById.has(c1)).toBe(true);
+  });
+
+  it("and the live entry always wins, which is what makes it inert", () => {
+    const { store } = twoClips();
+    expect(store.dispatch({ type: "remove-nodes", nodeIds: [c1] }).ok).toBe(true);
+    const tombstone = store.getGraph().deadRevById.get(c1);
+    expect(tombstone).toBeDefined();
+
+    expect(store.undo().ok).toBe(true);
+    const restored = store.getGraph();
+    // `getSubtreeRev` reads the live map first and only falls through for an id
+    // with no live entry, so the stale dead number can never be the answer for
+    // a node that is back.
+    expect(getSubtreeRev(restored, c1)).toBe(restored.subtreeRevById.get(c1));
+    // And the live rev sits at or above the tombstone, never below it — walking
+    // a returning id back down is the fold-cache poisoning `applyRemoved`
+    // documents.
+    expect(getSubtreeRev(restored, c1)).toBeGreaterThanOrEqual(tombstone ?? 0);
+  });
+
+  it("the audit is satisfied throughout, because it does not police this map", () => {
+    const { engine, store } = twoClips();
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.dispatch({ type: "remove-nodes", nodeIds: [c1] }).ok).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.undo().ok).toBe(true);
+    // Overlapping, and valid. If a future check DOES start policing
+    // `deadRevById`, this is the line that will notice.
+    expect(store.getGraph().deadRevById.has(c1)).toBe(true);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. resolveDrop runs the structural checks, not the budgets
+// ---------------------------------------------------------------------------
+
+describe("resolveDrop refuses the illegal gesture but not the unaffordable one", () => {
+  it("refuses a structurally illegal drop while it is still a gesture", () => {
+    // This half of the docblock is true and worth pinning beside the half that
+    // was not: dropping a container into its own subtree is refused here, not
+    // one dispatch later.
+    const engine = createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: ["outer"] },
+        {
+          id: "outer",
+          kind: "folder",
+          data: { name: "O" },
+          children: ["inner"],
+        },
+        { id: "inner", kind: "folder", data: { name: "I" }, children: [] },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const resolved = store.resolveDrop({
+      type: "move",
+      nodeIds: [parseNodeId("outer")],
+      toParentId: parseNodeId("inner"),
+      toIndexBefore: 0,
+    });
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) return;
+    expect(resolved.error.code).toBe("would-create-cycle");
+  });
+
+  it("accepts a drop the ceiling will refuse one step later", () => {
+    // The half that was false. `maxNodes: 3` on a 3-node graph: the gesture
+    // reads as legal and the command it produced is then refused.
+    const { store } = twoClips(3);
+    expect(store.getGraph().nodesById.size).toBe(3);
+
+    const resolved = store.resolveDrop({
+      type: "insert",
+      toParentId: rootId,
+      toIndexBefore: 0,
+      seeds: [{ kind: "clip", data: { title: "N" } }],
+    });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+
+    const dispatched = store.dispatch(resolved.value);
+    expect(dispatched.ok).toBe(false);
+    if (dispatched.ok) return;
+    expect(dispatched.error.code).toBe("would-exceed-max-nodes");
+
+    // Nothing was written, which is why this is a gesture-layer gap and not a
+    // correctness bug: the command door still refused.
+    expect(store.getGraph().nodesById.size).toBe(3);
+  });
+});
+
+// A FOURTH CANDIDATE, CHECKED AND LEFT ALONE. `documentOrderComparator` claims
+// the pathological bucket — one content key in every collection — "costs the
+// same order as the rebuild it replaces. It is never worse than the rebuild,
+// and for every realistic bucket it is not close." Measured against the walk it
+// replaces, on exactly that shape:
+//
+//     collections x width      comparator     rebuild     ratio
+//       40 x 40   (1,641)         0.04 ms     0.27 ms      0.15
+//       80 x 80   (6,481)         0.03 ms     0.54 ms      0.06
+//      160 x 160 (25,761)         0.04 ms     2.41 ms      0.02
+//
+// Six to fifty times FASTER, and pulling further ahead as the graph grows. The
+// claim is sound and no test is added for it: a cost gate that can only ever
+// pass is noise, and the audit that matters here has already been done once.

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -518,9 +518,31 @@ export type Graph<Ts extends readonly ErasedNodeType[], S> = Readonly<{
    * writer (`applyRemoved`) and is shared by reference by every commit that
    * removes nothing, which is nearly all of them.
    *
-   * DISJOINT from `subtreeRevById` by construction: an id is live or dead,
-   * never both. `getSubtreeRev` reads live first regardless, and invariant
-   * check 6 asserts the disjointness rather than trusting it.
+   * NOT disjoint from `subtreeRevById`, and an earlier version of this comment
+   * claimed it was — "an id is live or dead, never both", backed by "invariant
+   * check 6 asserts the disjointness rather than trusting it." Both halves were
+   * false. Check 6 requires every LIVE node to have a rev and never reads this
+   * map at all, and the overlap is reachable by the most ordinary gesture there
+   * is: remove a node, then undo. Measured through the public store —
+   *
+   *   after remove : live=false dead=true
+   *   after undo   : live=true  dead=true
+   *
+   * — because `applyRemoved` writes the tombstone and `applyInserted` seeds the
+   * returning id ABOVE it without clearing it, which is exactly what the
+   * high-water rule requires.
+   *
+   * The overlap is INERT rather than merely tolerated: `getSubtreeRev` reads
+   * `subtreeRevById` first and only falls through to this map for an id with no
+   * live entry, so a stale dead number can never be the answer for a live node.
+   * What it costs is one number per ever-removed id for the store's lifetime,
+   * which is the trade `applyRemoved` argues for at length.
+   *
+   * Stated here as an observation rather than an assertion because nothing
+   * checks it. If a future check wants to police this map, the property worth
+   * asserting is the high-water rule — a tombstone sits strictly above every
+   * rev its dead lineage cached — not disjointness, which is neither true nor
+   * needed.
    */
   deadRevById: ReadonlyMap<NodeId, number>;
   /** Derived from `contentKey`. Values are in document order. */


### PR DESCRIPTION
Fifth from the `keel-core` review, after #605–#608. No behaviour changes — this is the prose.

The package's comments are load-bearing: they record the measurement behind each decision and name the rejected alternative, and a reader is meant to be able to trust them. review3 already caught this failure mode once — `review3-consumers-go-through-the-accessors.test.ts` opens on *"comments describing checks that did not exist, three of which caused the bug beneath them."*

Four more comments assert a **check** or a **bound**. I ran each against the code rather than reading it.

## False — `Graph.deadRevById`

Claimed *"DISJOINT from `subtreeRevById` by construction: an id is live or dead, never both"*, citing *"invariant check 6 asserts the disjointness rather than trusting it."*

Both halves wrong. Check 6 requires every **live** node to have a rev and never reads `deadRevById`. And the overlap needs nothing exotic — remove, then undo:

```
after remove : live=false dead=true
after undo   : live=true  dead=true
```

That's `applyInserted` seeding the returning id *above* its tombstone without clearing it — exactly what the high-water rule requires. The comment now says so, and says why the overlap is **inert** rather than merely tolerated: `getSubtreeRev` reads live first, so a stale dead number can never be the answer for a live node. It also names the property worth asserting if a future check wants one — the high-water rule, not disjointness, which is neither true nor needed.

## False — `resolveDrop`

Claimed *"It runs the same validity checks as the command it produces, so an illegal gesture is refused while it is still a gesture."*

It runs the **structural** checks — unknown node, not-a-container, cycle, root moves — and not the budgets. Measured, `maxNodes: 3` on a 3-node graph:

```
resolveDrop(insert intent)  -> ok
dispatch(that command)      -> would-exceed-max-nodes
```

A drop that cannot commit reads as a legal drop target. That's a gesture-layer gap, not a correctness bug — the command door still refuses and nothing is written — so the comment now says which half it does. **Closing the gap is a deliberate UX call and I left it to you**: teaching `resolveDrop` the budgets would make an unaffordable drag show as invalid mid-drag, which is arguably better, but it changes drag behaviour.

## Stale — `createChildrenOverlay`

Listed `indexOf` *"on the removal side"* among three costs it had removed. The removal arm was made linear in #605; the **move** arm still scans — deliberately, because its `fromIndex` is a pre-state index checked against the untouched graph and is not an index into the overlay. The comment now spells out which arm is which, since reading it the other way is what cost a later round a second look at an already-"fixed" quadratic.

## True, and left alone — `documentOrderComparator`

Claims the pathological bucket *"costs the same order as the rebuild it replaces. It is never worse than the rebuild."* Measured against the walk it replaces, on exactly that shape — one content key in every collection:

| shape | comparator | rebuild | ratio |
|---|---|---|---|
| 40 × 40 (1,641 nodes) | 0.04 ms | 0.27 ms | **0.15×** |
| 80 × 80 (6,481) | 0.03 ms | 0.54 ms | **0.06×** |
| 160 × 160 (25,761) | 0.04 ms | 2.41 ms | **0.02×** |

Six to fifty times *faster*, pulling further ahead as the graph grows. The claim is sound. It was filed as a finding against a different function and the number didn't reproduce — I've recorded the measurement in the test file so the next reader doesn't re-audit it.

## Tests

5 cases pinning the two corrected facts, so the prose can't drift back. If someone makes `deadRevById` disjoint or teaches `resolveDrop` the budgets, they fail and point at the comment that has to change with them. One of them also pins the *true* half of the `resolveDrop` docblock beside the half that wasn't.

No test for the fourth claim: a cost gate that can only ever pass is noise.

## Verification

- `tsc --noEmit` clean; no source behaviour changed
- full `unit` project: **1,534 passing**, up from 1,529
- `npm run lint`: 0 errors (11 pre-existing warnings, untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)