### PR TITLE
A seed forest is a DAG, and the ceiling was checked after the work

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -704,17 +704,64 @@ function depthOf<Ts extends readonly WidenedNodeType[], S>(
 function tallestSeed<Ts extends readonly WidenedNodeType[], S>(
   seeds: readonly Seed<Ts, S>[],
 ): number {
+  // MEMOISED BY OBJECT IDENTITY, because a seed forest is a plain object tree
+  // and nothing stops two branches pointing at the SAME child. That is a DAG,
+  // not a cycle, so the cyclic-seed guard in `buildSeedPlacements` never fires
+  // for it — and a plain walk would visit the shared subtree once per path,
+  // which is 2^depth for one child reused at every level.
+  //
+  // Heights are what memoise cleanly here: a seed's height depends only on the
+  // seed, so the same object always has the same answer and computing it once
+  // makes the walk O(distinct seeds) instead of O(paths).
+  //
+  // The map is scoped to the call and keyed by reference, so it holds the
+  // consumer's objects only for as long as the check runs.
+  const heightOf = new Map<Seed<Ts, S>, number>();
+
+  // ITERATIVE, with an explicit stack, for the reason every walk in this
+  // package is: nesting is consumer-supplied and not this module's to trust.
+  // Two passes over each frame — the first schedules children, the second folds
+  // their finished heights — which is how a post-order fold is written without
+  // recursion.
   let tallest = 0;
-  const stack: Readonly<{ seed: Seed<Ts, S>; depth: number }>[] = seeds.map(
-    (seed) => ({ seed, depth: 1 }),
-  );
-  while (stack.length > 0) {
-    const frame = stack.pop();
-    if (frame === undefined) break;
-    if (frame.depth > tallest) tallest = frame.depth;
-    const kids = frame.seed.children;
-    if (kids === undefined) continue;
-    for (const kid of kids) stack.push({ seed: kid, depth: frame.depth + 1 });
+  for (const root of seeds) {
+    const stack: Readonly<{ seed: Seed<Ts, S>; expanded: boolean }>[] = [
+      { seed: root, expanded: false },
+    ];
+    while (stack.length > 0) {
+      const frame = stack.pop();
+      if (frame === undefined) break;
+      const { seed, expanded } = frame;
+      if (heightOf.has(seed)) continue;
+
+      const kids = seed.children;
+      if (kids === undefined || kids.length === 0) {
+        heightOf.set(seed, 1);
+        continue;
+      }
+
+      if (!expanded) {
+        stack.push({ seed, expanded: true });
+        for (const kid of kids) {
+          if (!heightOf.has(kid)) stack.push({ seed: kid, expanded: false });
+        }
+        continue;
+      }
+
+      let tallestChild = 0;
+      for (const kid of kids) {
+        // Present for every child by now: this frame was re-pushed beneath all
+        // of them. A cyclic seed is the one shape that could leave one missing,
+        // and `buildSeedPlacements` refuses that with `parse-failed` — so the
+        // `?? 0` is a total-function guard, not a silent floor anything relies
+        // on.
+        const kidHeight = heightOf.get(kid) ?? 0;
+        if (kidHeight > tallestChild) tallestChild = kidHeight;
+      }
+      heightOf.set(seed, tallestChild + 1);
+    }
+    const rootHeight = heightOf.get(root) ?? 1;
+    if (rootHeight > tallest) tallest = rootHeight;
   }
   return tallest;
 }
@@ -833,6 +880,43 @@ function buildSeedPlacements<Ts extends readonly WidenedNodeType[], S>(
     }
 
     placements.push({ node, parentId, index });
+
+    // THE CEILING, CHECKED AS WE BUILD rather than after.
+    //
+    // `applyInsertNodes` also checks `maxNodes` once this returns, and that
+    // check is the one whose message a consumer reads — but by then the work is
+    // already done, and the work is what needs bounding. A seed forest is a
+    // plain object tree from the consumer, and nothing stops two branches
+    // pointing at the SAME child object: that is a DAG, not a cycle, so
+    // `seedPathContains` above never fires (no seed is its own ancestor) and the
+    // walk expands it to 2^depth.
+    //
+    // MEASURED against a `maxNodes` of 50, one shared child per level:
+    //
+    //   depth 10  ->    2,048 placements built,     4 ms
+    //   depth 12  ->    8,192                      11 ms
+    //   depth 14  ->   32,768                      37 ms
+    //   depth 16  ->  131,072                     144 ms
+    //
+    // Doubling per level, all of it to end in `would-exceed-max-nodes` for a
+    // ceiling of 50. At depth 30 it is two billion nodes and the process is
+    // gone before anything gets to refuse.
+    //
+    // Refusing HERE makes the cost O(maxNodes) instead of O(2^depth), which is
+    // the same correction ./serialize made on the ingress door — it calls its
+    // equivalent "the EARLIEST honest point". The rejection is shaped exactly
+    // like the post-hoc one so a consumer cannot tell which arm refused; only
+    // `actual` differs, and it is honestly "where we stopped counting" rather
+    // than a total nobody should have computed.
+    const wouldHold = graph.nodesById.size + placements.length;
+    if (wouldHold > ctx.maxNodes) {
+      return fail(
+        "would-exceed-max-nodes",
+        `Inserting these seeds into a graph of ${graph.nodesById.size} would pass ` +
+          `the ${ctx.maxNodes} ceiling. Raise EngineConfig.maxNodes if this is legitimate.`,
+        { parentId: toParentId, limit: ctx.maxNodes, actual: wouldHold },
+      );
+    }
 
     if (seedChildren !== undefined) {
       const path: SeedPath<Ts, S> = { seed, parent: ancestors };

--- a/packages/keel-core/review4-a-seed-forest-is-a-dag-not-a-tree.test.ts
+++ b/packages/keel-core/review4-a-seed-forest-is-a-dag-not-a-tree.test.ts
@@ -1,0 +1,221 @@
+// Fourth review round — the ceiling was checked after the work, not before.
+//
+// A seed forest is a plain object tree handed in by the consumer, and NOTHING
+// stops two branches pointing at the same child object. That is a DAG, not a
+// cycle: no seed is its own ancestor, so `buildSeedPlacements`'s cyclic-seed
+// guard never fires for it. The walk then visits the shared subtree once per
+// PATH, which is 2^depth for one child reused at every level.
+//
+// `applyInsertNodes` did check `maxNodes` — after `buildSeedPlacements`
+// returned, counted from the placements it had already built. So the refusal was
+// correct and the cost was not. MEASURED against a `maxNodes` of 50:
+//
+//   depth      placements built     time      then refused with actual=
+//      10                 2,048      4 ms                        2,048
+//      12                 8,192     11 ms                        8,192
+//      14                32,768     37 ms                       32,768
+//      16               131,072    144 ms                      131,072
+//
+// Doubling per level, all of it to end in `would-exceed-max-nodes` for a ceiling
+// of 50. At depth 30 that is two billion placements and the process is gone
+// before anything gets to refuse.
+//
+// After, at every one of those depths: `actual=51`, under a millisecond. The
+// walk stops the moment it passes the ceiling, so the cost is O(maxNodes)
+// instead of O(2^depth) — the same correction ./serialize made on the ingress
+// door, which calls its equivalent "the EARLIEST honest point".
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  type Seed,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const rootId = parseNodeId("root");
+
+function storeWith(config: Readonly<{ maxNodes?: number; maxDepth?: number }>) {
+  const engine = createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    ...config,
+  });
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { folder: 1 },
+    rootIds: ["root"],
+    nodes: [{ id: "root", kind: "folder", data: { name: "R" }, children: [] }],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+/**
+ * A seed DAG: every level reuses the SAME child object twice.
+ *
+ * Expanded as a tree this is 2^depth nodes. As an object graph it is `depth`
+ * objects. Nothing here is cyclic — walk any path from the root and you never
+ * meet the same object twice on that path — which is exactly why the
+ * cyclic-seed guard cannot catch it.
+ */
+function sharedChildDag(depth: number): Seed<Types, Summary> {
+  let node: Seed<Types, Summary> = {
+    kind: "folder",
+    data: { name: "leaf" },
+    children: [],
+  };
+  for (let i = 0; i < depth; i += 1) {
+    node = { kind: "folder", data: { name: `d${i}` }, children: [node, node] };
+  }
+  return node;
+}
+
+describe("a shared seed child is refused without being expanded", () => {
+  it("stops at the ceiling instead of at 2^depth", () => {
+    const CEILING = 50;
+    for (const depth of [10, 12, 14, 16]) {
+      const { store } = storeWith({ maxNodes: CEILING });
+      const refused = store.dispatch({
+        type: "insert-nodes",
+        toParentId: rootId,
+        toIndex: 0,
+        seeds: [sharedChildDag(depth)],
+      });
+
+      expect(refused.ok).toBe(false);
+      if (refused.ok) return;
+      expect(refused.error.code).toBe("would-exceed-max-nodes");
+
+      // THE ASSERTION THAT MATTERS. `actual` is how many placements had been
+      // built when the walk stopped, so it is a direct readout of the work
+      // done. Before the running budget it was 2^depth — 131,072 at depth 16
+      // against a ceiling of 50. Bounded just above the ceiling now, and FLAT
+      // as depth grows, which is the property a threshold on time could not
+      // state.
+      expect(refused.error.actual).toBeLessThanOrEqual(CEILING + 1);
+
+      // Nothing was written: the reducer validates completely, then applies.
+      expect(store.getGraph().nodesById.size).toBe(1);
+      store.destroy();
+    }
+  }, 120_000);
+
+  it("does not explode in the DEPTH pre-check either", () => {
+    // `tallestSeed` runs before `buildSeedPlacements`, only when `maxDepth` is
+    // set, and it walked the same DAG the same exponential way. It memoises by
+    // object identity now — a seed's height depends only on the seed, so the
+    // same object always has the same answer.
+    const { store } = storeWith({ maxDepth: 4, maxNodes: 100_000 });
+    const refused = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [sharedChildDag(20)],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    // Depth is answered from the seeds alone and refused first, so this never
+    // reaches the node ceiling.
+    expect(refused.error.code).toBe("would-exceed-max-depth");
+    expect(refused.error.actual).toBe(22);
+  }, 120_000);
+
+  it("still refuses a genuinely CYCLIC seed, which is a different shape", () => {
+    // A DAG is not a cycle, and the guard for one is not the guard for the
+    // other. This is the cycle: a seed reachable from itself.
+    const { store } = storeWith({ maxNodes: 100 });
+    const cyclic: { kind: "folder"; data: Folder; children: unknown[] } = {
+      kind: "folder",
+      data: { name: "self" },
+      children: [],
+    };
+    cyclic.children.push(cyclic);
+
+    const refused = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [cyclic as unknown as Seed<Types, Summary>],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("parse-failed");
+  }, 120_000);
+
+  it("still accepts an ordinary nested insert, shared objects included", () => {
+    // The guard must not cost the traffic it sits in front of. A shared child
+    // is LEGAL when the expansion fits — it just means those subtrees are
+    // duplicated, which is what the consumer asked for.
+    const { engine, store } = storeWith({ maxNodes: 100 });
+    const shared: Seed<Types, Summary> = {
+      kind: "folder",
+      data: { name: "shared" },
+      children: [],
+    };
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [
+        { kind: "folder", data: { name: "a" }, children: [shared, shared] },
+      ],
+    });
+    expect(inserted.ok).toBe(true);
+    // One parent plus two independent copies of the shared child: the objects
+    // were shared, the NODES are not.
+    expect(store.getGraph().nodesById.size).toBe(4);
+    expect(engine.findInvariantViolation(store.getGraph())).toBeNull();
+    expect(store.undo().ok).toBe(true);
+    expect(store.getGraph().nodesById.size).toBe(1);
+  });
+});


