### PR TITLE
`types` must be a tuple, and now the door says so

### DIFF
--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -21,6 +21,7 @@ import type {
   Command,
   Engine,
   EngineConfig,
+  RequireTupleTypes,
   EngineContext,
   Folded,
   FoldRegistry,
@@ -253,7 +254,9 @@ export function createEngine<
   const Ts extends readonly WidenedNodeType[],
   S,
   F extends FoldRegistry<Ts, S>,
->(config: EngineConfig<Ts, S, F>): Engine<Ts, S, F> {
+>(
+  config: EngineConfig<Ts, S, F> & RequireTupleTypes<Ts>,
+): Engine<Ts, S, F> {
   const registry = buildRegistry(config.types);
 
   // ConsumerDefinedFold keys must be unique, and this is the check `readCachedFold` in

--- a/packages/keel-core/typecheck-fixture-types-must-be-a-tuple.ts
+++ b/packages/keel-core/typecheck-fixture-types-must-be-a-tuple.ts
@@ -1,0 +1,205 @@
+// COMPILE-ONLY FIXTURE. No runtime role, not exported from the package barrel,
+// not imported by anything. `npx tsc --noEmit -p tsconfig.json` IS its
+// assertion: each `@ts-expect-error` below FAILS THE BUILD if the error it
+// names stops happening.
+//
+// WHAT IT DEFENDS, and why it cannot be a normal test.
+//
+// `Ts` is the compile-time half of the kind-to-`Data` correspondence. The TUPLE
+// is what remembers that `"clip"` means `Data = Clip`; a plain array has no
+// per-position types, so every mapped type built on `Ts` — `EditOf`,
+// `DataForKind`, `KindOf`, `Seed` — collapses from a discriminated union into a
+// cross-product. At that point a folder's edit under `kind: "clip"` typechecks,
+// and so does every other wrong-kind payload.
+//
+// Nothing fails at runtime when that happens. The engine works; it has simply
+// stopped checking, and the next wrong-kind edit is caught by `applyEdit`
+// throwing on a field that is not there, in the consumer, months later. A
+// vitest assertion cannot see any of this — the collapse is entirely in the
+// types, which is why the assertion has to be the compiler.
+//
+// MEASURED before `RequireTupleTypes` existed, the same wrong-kind edit through
+// `store.dispatch`:
+//
+//   types: [clipType, folderType] as const   ->  error, correctly
+//   types: [clipType, folderType]            ->  COMPILED CLEAN
+//
+// `createEngine`'s `const Ts` already rescues an INLINE literal, so the hole was
+// never the documented example — it was the named variable declared without
+// `as const`, which is how anyone with more than two node types writes it.
+
+import { createEngine } from "./engine";
+import {
+  defineNodeType,
+  parseNodeId,
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Two kinds with genuinely different `Data` AND `Edit`
+// ---------------------------------------------------------------------------
+//
+// Two is the minimum that can tell a real discriminated union apart from a
+// widened one: with a single kind, the cross-product and the union are the same
+// type and the fixture would pass in both worlds.
+
+type Clip = Readonly<{ title: string; seconds: number }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const record: Record<string, unknown> = { ...raw };
+    const title = record["title"];
+    const seconds = record["seconds"];
+    if (typeof title !== "string" || typeof seconds !== "number") {
+      return { ok: false, error: [{ path: "$", message: "shape" }] };
+    }
+    return { ok: true, value: { title, seconds } };
+  },
+  serialize(data): unknown {
+    return { title: data.title, seconds: data.seconds };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const nodeId = parseNodeId("x");
+
+// ---------------------------------------------------------------------------
+// 1. A TUPLE keeps every per-kind type alive
+// ---------------------------------------------------------------------------
+
+const tupleTypes = [clipType, folderType] as const;
+
+const tupleEngine = createEngine<typeof tupleTypes, Summary, {}>({
+  types: tupleTypes,
+  summary,
+  folds: {},
+});
+
+declare const tupleStore: ReturnType<typeof tupleEngine.createStore>;
+
+// The RIGHT edit for the kind compiles, which is half the assertion — a fixture
+// that only proved things fail would also pass against a type that rejects
+// everything.
+tupleStore.dispatch({
+  type: "edit-nodes",
+  edits: [{ nodeId, kind: "clip", edit: { title: "ok" } }],
+});
+
+tupleStore.dispatch({
+  type: "edit-nodes",
+  edits: [{ nodeId, kind: "folder", edit: { name: "ok" } }],
+});
+
+tupleStore.dispatch({
+  type: "edit-nodes",
+  edits: [
+    // @ts-expect-error — `name` is the FOLDER's edit; under `kind: "clip"` it
+    // must not typecheck. This is the property the whole tuple constraint
+    // exists to keep, and the one that silently died on a plain array.
+    { nodeId, kind: "clip", edit: { name: "wrong kind" } },
+  ],
+});
+
+tupleStore.dispatch({
+  type: "insert-nodes",
+  toParentId: nodeId,
+  toIndex: 0,
+  // @ts-expect-error — a clip's `Data` under `kind: "folder"`. Seeds carry the
+  // same correspondence as edits and lose it the same way.
+  seeds: [{ kind: "folder", data: { title: "wrong", seconds: 1 } }],
+});
+
+// ---------------------------------------------------------------------------
+// 2. A plain ARRAY is refused at the door, by name
+// ---------------------------------------------------------------------------
+
+const arrayTypes = [clipType, folderType];
+
+createEngine<typeof arrayTypes, Summary, {}>({
+  // @ts-expect-error — `RequireTupleTypes` resolves to a string whose text IS
+  // the fix, so the consumer reads "must be a TUPLE, not an array — add `as
+  // const`" in the error rather than getting an engine that has quietly stopped
+  // checking. Before the guard, this line compiled clean.
+  types: arrayTypes,
+  summary,
+  folds: {},
+});
+
+// ---------------------------------------------------------------------------
+// 3. The inline literal was never broken, and must stay unbroken
+// ---------------------------------------------------------------------------
+//
+// `const Ts` infers a tuple from a literal at the call site, so this form always
+// worked — which is exactly why the defect survived review: the documented
+// example is the one case that was fine.
+
+const inlineEngine = createEngine({
+  types: [clipType, folderType],
+  summary,
+  folds: {},
+});
+
+declare const inlineStore: ReturnType<typeof inlineEngine.createStore>;
+
+inlineStore.dispatch({
+  type: "edit-nodes",
+  edits: [
+    // @ts-expect-error — still a wrong-kind edit, still refused, with no
+    // `as const` anywhere in sight.
+    { nodeId, kind: "clip", edit: { name: "wrong kind" } },
+  ],
+});

--- a/packages/keel-core/typecheck-fixture-types-must-be-a-tuple.ts
+++ b/packages/keel-core/typecheck-fixture-types-must-be-a-tuple.ts
@@ -123,13 +123,16 @@ const nodeId = parseNodeId("x");
 
 const tupleTypes = [clipType, folderType] as const;
 
-const tupleEngine = createEngine<typeof tupleTypes, Summary, {}>({
+// `_`-prefixed because the rule asks for it: the binding is read only in a TYPE
+// position below, and this fixture needs it to exist for exactly that reason —
+// `typeof` is how the store gets the engine's inferred parameters.
+const _tupleEngine = createEngine<typeof tupleTypes, Summary, {}>({
   types: tupleTypes,
   summary,
   folds: {},
 });
 
-declare const tupleStore: ReturnType<typeof tupleEngine.createStore>;
+declare const tupleStore: ReturnType<typeof _tupleEngine.createStore>;
 
 // The RIGHT edit for the kind compiles, which is half the assertion — a fixture
 // that only proved things fail would also pass against a type that rejects
@@ -187,13 +190,13 @@ createEngine<typeof arrayTypes, Summary, {}>({
 // worked — which is exactly why the defect survived review: the documented
 // example is the one case that was fine.
 
-const inlineEngine = createEngine({
+const _inlineEngine = createEngine({
   types: [clipType, folderType],
   summary,
   folds: {},
 });
 
-declare const inlineStore: ReturnType<typeof inlineEngine.createStore>;
+declare const inlineStore: ReturnType<typeof _inlineEngine.createStore>;
 
 inlineStore.dispatch({
   type: "edit-nodes",

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1515,15 +1515,75 @@ export type PhantomTypes<
   Folds: F;
 }>;
 
+/**
+ * `createEngine`'s tuple guard, intersected onto its `config` parameter.
+ *
+ * `Ts` is the compile-time half of the kind-to-`Data` correspondence: the TUPLE
+ * is what remembers that `"clip"` means `Data = Clip`. A plain array has no
+ * per-position types, so every mapped type built on `Ts` — `EditOf`,
+ * `DataForKind`, `KindOf`, `Seed` — collapses from a discriminated union into a
+ * cross-product, and a folder's edit under `kind: "clip"` typechecks.
+ *
+ * MEASURED, the same wrong-kind edit through `store.dispatch`:
+ *
+ *   types: [clipType, folderType] as const   ->  error, correctly
+ *   types: [clipType, folderType]            ->  COMPILED CLEAN
+ *
+ * `createEngine`'s `const Ts` already rescues an inline literal, so the hole is
+ * the named variable declared without `as const` — which is how anyone with
+ * more than two node types writes it.
+ *
+ * A tuple's `length` is a literal (`2`); an array's is `number`, so
+ * `number extends Ts["length"]` is true only for the array. It then resolves to
+ * a type whose NAME is the fix, and the consumer reads the instruction in the
+ * error rather than getting a silently weaker engine.
+ *
+ * INTERSECTED at the call door rather than declared on `EngineConfig.types`,
+ * for a reason worth keeping: `config.types` stays assignable to `Ts` inside
+ * the function body, because an intersection is assignable to each of its
+ * members. Putting the conditional on the property instead made
+ * `buildRegistry(config.types)` stop compiling and would have bought a fifth
+ * sanctioned cast to fix — a real cost for the same diagnostic.
+ */
+export type RequireTupleTypes<Ts extends readonly WidenedNodeType[]> =
+  number extends Ts["length"]
+    ? {
+        types: "keel: `types` must be a TUPLE, not an array — add `as const`. Without it every per-kind type collapses and a wrong-kind edit compiles.";
+      }
+    : unknown;
+
 export type EngineConfig<
   Ts extends readonly WidenedNodeType[],
   S,
   F extends FoldRegistry<Ts, S>,
 > = Readonly<{
-  /** Duplicate `kind` is REJECTED at runtime — it THROWS, because a duplicate
-   *  is a programmer error at module init, not a recoverable condition. Two
-   *  node types claiming one kind means one silently wins at the trust boundary
-   *  and the discriminant is dead. */
+  /**
+   * Duplicate `kind` is REJECTED at runtime — it THROWS, because a duplicate
+   * is a programmer error at module init, not a recoverable condition. Two
+   * node types claiming one kind means one silently wins at the trust boundary
+   * and the discriminant is dead.
+   *
+   * MUST BE A TUPLE, and this type enforces it rather than trusting it. `Ts` is
+   * the compile-time half of the kind-to-`Data` correspondence: the tuple is
+   * what remembers that `"clip"` means `Data = Clip`. A plain ARRAY has no
+   * per-position types, so every mapped type built on `Ts` — `EditOf`,
+   * `DataForKind`, `KindOf`, `Seed` — collapses from a discriminated union to a
+   * cross-product, and a folder's edit under `kind: "clip"` typechecks.
+   *
+   * MEASURED, the same wrong-kind edit through `store.dispatch`:
+   *
+   *   types: [clipType, folderType] as const   ->  error, correctly
+   *   types: [clipType, folderType]            ->  COMPILED CLEAN
+   *
+   * `createEngine`'s `const Ts` already rescues an inline literal, so the hole
+   * is the named variable declared without `as const` — which is how anyone
+   * with more than two node types writes it.
+   *
+   * THE GUARD LIVES ON `createEngine`, not here — see `RequireTupleTypes`. This
+   * type keeps saying `Ts`, honestly, because that is what a config holds once
+   * it exists; the door is where the mistake is made and where it is worth
+   * refusing.
+   */
   types: Ts;
   summary: ConsumerDefinedSummaryType<S>;
   folds: F;


### PR DESCRIPTION
Stacked on #613 — retarget to `main` once that merges. Resumes the review's open findings.

**Correction first:** I said after #611 that the review's actionable list was closed. That was wrong. Recounting the 28 synthesised issues: 17 shipped, **11 still open** — and seven of those are mediums, not lows. This is the first of them.

## The defect

`Ts` is the compile-time half of the kind-to-`Data` correspondence. The **tuple** is what remembers that `"clip"` means `Data = Clip`. A plain array has no per-position types, so every mapped type built on it — `EditOf`, `DataForKind`, `KindOf`, `Seed` — collapses from a discriminated union into a cross-product.

Measured, the same wrong-kind edit through `store.dispatch`:

```
types: [clipType, folderType] as const   ->  error, correctly
types: [clipType, folderType]            ->  COMPILED CLEAN
```

A folder's edit under `kind: "clip"` typechecks. So does every other wrong-kind payload.

**Why it survived review:** `createEngine`'s `const Ts` already rescues an *inline* literal, so the documented example is the one form that was never broken. The hole is the named variable declared without `as const` — which is how anyone with more than two node types writes it.

## The guard

A tuple's `length` is a literal; an array's is `number`, so `number extends Ts["length"]` separates them. `RequireTupleTypes` resolves to a string whose **text is the fix**, so the consumer reads *"must be a TUPLE, not an array — add `as const`"* in the error rather than getting an engine that has quietly stopped checking.

**It's intersected onto `createEngine`'s parameter, not declared on `EngineConfig.types`** — and that's not cosmetic. Putting the conditional on the property made `buildRegistry(config.types)` stop compiling, because TypeScript can't resolve a conditional over a still-generic `Ts` inside the body. Fixing *that* would have cost a fifth sanctioned cast in a package that documents its four. An intersection is assignable to each of its members, so `config.types` stays `Ts` and no cast appears. `EngineConfig` also goes on saying `types: Ts`, honestly — that's what a config holds once it exists; the door is where the mistake is made.

## Why the test is a compile-only fixture

**Nothing fails at runtime when this breaks.** The engine still works; it has simply stopped checking, and the next wrong-kind edit surfaces as `applyEdit` throwing on a missing field, in the consumer, months later. A vitest assertion cannot see any of it — the collapse is entirely in the types, so the assertion has to be the compiler.

`typecheck-fixture-types-must-be-a-tuple.ts` follows keel-react's existing fixture convention: `tsc --noEmit` is the assertion, and each `@ts-expect-error` fails the build if the error it names stops happening.

**Seen to fail before being trusted.** With the guard removed:

```
typecheck-fixture-types-must-be-a-tuple.ts(173,3):
  error TS2578: Unused '@ts-expect-error' directive.
```

It can't pass quietly. It also asserts the **right** edits still compile — a fixture that only proved things fail would pass against a type that rejects everything.

## Verification

- `tsc --noEmit` clean for `keel-core` and `keel-react`, and clean under `--noUnusedLocals`
- full `unit` project: **1,539 passing**
- `npm run lint`: 0 errors

## Still open after this

Six mediums — lazy load rebuilding both indexes over the whole merged graph, `tallestSubtree`'s per-descendant `ancestorChain`, exponential seed-forest expansion (13.1s measured before refusal), `emitChange` ordering under re-entrancy, a seed summary stored without going through `parse`, and a repaired shape-mismatch node re-quarantining forever. Plus four lows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)