### PR TITLE
Four small ones on the public surface, and a refusal message the sender sized

### DIFF
--- a/packages/keel-core/folds.ts
+++ b/packages/keel-core/folds.ts
@@ -31,6 +31,7 @@ import type {
   ExactFolded,
   ConsumerDefinedFold,
   FoldCache,
+  FoldCacheStats,
   Folded,
   FoldedChild,
   Graph,
@@ -277,27 +278,13 @@ export const DEFAULT_FOLD_CACHE_LIMIT = 8 * 16384;
  * `hits` / `misses` / `evictions` are LIFETIME counts and survive `clear()`;
  * `size` is current occupancy.
  *
- * Structurally duplicated by `EngineConfig.onFoldCacheStats`'s parameter in
- * ./types — that module is the base of the package and imports nothing, so a
- * types -> folds edge would be a cycle. The two must stay identical.
+ * DECLARED IN ./types and re-exported here, so `EngineConfig.onFoldCacheStats`
+ * and `ObservableFoldCache.stats` are the same type rather than two hand-copies
+ * that "must stay identical". Re-exported rather than moved outright because
+ * this is the module the type belongs to conceptually, and a consumer reading
+ * the cache should not have to know it is declared one layer down.
  */
-export type FoldCacheStats = Readonly<{
-  /** Lifetime `get` calls answered from the table. */
-  hits: number;
-  /** Lifetime `get` calls that had to fold. */
-  misses: number;
-  /**
-   * Entries dropped FOR CAPACITY, and only for capacity. `clear()` is not
-   * counted: conflating a deliberate reset with cache pressure would destroy
-   * the only number that says the limit is too low.
-   */
-  evictions: number;
-  /** Entries held right now. */
-  size: number;
-  /** The EFFECTIVE ceiling after flooring and the non-finite fallback, not the
-   *  raw constructor argument. */
-  limit: number;
-}>;
+export type { FoldCacheStats };
 
 /**
  * A `FoldCache` that can also be measured. `createFoldCache` always returns

--- a/packages/keel-core/graph/construction.ts
+++ b/packages/keel-core/graph/construction.ts
@@ -1,4 +1,4 @@
-// KEEL graph — the functions that MINT a graph value.
+// KEEL graph — the functions that CREATE a graph value.
 //
 // `emptyGraph` and `buildGraph` produce one from nothing and from already-parsed
 // parts; `markMissing` produces the next one after storage says a subtree is

--- a/packages/keel-core/graph/index.ts
+++ b/packages/keel-core/graph/index.ts
@@ -19,7 +19,7 @@
 //                    full rebuild from it
 //   incremental-indexes  every cheaper updater OF that definition — read as a
 //                    pair with the file above, see its header for why
-//   construction     the functions that mint a Graph
+//   construction     the functions that create a Graph
 //   invariants       the structural audit
 //
 // CURATED, not `export *`. Two things are deliberately not re-exported:

--- a/packages/keel-core/index.ts
+++ b/packages/keel-core/index.ts
@@ -120,6 +120,12 @@ export {
   rebuildDerivedIndexes,
   sourceKeyOf,
   subtreeIds,
+  // `rebuildDerivedIndexes` RETURNS a `DerivedIndexes`, and leaving the type
+  // unnamed here was the same curation misfire as `FoldCacheStats` below: a
+  // consumer could call the function and could not write down the type of what
+  // it handed back, so the only way to hold the result in a typed local was to
+  // reach past this barrel into ./graph.
+  type DerivedIndexes,
 } from "./graph";
 
 // ---------------------------------------------------------------------------

--- a/packages/keel-core/review4-a-refusal-message-is-bounded.test.ts
+++ b/packages/keel-core/review4-a-refusal-message-is-bounded.test.ts
@@ -1,0 +1,209 @@
+// Fourth review round — the ingress trust boundary quoted the wire verbatim.
+//
+// `JSON.stringify(node.id)` was the pattern at every ingress refusal, and a
+// `NodeId` is ANY string except whitespace-only — including one whose length the
+// sender chose. So the size of `error.message` was a function of the payload,
+// and the consumer puts that message in a log line, a toast, or an error report.
+//
+// Measured before the fix, a 1 MB id in a `dangling-child` payload:
+//
+//   id length sent :  1,000,000
+//   message length :  1,000,049
+//
+// After: 169. The bound is `quoteFromWire`, which clamps BEFORE it quotes —
+// quoting first would allocate the whole megabyte and escape every character of
+// it before throwing the result away, which is most of the cost being avoided.
+//
+// Not a vulnerability on its own; the document is refused either way. It is the
+// difference between a refusal that costs what the refusal costs and one that
+// costs whatever the sender decided.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const makeEngine = () =>
+  createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+
+/** Comfortably above the 120-char clamp, comfortably below anything slow. */
+const HUGE = "x".repeat(200_000);
+
+/** The bound each message must respect. Not the clamp itself — a message is a
+ *  sentence with a quoted name in it, and the sentence has a length too. */
+const REASONABLE = 1_000;
+
+describe("a refusal message is bounded by the engine, not by the sender", () => {
+  it("a huge node id in a dangling-child payload", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: [HUGE] },
+      ],
+    });
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    expect(loaded.error.code).toBe("dangling-child");
+    expect(loaded.error.message.length).toBeLessThan(REASONABLE);
+    // The id is still IDENTIFIABLE — clamped, not withheld. A refusal that says
+    // nothing about which node it means is a different bug.
+    expect(loaded.error.message).toContain("xxx");
+  });
+
+  it("a huge id that is a duplicate", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: [HUGE] },
+        { id: HUGE, kind: "folder", data: { name: "A" }, children: [] },
+        { id: HUGE, kind: "folder", data: { name: "B" }, children: [] },
+      ],
+    });
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    expect(loaded.error.code).toBe("duplicate-node-id");
+    expect(loaded.error.message.length).toBeLessThan(REASONABLE);
+  });
+
+  it("a huge KIND, which is the other string the wire chooses", () => {
+    // Through `schemaVersions`, which formats the kind into a message. An
+    // unknown kind on a NODE quarantines instead of refusing, and the
+    // `IngressError` it produces carries `kind` as a structured FIELD rather
+    // than inside a sentence — that one is deliberately not clamped, because a
+    // consumer deciding what to do about a failed kind needs the whole kind.
+    // The bound is on messages, not on data.
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1, [HUGE]: "not-a-number" },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: [] },
+      ],
+    });
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    expect(loaded.error.message.length).toBeLessThan(REASONABLE);
+  });
+
+  it("a huge id on the LAZY door, which refuses twice over", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "R" },
+          children: ["lazy"],
+        },
+        {
+          id: "lazy",
+          kind: "folder",
+          data: { name: "L" },
+          childrenState: "unloaded",
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    // A huge id is a perfectly VALID id, so the payload has to be malformed for
+    // there to be a refusal at all — the first draft of this test just loaded a
+    // 200KB id successfully. A dangling child inside the payload puts the huge
+    // string in the inner message AND the outer one wraps it, which is the
+    // "refuses twice over" this door does.
+    const result = store.load(parseNodeId("lazy"), {
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["p1"],
+      nodes: [{ id: "p1", kind: "folder", data: { name: "P" }, children: [HUGE] }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("malformed-document");
+    expect(result.error.message.length).toBeLessThan(REASONABLE);
+    // Both layers bounded, not just the outer one.
+    expect(result.error.cause?.message.length ?? 0).toBeLessThan(REASONABLE);
+  });
+
+  it("an ordinary id is not clamped, so the bound costs nothing normal", () => {
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "R" },
+          children: ["timeline-e2e,comma/and-slash"],
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    // Verbatim, including the comma and slash that are legal in a NodeId.
+    expect(loaded.error.message).toContain("timeline-e2e,comma/and-slash");
+  });
+});

