### PR TITLE
"Leaves ... intact" garden-paths in a codebase full of leaves

### DIFF
--- a/packages/keel-core/commands.ts
+++ b/packages/keel-core/commands.ts
@@ -45,7 +45,7 @@ import {
   type WidenedNodeType,
 } from "./types";
 import {
-  dataChangeLeavesDerivedIndexesIntact,
+  derivedIndexesSurviveDataChange,
   KeyHookFailure,
   keyHookMessage,
   ownsItsSubtree,
@@ -1644,7 +1644,7 @@ function applyNonUndoableWriteEditsUnguarded<Ts extends readonly WidenedNodeType
   // `placementsByContentKey` stops churning on every server write.
   const movesAKey = plans.some(
     (plan) =>
-      !dataChangeLeavesDerivedIndexesIntact(
+      !derivedIndexesSurviveDataChange(
         ctx.registry,
         plan.kind,
         plan.before,

--- a/packages/keel-core/graph/incremental-indexes.ts
+++ b/packages/keel-core/graph/incremental-indexes.ts
@@ -294,7 +294,7 @@ export function placementsAfterInsert<Ts extends readonly WidenedNodeType[], S>(
     else bucket.push(node.id);
   }
   // Nothing arriving carries a key, so the index is exactly what it was. By
-  // reference, which is what `insertLeavesDerivedIndexesIntact` bought before
+  // reference, which is what `derivedIndexesSurviveInsert` bought before
   // this function existed and is worth keeping.
   if (arrivalsByKey.size === 0) return previous;
 
@@ -486,8 +486,16 @@ export function derivedIndexesAfterRemoval<Ts extends readonly WidenedNodeType[]
  * can disturb are the ones it would contribute itself. A batch that contributes
  * no key at all (a new folder, in a registry where only clips carry keys) leaves
  * both maps exactly as they were, and both can be handed on by reference.
+ *
+ * "SURVIVE", not the "leaves ... intact" this and its data-change sibling used
+ * to be called. `insertLeavesDerivedIndexesIntact` meant "leaves" as the verb,
+ * but this package has `LeafNode`, `leaf-seed-with-children`, and a comment
+ * titled "a leaf owns nothing" — leaf is a NOUN here, so the name parsed as
+ * "insert leaves" before it parsed as "insert leaves them intact". A word that
+ * garden-paths in the one codebase it lives in is the wrong word, however
+ * correct its grammar.
  */
-export function insertLeavesDerivedIndexesIntact<Ts extends readonly WidenedNodeType[], S>(
+export function derivedIndexesSurviveInsert<Ts extends readonly WidenedNodeType[], S>(
   registry: NodeTypeRegistry,
   nodes: readonly GraphNode<Ts, S>[],
 ): boolean {
@@ -510,7 +518,7 @@ export function insertLeavesDerivedIndexesIntact<Ts extends readonly WidenedNode
  * `data-changed` cannot move a node, so document order is untouched and equal
  * keys really do mean an untouched index.
  */
-export function dataChangeLeavesDerivedIndexesIntact(
+export function derivedIndexesSurviveDataChange(
   registry: NodeTypeRegistry,
   kind: string,
   before: unknown,

--- a/packages/keel-core/graph/index.ts
+++ b/packages/keel-core/graph/index.ts
@@ -73,9 +73,9 @@ export {
 } from "./derived-indexes";
 
 export {
-  dataChangeLeavesDerivedIndexesIntact,
+  derivedIndexesSurviveDataChange,
   derivedIndexesAfterRemoval,
-  insertLeavesDerivedIndexesIntact,
+  derivedIndexesSurviveInsert,
   ownersAfterInsert,
   placementsAfterInsert,
   reindexPlacementsAcrossMove,

--- a/packages/keel-core/patches.ts
+++ b/packages/keel-core/patches.ts
@@ -64,7 +64,7 @@ import {
   KeyHookFailure,
   keyHookMessage,
   bumpSubtreeRevsInto,
-  dataChangeLeavesDerivedIndexesIntact,
+  derivedIndexesSurviveDataChange,
   derivedIndexNeed,
   derivedIndexesAfterRemoval,
   rebuildDerivedIndexes,
@@ -831,7 +831,7 @@ function applyInserted<Ts extends readonly WidenedNodeType[], S>(
   // bucket stays sorted, and the only new entries are the arrivals' own.
   //
   // This used to fall back to a whole-document rebuild whenever ANY arriving
-  // node carried a key — and `insertLeavesDerivedIndexesIntact` short-circuits
+  // node carried a key — and `derivedIndexesSurviveInsert` short-circuits
   // on the first keyed node, so one keyed seed condemned the whole batch.
   // MEASURED, counting `contentKey`: inserting ONE clip cost 1,002 / 10,002 /
   // 40,002 calls at those board sizes, while removing one cost 1, because the
@@ -1033,7 +1033,7 @@ function applyDataChanged<Ts extends readonly WidenedNodeType[], S>(
   // per change; rebuilding costs a document-order DFS plus two calls per NODE.
   const movesAKey = changes.some(
     (change) =>
-      !dataChangeLeavesDerivedIndexesIntact(
+      !derivedIndexesSurviveDataChange(
         ctx.registry,
         change.kind,
         change.before,


### PR DESCRIPTION
Stacked on #617 — retarget to `main` once that merges. No behaviour change; 10 sites, 4 files.

```
insertLeavesDerivedIndexesIntact     -> derivedIndexesSurviveInsert
dataChangeLeavesDerivedIndexesIntact -> derivedIndexesSurviveDataChange
```

## Why

"Leaves" was meant as the verb. But this package has `LeafNode`, `leaf-seed-with-children`, and a comment titled *"a leaf owns nothing"* — **leaf is a noun here**. So `insertLeaves…` parses as *"insert leaves"* before it parses as *"insert leaves them intact"*, and the reader has to back up and re-read.

A word that garden-paths in the one codebase it lives in is the wrong word, however correct its grammar. I misread it myself on first pass through the file.

## Why `Survive`

Same meaning, no ambiguous term, and it puts the subject first — `derivedIndexes…` — which matches the family beside it: `placementsAfterInsert`, `ownersAfterInsert`, `derivedIndexesAfterRemoval`.

The `Survive` verb is also what still marks these two as the **predicates** of the group. They answer yes/no; the others return an index. Keeping that visible in the name is worth the extra syllable.

## Verification

- `tsc --noEmit` clean, and under `--noUnusedLocals`
- `npm run lint:packages` and app lint — 0 errors
- full `unit` project: **1,543 passing**, unchanged
- zero occurrences of either old name remain; both prose mentions in `patches.ts` and `incremental-indexes.ts` moved with them

## Not done

You picked A, so the shape unification is left alone — the two `reindexPlacements…` functions keep their verb-first grammar while the other five are noun-first. That's still available as a follow-up if the inconsistency bothers you later; it's 22 uses and mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)