### PR DESCRIPTION
Next open medium from the review.

## The defect

Seeds arrive as a plain object tree from the consumer, and nothing stops two branches pointing at the **same child object**. That's a DAG, not a cycle — walk any path and you never meet the same object twice on it — so `buildSeedPlacements`'s cyclic-seed guard never fires. The walk then visits the shared subtree once per *path*: **2^depth** for one child reused at every level.

`applyInsertNodes` did check `maxNodes`, but *after* `buildSeedPlacements` returned, counted from placements it had already built. The refusal was correct; the cost was not. Measured against a `maxNodes` of **50**:

| depth | placements built | time | refused with `actual=` |
|--:|--:|--:|--:|
| 10 | 2,048 | 4 ms | 2,048 |
| 12 | 8,192 | 11 ms | 8,192 |
| 14 | 32,768 | 37 ms | 32,768 |
| 16 | 131,072 | 144 ms | 131,072 |

Doubling per level, all of it to end in `would-exceed-max-nodes` for a ceiling of 50. At depth 30 that's two billion placements and the process is gone before anything refuses.

## The fix

A running budget inside the walk makes the cost **O(maxNodes)** rather than O(2^depth) — the same correction `serialize.ts` made on the ingress door, which calls its equivalent *"the EARLIEST honest point"*.

