### PR TITLE
walkPreOrder -> walkInDocumentOrder

### DIFF
--- a/packages/keel-core/graph/queries.ts
+++ b/packages/keel-core/graph/queries.ts
@@ -193,18 +193,40 @@ export function isSameOrAncestor<Ts extends readonly WidenedNodeType[], S>(
 }
 
 /**
- * Pre-order walk from `roots`, children in array order.
+ * Walk from `roots` in DOCUMENT ORDER, children in array order.
+ *
+ * Document order is PRE-ORDER — each node, then its whole subtree, then its
+ * next sibling — which is the order the rows appear in a fully expanded tree,
+ * top to bottom. That equivalence is the definition; this function is named for
+ * the result rather than the traversal because the result is what the rest of
+ * the package talks about. `documentOrder` and `documentOrderComparator` are
+ * public, `selectRange`'s contract is stated in document order, and the derived
+ * index buckets are sorted by it. A private helper called `walkPreOrder` made a
+ * reader translate twice to reach a word the package uses everywhere.
+ *
+ * WHAT DEPENDS ON THE ORDER, not just on visiting everything:
+ *   - `selectRange` is inclusive in document order, so shift-click selects what
+ *     the user sees between two rows.
+ *   - `walkDerivedIndexes` iterates this, so every `placementsByContentKey`
+ *     bucket comes out already sorted — which is what lets
+ *     `placementsAfterInsert` merge two sorted runs instead of re-sorting.
+ *   - `subtreeIds` includes its own root FIRST, and a pre-order root precedes
+ *     all of its descendants both before and after a permutation confined to
+ *     that subtree. `reindexPlacementsWithinSubtree` rests on exactly that.
  *
  * EXPLICIT STACK, never recursion: depth is hostile input — a document is a
  * flat node list off the wire, so nothing bounds nesting except whoever wrote
  * the document.
+ *
+ * Children are pushed in REVERSE so the LIFO pops them front-to-back; push them
+ * forward and every node's children come out mirrored.
  *
  * The `budget` is the same termination guard as `ancestorChain`'s. In a valid
  * graph it is never reached: every reachable id is a node and each is reached
  * once, so the walk length is exactly the number of reachable nodes. It bounds
  * the damage when the graph is not valid.
  */
-function walkPreOrder<Ts extends readonly WidenedNodeType[], S>(
+function walkInDocumentOrder<Ts extends readonly WidenedNodeType[], S>(
   graph: Graph<Ts, S>,
   roots: readonly NodeId[],
 ): NodeId[] {
@@ -237,7 +259,7 @@ export function subtreeIds<Ts extends readonly WidenedNodeType[], S>(
   id: NodeId,
 ): readonly NodeId[] {
   if (!graph.nodesById.has(id)) return NO_IDS;
-  return walkPreOrder(graph, [id]);
+  return walkInDocumentOrder(graph, [id]);
 }
 
 /** Pre-order across every root, in `rootIds` order. Backs `selectRange`, which
@@ -246,7 +268,7 @@ export function subtreeIds<Ts extends readonly WidenedNodeType[], S>(
 export function documentOrder<Ts extends readonly WidenedNodeType[], S>(
   graph: Graph<Ts, S>,
 ): readonly NodeId[] {
-  return walkPreOrder(graph, graph.rootIds);
+  return walkInDocumentOrder(graph, graph.rootIds);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Module-private helper, three references, no behaviour change.

## Why

The helper was named for the **traversal**; the package is named for the **result**:

| term | occurrences in `keel-core` |
|---|--:|
| "document order" (prose) | **48** |
| `documentOrder` (identifier) | **40** |
| "pre-order" | 12 |

And the public function this backs is literally `documentOrder`. A private helper speaking different vocabulary than the surface it implements made a reader translate twice — `walkPreOrder` → "document order" → "what the user sees" — to reach a word the package uses everywhere.

Both call sites now read as statements of fact:

```ts
subtreeIds    -> walkInDocumentOrder(graph, [id])
documentOrder -> walkInDocumentOrder(graph, graph.rootIds)
```

which also makes visible that the public `documentOrder` is just the all-roots case.

**"Pre-order" stays in the doc comment as the definition** — *document order is pre-order across every root* — so the standard CS term is still there for whoever wants it, without being the name.

## The comment gained what it had left implicit

Which callers depend on the **order**, not merely on visiting everything:

- `selectRange` is inclusive in document order, so shift-click selects what the user sees between two rows.
- `walkDerivedIndexes` iterates this, so every `placementsByContentKey` bucket comes out already sorted — which is what lets `placementsAfterInsert` merge two sorted runs instead of re-sorting.
- `subtreeIds` includes its own root **first**, and a pre-order root precedes all its descendants both before and after a permutation confined to that subtree. `reindexPlacementsWithinSubtree` rests on exactly that.

Plus the reverse child push, which was unexplained: push them forward and every node's children come out mirrored.

## Verification

Full gate, including the step I missed on #614:

- `tsc --noEmit` clean, and clean under `--noUnusedLocals`
- `npm run lint:packages` — **0 errors**
- `npm run lint` (app) — 0 errors
- full `unit` project: **1,539 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)