### PR TITLE
Two ownership names that invited the bug the file is about

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -1263,7 +1263,7 @@ function planEdits<Ts extends readonly WidenedNodeType[], S>(
 
     // DELEGATED, not re-derived — the same correction `owningSourceKey` above
     // already carries. This used to read
-    // `collection === null || ownsSubtree(collection.children)`, and
+    // `collection === null || stateOwnsSubtree(collection.children)`, and
     // `collection === null` IS the leaf case, so it made a leaf an owner. That
     // is verbatim the predicate review3 deleted from ./graph, and it left this
     // door disagreeing with the other four: `walkDerivedIndexes`, invariant
@@ -1275,7 +1275,7 @@ function planEdits<Ts extends readonly WidenedNodeType[], S>(
     // unrepairable state `ownsItsSubtree` was made THE SINGLE ANSWER to end.
     //
     // Total on its own terms: false for quarantined, for a leaf, and for a
-    // `reference` — subsuming the `ownsSubtree` branch this replaced.
+    // `reference` — subsuming the `stateOwnsSubtree` branch this replaced.
     if (ownsItsSubtree<Ts, S>(node)) {
       const nextKey = nodeType.sourceKey?.(nextData) ?? null;
       if (nextKey !== null) {

--- a/packages/keel-core/graph.test.ts
+++ b/packages/keel-core/graph.test.ts
@@ -27,7 +27,7 @@ import {
   isLoaded,
   isSameOrAncestor,
   markMissing,
-  ownsSubtree,
+  stateOwnsSubtree,
   rebuildDerivedIndexes,
   sourceKeyOf,
   subtreeIds,
@@ -346,7 +346,7 @@ describe("queries are total", () => {
   });
 });
 
-describe("childrenStateOf / isCollection / isLoaded / ownsSubtree", () => {
+describe("childrenStateOf / isCollection / isLoaded / stateOwnsSubtree", () => {
   const graph = graphOf({
     nodes: [
       folder("root", LOADED),
@@ -400,10 +400,10 @@ describe("childrenStateOf / isCollection / isLoaded / ownsSubtree", () => {
   });
 
   it("only `reference` disclaims ownership", () => {
-    expect(ownsSubtree({ status: "loaded" })).toBe(true);
-    expect(ownsSubtree({ status: "unloaded" })).toBe(true);
-    expect(ownsSubtree({ status: "missing", reason: "404" })).toBe(true);
-    expect(ownsSubtree({ status: "reference" })).toBe(false);
+    expect(stateOwnsSubtree({ status: "loaded" })).toBe(true);
+    expect(stateOwnsSubtree({ status: "unloaded" })).toBe(true);
+    expect(stateOwnsSubtree({ status: "missing", reason: "404" })).toBe(true);
+    expect(stateOwnsSubtree({ status: "reference" })).toBe(false);
   });
 });
 

--- a/packages/keel-core/graph/incremental-indexes.ts
+++ b/packages/keel-core/graph/incremental-indexes.ts
@@ -520,7 +520,7 @@ export function dataChangeLeavesDerivedIndexesIntact(
   if (nodeType === undefined) return true;
   // TAGGED like the two key accessors above, because these are the same two
   // consumer hooks and this was the ONE place that called them directly rather
-  // than through `contentKeyOf`/`sourceKeyOfKindData`. That is exactly why it
+  // than through `contentKeyOf`/`sourceKeyForData`. That is exactly why it
   // was still leaking after those were wrapped: measured, a throwing
   // `contentKey` reached here from `applyPatch` and escaped BOTH `dispatch` and
   // `undo` — the two doors review3 names — while every other door was already

--- a/packages/keel-core/graph/index.ts
+++ b/packages/keel-core/graph/index.ts
@@ -49,7 +49,7 @@ export {
   isLoaded,
   isSameOrAncestor,
   nodeCount,
-  ownsSubtree,
+  stateOwnsSubtree,
   subtreeIds,
 } from "./queries";
 
@@ -59,7 +59,7 @@ export {
   keyHookMessage,
   ownsItsSubtree,
   sourceKeyOf,
-  sourceKeyOfKindData,
+  sourceKeyForData,
 } from "./keys";
 
 export { bumpSubtreeRevs, bumpSubtreeRevsInto } from "./revisions";

--- a/packages/keel-core/graph/keys.ts
+++ b/packages/keel-core/graph/keys.ts
@@ -15,7 +15,7 @@ import type {
   NodeTypeRegistry,
 } from "../types";
 import { describeThrown } from "../types";
-import { ownsSubtree } from "./queries";
+import { stateOwnsSubtree } from "./queries";
 
 // Both return `null` for a quarantined node, and that is not a shortcut. A
 // quarantined node holds `raw`, not parsed `Data`; no node type is willing to vouch
@@ -112,22 +112,27 @@ export function sourceKeyOf<Ts extends readonly WidenedNodeType[], S>(
   node: GraphNode<Ts, S>,
 ): string | null {
   if (node.quarantined) return null;
-  return sourceKeyOfKindData(registry, node.kind, node.data, node.id);
+  return sourceKeyForData(registry, node.kind, node.data, node.id);
 }
 
 /**
- * The same `sourceKey` call, for a caller holding a value the node does not
- * hold YET.
+ * The key a piece of DATA would claim — for a caller holding a value no node
+ * holds yet.
  *
  * `verifyDataChanged` needs exactly this: it must know what key a patch's
  * `after` would claim before deciding whether replaying it is safe, and the
- * node in the graph still carries the old value. Split out rather than
- * duplicated so the two cannot disagree about which node-type hook answers, and so
- * the deliberate absence of a try/catch stays in ONE place — see the block
- * comment above `contentKeyOf` for why a throwing key function is not swallowed
- * into `null`.
+ * node in the graph still carries the old value.
+ *
+ * `Of` a node, `For` raw data — that is the whole distinction between this and
+ * `sourceKeyOf` above. It was `sourceKeyOfKindData`, which listed its
+ * parameters instead of saying what it answers.
+ *
+ * Split out rather than duplicated so the two cannot disagree about which
+ * node-type hook answers, and so the `KeyHookFailure` wrapping stays in ONE
+ * place — see the block comment at the top of this file for why a throwing key
+ * function is neither swallowed into `null` nor allowed to travel raw.
  */
-export function sourceKeyOfKindData(
+export function sourceKeyForData(
   registry: NodeTypeRegistry,
   kind: string,
   data: unknown,
@@ -169,6 +174,12 @@ export function sourceKeyOfKindData(
  *     have made a stored document stop loading, which is the failure quarantine
  *     exists to prevent and which this repo has already paid for once.
  *
+ * Reads a bare `ChildrenState` through `stateOwnsSubtree` in ./queries, which is
+ * the same question one layer down. Prefer THIS one at every call site that has
+ * a node: it rules out the two cases that have no state to ask about before
+ * delegating, and keeping the pair distinguishable is why that one is named for
+ * its argument.
+ *
  * A quarantined node owns nothing either: its key would have to come from a
  * node type that by definition did not run, so `sourceKeyOf` already answers `null`
  * for it. Stated here as well so the predicate is total on its own terms rather
@@ -179,7 +190,7 @@ export function ownsItsSubtree<Ts extends readonly WidenedNodeType[], S>(
 ): boolean {
   if (node.quarantined) return false;
   if (!node.container) return false;
-  return ownsSubtree(node.children);
+  return stateOwnsSubtree(node.children);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/keel-core/graph/queries.ts
+++ b/packages/keel-core/graph/queries.ts
@@ -125,15 +125,27 @@ export function isLoaded<Ts extends readonly WidenedNodeType[], S>(
 }
 
 /**
- * Does this placement own the subtree beneath it?
+ * Does a placement in this CHILDREN-STATE own the subtree beneath it?
  *
  * `loaded`, `unloaded` and `missing` all own it — `missing` included, because
  * confirmed-gone is knowledge about a subtree you own, not a handoff to someone
  * else. Only `reference` disclaims ownership, and that single fact is what
  * makes the placement forest a genuine tree: a reference is structurally
  * childless forever, so no walk can descend through one into a cycle.
+ *
+ * NAMED FOR ITS ARGUMENT, because the other half of this question lives one
+ * layer up as `ownsItsSubtree(node)` in ./keys and the two were previously one
+ * word apart — `ownsSubtree` and `ownsItsSubtree`, 42 uses between them, taking
+ * different types and answering different questions. Getting ownership wrong in
+ * more than one place is the exact bug ./keys' own history is about, so the
+ * names should not invite it.
+ *
+ * THE DIVISION: this one asks about a STATE and knows nothing about the node
+ * holding it. `ownsItsSubtree` asks about a NODE, and rules out the two cases
+ * that have no state to ask about — quarantined, and leaf — before delegating
+ * here. Call that one unless you are holding a bare `ChildrenState`.
  */
-export function ownsSubtree(state: ChildrenState): boolean {
+export function stateOwnsSubtree(state: ChildrenState): boolean {
   return state.status !== "reference";
 }
 

--- a/packages/keel-core/index.ts
+++ b/packages/keel-core/index.ts
@@ -116,7 +116,7 @@ export {
   isSameOrAncestor,
   markMissing,
   nodeCount,
-  ownsSubtree,
+  stateOwnsSubtree,
   rebuildDerivedIndexes,
   sourceKeyOf,
   subtreeIds,

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -60,7 +60,7 @@ import {
   ownersAfterInsert,
   ownsItsSubtree,
   sourceKeyOf,
-  sourceKeyOfKindData,
+  sourceKeyForData,
   KeyHookFailure,
   keyHookMessage,
   bumpSubtreeRevsInto,
@@ -1684,7 +1684,7 @@ function verifyDataChanged<Ts extends readonly WidenedNodeType[], S>(
       if (node === undefined || !ownsItsSubtree<Ts, S>(node)) continue;
       claims.set(
         change.nodeId,
-        sourceKeyOfKindData(ctx.registry, change.kind, change.after),
+        sourceKeyForData(ctx.registry, change.kind, change.after),
       );
     }
     const conflict = ownershipConflict(graph, claims);

--- a/packages/keel-core/review3-a-leaf-owns-no-subtree.test.ts
+++ b/packages/keel-core/review3-a-leaf-owns-no-subtree.test.ts
@@ -5,11 +5,11 @@
 // non-`reference` one. Three call sites decided who counts as an owner, and
 // they did not agree about LEAVES:
 //
-//   graph.ts    isOwningPlacement   `state === null || ownsSubtree(state)`
+//   graph.ts    isOwningPlacement   `state === null || stateOwnsSubtree(state)`
 //                                   -> a leaf (state null) IS an owner
-//   commands.ts owningSourceKey     `if (node.container && !ownsSubtree(...))`
+//   commands.ts owningSourceKey     `if (node.container && !stateOwnsSubtree(...))`
 //                                   -> the check is skipped for a leaf, so it IS
-//   serialize.ts findDuplicateOwner `if (state === null || !ownsSubtree(state))`
+//   serialize.ts findDuplicateOwner `if (state === null || !stateOwnsSubtree(state))`
 //                                   -> a leaf is SKIPPED, so it is NOT
 //
 // Two against one, and the one was right. Measured before the fix, with two

--- a/packages/keel-core/review4-the-replay-gate-enforces-what-the-forward-door-does.test.ts
+++ b/packages/keel-core/review4-the-replay-gate-enforces-what-the-forward-door-does.test.ts
@@ -414,7 +414,7 @@ describe("the replay gate refuses an insert that would breach maxNodes", () => {
 describe("a leaf owns no sourceKey when it is edited", () => {
   // review3-a-leaf-owns-no-subtree.test.ts fixed three sites and this was the
   // fourth: `planEdits` spelled the rule out again as
-  // `collection === null || ownsSubtree(collection.children)`, and
+  // `collection === null || stateOwnsSubtree(collection.children)`, and
   // `collection === null` IS the leaf case. That is verbatim the predicate
   // review3 deleted. Both edit doors share `planEdits`, so a server-side
   // `applyNonUndoableWrite` could not repair it either.


### PR DESCRIPTION
Stacked on #616 — retarget to `main` once that merges. No behaviour change; 48 sites, 10 files.

## `ownsSubtree` → `stateOwnsSubtree`

These sat one word apart, in different files, taking different types, answering different questions — **42 uses between them**:

```ts
ownsSubtree(state: ChildrenState)   // queries.ts, depth 2
ownsItsSubtree(node: GraphNode)     // keys.ts,    depth 3
```

Getting ownership wrong in more than one place is the *exact* bug `graph/keys.ts`'s own history is about: three call sites decided it independently, disagreed about leaves, and produced a document that loaded, failed its own audit, and could not be repaired through the API. Names you have to look twice at invite the mistake the file exists to prevent.

Naming the primitive for its **argument** settles it. `stateOwnsSubtree` asks about a state and knows nothing about the node holding it; `ownsItsSubtree` asks about a node, rules out the two cases that have no state to ask about — quarantined, and leaf — then delegates. Each doc now points at the other and says which to reach for.

**Deliberately not `isOwningState`**, which is the more idiomatic `is*` form: it's a near-miss of `isOwningPlacement`, the **deleted** predicate that `review3-a-leaf-owns-no-subtree.test.ts` quotes by name as the wrong answer. A name one letter from "the bug" is worse than a slightly less idiomatic one.

## `sourceKeyOfKindData` → `sourceKeyForData`

The old name listed its parameters instead of saying what it answers. It's the key a piece of **data** would claim, for a caller holding a value no node holds yet — `verifyDataChanged` checking a patch's `after` before deciding replay is safe.

**`Of` a node, `For` raw data.** That's the whole distinction from `sourceKeyOf` beside it, and the names now carry it.

## Verification

- `tsc --noEmit` clean, and under `--noUnusedLocals`
- `npm run lint:packages` and app lint — 0 errors
- full `unit` project: **1,543 passing**, unchanged
- `ownsItsSubtree` untouched at 25 uses; zero occurrences of either old name remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)