After, at every one of those depths: **`actual=51`, under a millisecond, flat as depth grows.** The rejection is shaped exactly like the post-hoc one, so a consumer can't tell which arm refused.

`tallestSeed` had the same exponential shape on the same input — reachable whenever `maxDepth` is set, and it runs *before* any of this. It now memoises height by object identity (a seed's height depends only on the seed, so the same object always has the same answer), turning the walk into O(distinct seeds). Written as an iterative post-order fold with an explicit stack, because nesting is consumer-supplied and this package doesn't recurse on hostile depth.

## Tests

4 cases. The one that matters asserts **`actual`** — how many placements had been built when the walk stopped, a direct readout of work done — is bounded just above the ceiling and **flat as depth grows**. That's a property a threshold on wall-clock time couldn't state, which matters given three timing gates were deleted this round.

Seen to fail: with the budget disabled it reports `expected 2048 to be less than or equal to 51`. (My first attempt at that control silently didn't apply, and I only caught it because a *passing* control is suspicious.)

The other three keep the guard honest about what it must **not** break: a genuinely cyclic seed is still `parse-failed`, the depth pre-check still refuses first when `maxDepth` is set, and an ordinary insert with a shared child still succeeds — sharing an object is legal, it just means those subtrees are duplicated, which is what the consumer asked for.

## Verification

- `tsc --noEmit` clean, and under `--noUnusedLocals`
- `npm run lint:packages` and app lint — 0 errors
- full `unit` project: **1,543 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)