--- a/packages/keel-core/serialize.ts
+++ b/packages/keel-core/serialize.ts
@@ -50,6 +50,7 @@ import {
   type Issue,
   type LoadRejection,
   type LoadReport,
+  quoteFromWire,
   type NodeId,
   type NodeTypeRegistry,
   type ParseCtx,
@@ -219,7 +220,7 @@ export function parseSerializedDocument(
     for (const [kind, value] of Object.entries(rawVersions)) {
       if (typeof value !== "number" || !Number.isFinite(value)) {
         return malformed(
-          `schemaVersions[${JSON.stringify(kind)}] must be a finite number`,
+          `schemaVersions[${quoteFromWire(kind)}] must be a finite number`,
         );
       }
       schemaVersions[kind] = value;
@@ -496,7 +497,7 @@ export function parseNodeData<S>(
     return ingressError(args.nodeId, args.kind, "unknown-kind", [
       {
         path: "$.kind",
-        message: `No node type is registered for kind ${JSON.stringify(args.kind)}`,
+        message: `No node type is registered for kind ${quoteFromWire(args.kind)}`,
       },
     ]);
   }
@@ -548,7 +549,7 @@ export function parseNodeData<S>(
   const parsedValue: unknown = parsed.value;
   runContentDevChecks(
     ctx.devChecks,
-    `the ${JSON.stringify(args.kind)} node type (node ${JSON.stringify(args.nodeId)})`,
+    `the ${quoteFromWire(args.kind)} node type (node ${quoteFromWire(args.nodeId)})`,
     parsedValue,
     () => nodeType.serialize(parsedValue),
     // DIRECTLY, never through `parseNodeData` — see the re-entry note above.
@@ -719,7 +720,7 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
     if (wireById.has(id.value)) {
       return fail({
         code: "duplicate-node-id",
-        message: `Node id ${JSON.stringify(node.id)} appears more than once in nodes`,
+        message: `Node id ${quoteFromWire(node.id)} appears more than once in nodes`,
         nodeId: id.value,
       });
     }
@@ -742,14 +743,14 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
     if (!wireById.has(id.value)) {
       return fail({
         code: "unknown-root",
-        message: `rootIds names ${JSON.stringify(rawRootId)}, which is not in nodes`,
+        message: `rootIds names ${quoteFromWire(rawRootId)}, which is not in nodes`,
         nodeId: id.value,
       });
     }
     if (rootSet.has(id.value)) {
       return fail({
         code: "duplicate-node-id",
-        message: `rootIds names ${JSON.stringify(rawRootId)} more than once`,
+        message: `rootIds names ${quoteFromWire(rawRootId)} more than once`,
         nodeId: id.value,
       });
     }
@@ -800,9 +801,9 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
       // produce. `QuarantinedNode` carries both `container` and a
       // `ChildrenState` precisely so this case has somewhere to land.
       const mismatch = hasChildren
-        ? `carries a children array while kind ${JSON.stringify(node.kind)} is registered as a leaf`
+        ? `carries a children array while kind ${quoteFromWire(node.kind)} is registered as a leaf`
         : node.childrenState !== undefined
-          ? `carries childrenState ${JSON.stringify(node.childrenState)} while kind ${JSON.stringify(node.kind)} is registered as a leaf`
+          ? `carries childrenState ${quoteFromWire(node.childrenState)} while kind ${quoteFromWire(node.kind)} is registered as a leaf`
           : null;
       if (mismatch === null) {
         containerById.set(id, false);
@@ -810,7 +811,7 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
       }
       shapeMismatchById.set(id, {
         path: "$",
-        message: `Node ${JSON.stringify(node.id)} ${mismatch}`,
+        message: `Node ${quoteFromWire(node.id)} ${mismatch}`,
       });
       // Fall through to the container arm below, so the declared children are
       // walked, counted and attached exactly as a real container's would be.
@@ -853,7 +854,7 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
       if (!wireById.has(child.value)) {
         return fail({
           code: "dangling-child",
-          message: `Node ${JSON.stringify(node.id)} names child ${JSON.stringify(rawChildId)}, which is not in nodes`,
+          message: `Node ${quoteFromWire(node.id)} names child ${quoteFromWire(rawChildId)}, which is not in nodes`,
           nodeId: child.value,
         });
       }
@@ -866,14 +867,14 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
       if (parentById.has(child.value)) {
         return fail({
           code: "multi-parent",
-          message: `Node ${JSON.stringify(rawChildId)} appears as a child more than once`,
+          message: `Node ${quoteFromWire(rawChildId)} appears as a child more than once`,
           nodeId: child.value,
         });
       }
       if (rootSet.has(child.value)) {
         return fail({
           code: "multi-parent",
-          message: `Node ${JSON.stringify(rawChildId)} is a root and also a child of ${JSON.stringify(node.id)}`,
+          message: `Node ${quoteFromWire(rawChildId)} is a root and also a child of ${quoteFromWire(node.id)}`,
           nodeId: child.value,
         });
       }
@@ -889,7 +890,7 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
       if (containerById.get(id) !== true) {
         return fail({
           code: "root-not-container",
-          message: `Root ${JSON.stringify(id)} is not a container`,
+          message: `Root ${quoteFromWire(id)} is not a container`,
           nodeId: id,
         });
       }
@@ -949,7 +950,7 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
       if (id.ok && !seen.has(id.value)) {
         return fail({
           code: "unreachable-node",
-          message: `Node ${JSON.stringify(node.id)} is not reachable from any root`,
+          message: `Node ${quoteFromWire(node.id)} is not reachable from any root`,
           nodeId: id.value,
         });
       }
@@ -1093,7 +1094,7 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
           summary = parsedSummary.value;
           runContentDevChecks(
             ctx.devChecks,
-            `the summary type (node ${JSON.stringify(id)})`,
+            `the summary type (node ${quoteFromWire(id)})`,
             parsedSummary.value,
             () => ctx.summary.serialize(parsedSummary.value),
             (raw) => ctx.summary.parse(raw),
@@ -1111,7 +1112,7 @@ function buildDocument<Ts extends readonly ErasedNodeType[], S>(
       if (policy === "reject") {
         return fail({
           code: summaryFailed ? "summary-parse-failed" : "ingress-rejected",
-          message: `Node ${JSON.stringify(wire.id)} (kind ${JSON.stringify(wire.kind)}) failed ingress: ${failure.reason}`,
+          message: `Node ${quoteFromWire(wire.id)} (kind ${quoteFromWire(wire.kind)}) failed ingress: ${failure.reason}`,
           nodeId: id,
           issues: failure.issues,
           ingress: [failure],
@@ -1199,7 +1200,7 @@ function findDuplicateOwner<Ts extends readonly ErasedNodeType[], S>(
     if (existing !== undefined) {
       return {
         code: "duplicate-owner",
-        message: `sourceKey ${JSON.stringify(key)} is owned by both ${JSON.stringify(existing)} and ${JSON.stringify(id)}; the second placement must be a reference`,
+        message: `sourceKey ${quoteFromWire(key)} is owned by both ${quoteFromWire(existing)} and ${quoteFromWire(id)}; the second placement must be a reference`,
         nodeId: id,
       };
     }
@@ -1331,7 +1332,7 @@ export function serializeGraph<Ts extends readonly ErasedNodeType[], S>(
       return nodeType.serialize(data);
     } catch (thrown) {
       console.error(
-        `keel: ${JSON.stringify(kind)}.serialize threw while writing a node for save. ` +
+        `keel: ${quoteFromWire(kind)}.serialize threw while writing a node for save. ` +
           `That node is being written in its live form instead, which may not round-trip. ` +
           `The rest of the document is unaffected.`,
         thrown,
@@ -1390,7 +1391,7 @@ export function serializeGraph<Ts extends readonly ErasedNodeType[], S>(
           draft.summary = ctx.summary.serialize(node.summary);
         } catch (thrown) {
           console.error(
-            `keel: the summary type's serialize threw while writing node ${JSON.stringify(id)} for save. ` +
+            `keel: the summary type's serialize threw while writing node ${quoteFromWire(id)} for save. ` +
               `Its stored summary is being omitted; the rest of the document is unaffected.`,
             thrown,
           );
@@ -1472,7 +1473,7 @@ function loadChildrenIntoUnguarded<Ts extends readonly ErasedNodeType[], S>(
   if (target === undefined) {
     return loadRejection({
       code: "unknown-node",
-      message: `No node ${JSON.stringify(id)} in this graph`,
+      message: `No node ${quoteFromWire(id)} in this graph`,
       nodeId: id,
     });
   }
@@ -1486,14 +1487,14 @@ function loadChildrenIntoUnguarded<Ts extends readonly ErasedNodeType[], S>(
   if (state === null) {
     return loadRejection({
       code: "not-a-container",
-      message: `Node ${JSON.stringify(id)} is not a container`,
+      message: `Node ${quoteFromWire(id)} is not a container`,
       nodeId: id,
     });
   }
   if (state.status !== "unloaded") {
     return loadRejection({
       code: "target-not-unloaded",
-      message: `Node ${JSON.stringify(id)} is ${state.status}, not unloaded; only an unloaded owner can be filled`,
+      message: `Node ${quoteFromWire(id)} is ${state.status}, not unloaded; only an unloaded owner can be filled`,
       nodeId: id,
     });
   }
@@ -1509,7 +1510,7 @@ function loadChildrenIntoUnguarded<Ts extends readonly ErasedNodeType[], S>(
   if (!built.ok) {
     return loadRejection({
       code: "malformed-document",
-      message: `Payload for ${JSON.stringify(id)} is not a usable document: ${built.error.message}`,
+      message: `Payload for ${quoteFromWire(id)} is not a usable document: ${built.error.message}`,
       nodeId: id,
       cause: built.error,
     });
@@ -1523,7 +1524,7 @@ function loadChildrenIntoUnguarded<Ts extends readonly ErasedNodeType[], S>(
   if (colliding.length > 0) {
     return loadRejection({
       code: "id-collision",
-      message: `Payload for ${JSON.stringify(id)} reuses ${colliding.length} id(s) the graph already holds`,
+      message: `Payload for ${quoteFromWire(id)} reuses ${colliding.length} id(s) the graph already holds`,
       nodeId: id,
       collidingIds: colliding,
     });

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -929,7 +929,16 @@ export type StructuralErrorCode =
   | "unknown-root"
   | "root-not-container"
   | "unreachable-node"
-  | "leaf-with-children"
+  // NO `"leaf-with-children"` here, and its absence is the point. Ingress does
+  // not REJECT a leaf that arrived carrying children — it quarantines that node
+  // as `"shape-mismatch"` and keeps the rest of the document, which is the whole
+  // design: one node's confusion must not cost the user their file. The member
+  // sat in this union unreachable, and a consumer writing an exhaustive switch
+  // over `StructuralErrorCode` had to handle a case ./serialize cannot produce.
+  //
+  // `ViolationCode` still declares it, correctly — the AUDIT can find a leaf
+  // with children on a graph built in memory, and `graph/invariants` returns
+  // exactly that. Two unions, two different questions.
   | "duplicate-owner"
   | "summary-parse-failed"
   /** `onUnknownKind` / `onParseFailure` was set to `"reject"`. */
@@ -1264,6 +1273,39 @@ export type ValueOf<X> = FoldValue<X>;
  * collapse to `unknown`, and a legitimately-cached `undefined` would be
  * indistinguishable from a miss.
  */
+/**
+ * What a fold cache will tell you about itself.
+ *
+ * DECLARED HERE, not in ./folds, and that is the correction rather than a
+ * preference. This shape used to live in ./folds and be hand-copied into
+ * `EngineConfig.onFoldCacheStats`'s parameter, on the argument that "this module
+ * is the base of the package and imports nothing, so a types -> folds edge would
+ * be a cycle." The premise is true and the conclusion did not follow: the fix is
+ * the other direction. `FoldCache` directly below has always lived here and been
+ * imported BY ./folds, which is the same relationship — so this can be too, and
+ * the two copies that "must stay identical" become one that cannot drift.
+ *
+ * `hits` / `misses` / `evictions` are LIFETIME counts and survive `clear()`;
+ * `size` is current occupancy.
+ */
+export type FoldCacheStats = Readonly<{
+  /** Lifetime `get` calls answered from the table. */
+  hits: number;
+  /** Lifetime `get` calls that had to fold. */
+  misses: number;
+  /**
+   * Entries dropped FOR CAPACITY, and only for capacity. `clear()` is not
+   * counted: conflating a deliberate reset with cache pressure would destroy
+   * the only number that says the limit is too low.
+   */
+  evictions: number;
+  /** Entries held right now. */
+  size: number;
+  /** The EFFECTIVE ceiling after flooring and the non-finite fallback, not the
+   *  raw constructor argument. */
+  limit: number;
+}>;
+
 export type FoldCache = Readonly<{
   get(
     foldKey: string,
@@ -1571,25 +1613,12 @@ export type EngineConfig<
    * helped — same answers, more work — so an undersized `foldCacheLimit` has no
    * other symptom.
    *
-   * The parameter shape is spelled out here instead of importing
-   * `FoldCacheStats` from ./folds: this module is the base of the package and
-   * imports nothing, so a types -> folds edge would be a cycle. The two are
-   * structurally identical and must stay so.
+   * Takes `FoldCacheStats` — the type declared above, which ./folds imports —
+   * rather than a hand-copy of its shape. The copy was here on the argument
+   * that importing it from ./folds would be a cycle; true, and beside the
+   * point, since the type can simply live in the module that has no imports.
    */
-  onFoldCacheStats?(
-    readStats: () => Readonly<{
-      /** Lifetime reads answered from the table. */
-      hits: number;
-      /** Lifetime reads that had to fold. */
-      misses: number;
-      /** Entries dropped FOR CAPACITY only — never by `clear()`. */
-      evictions: number;
-      /** Entries held right now. */
-      size: number;
-      /** The effective ceiling, after flooring and the non-finite fallback. */
-      limit: number;
-    }>,
-  ): void;
+  onFoldCacheStats?(readStats: () => FoldCacheStats): void;
   devChecks?: boolean;
 }>;
 
@@ -1884,6 +1913,27 @@ function clamp(text: string): string {
   return text.length > DESCRIBE_LIMIT
     ? `${text.slice(0, DESCRIBE_LIMIT - 3)}...`
     : text;
+}
+
+/**
+ * Quote a string that came OFF THE WIRE, for a refusal message.
+ *
+ * `JSON.stringify(node.id)` was the pattern at every ingress refusal, and a
+ * `NodeId` is any string except whitespace-only — including one the sender chose
+ * the length of. Measured before this existed: a 1 MB id in a `dangling-child`
+ * payload produced a 1,000,049-character `error.message`, which the consumer
+ * then puts in a log line, a toast, or an error report.
+ *
+ * CLAMPS BEFORE IT QUOTES, not after. Quoting first would allocate the full
+ * megabyte and escape every character of it before throwing the result away,
+ * which is most of the cost the bound is for.
+ *
+ * For ids and kinds specifically — `describeValue` is the one for arbitrary
+ * consumer VALUES, and this one keeps the plain `"..."` shape a reader expects
+ * around a name.
+ */
+export function quoteFromWire(value: string): string {
+  return JSON.stringify(clamp(value));
 }
 
 export function describeThrown(thrown: unknown): string {


### PR DESCRIPTION
Sixth from the `keel-core` review. The low-severity tail, plus one that turned out to be worth more than its severity.

## A refusal message sized by the sender

`JSON.stringify(node.id)` was the pattern at every ingress refusal, and a `NodeId` is any string except whitespace-only — including one whose length the sender chose. Measured, a 1 MB id in a `dangling-child` payload:

```
id length sent :  1,000,000
message length :  1,000,049   ->  169 after
```

The consumer puts that message in a log line, a toast, or an error report. Not a vulnerability on its own — the document is refused either way — but it's the difference between a refusal that costs what the refusal costs and one that costs whatever the sender decided.

`quoteFromWire` is the bound, and it **clamps before it quotes**: quoting first would allocate the whole megabyte and escape every character of it before throwing the result away, which is most of the cost being avoided. Applied at all 24 message sites in `serialize.ts`; a grep for an unbounded `JSON.stringify` of a wire string returns nothing there now.

Deliberately **not** clamped: `IngressError.kind`. That's a structured field, not a sentence, and a consumer deciding what to do about a failed kind needs the whole kind. The bound is on messages, not on data.

## `FoldCacheStats` was two copies

`folds.ts` declared it and `EngineConfig.onFoldCacheStats` hand-copied its shape, on the argument that *"this module is the base of the package and imports nothing, so a types -> folds edge would be a cycle."*

The premise is true and the conclusion doesn't follow — the fix runs the other way. `FoldCache` has always lived in `types.ts` and been imported *by* `folds.ts`, the same relationship, so the stats type lives there now too and `folds.ts` re-exports it. Two copies that "must stay identical" became one that can't drift.

## A dead union member

`StructuralErrorCode` declared `"leaf-with-children"`, which `serialize.ts` cannot produce: ingress doesn't reject a leaf that arrived carrying children, it quarantines that node as `"shape-mismatch"` and keeps the rest of the document. A consumer writing an exhaustive switch had to handle a case that can't happen.

`ViolationCode` still declares it, correctly — the *audit* can find one on a graph built in memory, and `graph/invariants.ts` returns exactly that. Two unions, two different questions.

## A type the barrel withheld

`rebuildDerivedIndexes` is exported and returns a `DerivedIndexes`, which wasn't — so a consumer could call the function and couldn't write down the type of what it handed back. Same curation misfire the barrel already documents about `FoldCacheStats`.

## Tests

5 cases on the bound, **4 failing before it** at 200,042–200,049 characters against a 1,000 ceiling. One asserts an *ordinary* id still appears verbatim — commas and slashes included — so the bound costs nothing normal; another asserts the clamped id is still identifiable, since a refusal that can't say which node it means is a different bug.

Two of my test premises were wrong and the failures caught them: a huge id is a perfectly *valid* id, so the lazy-door payload had to be genuinely malformed for there to be a refusal at all, and `IngressError` has no `message` field to bound.

## Verification

- `tsc --noEmit` clean, and clean under `--noUnusedLocals`
- keel-core: **723 passing**
- full `unit` project: **1,539 passing**, up from 1,534
- `keel-react` typecheck clean; `npm run lint` 0 errors

Two enums change shape. `StructuralErrorCode` loses a member — a consumer switching on it exhaustively will now get an error for a case it can no longer receive, which is the point. `EngineConfig.onFoldCacheStats` takes a named type instead of an inline literal; structurally identical, so no call site changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)