### PR TITLE
serializeChecked: a save that can refuse a graph it cannot load back

### DIFF
--- a/packages/keel-core/engine.ts
+++ b/packages/keel-core/engine.ts
@@ -1320,6 +1320,15 @@ export function createEngine<
     deserialize: (raw) => deserializeDocument<Ts, S>(raw, ctx),
     serialize: (graph) => serializeGraph(graph, ctx),
 
+    // THE AUDIT FIRST, then the bytes. Ordered that way on purpose: computing
+    // the document and then discarding it would pay the whole serialize cost
+    // for a graph already known to be unwritable.
+    serializeChecked: (graph) => {
+      const violation = findInvariantViolationIn(graph, registry);
+      if (violation !== null) return { ok: false, error: violation };
+      return { ok: true, value: serializeGraph(graph, ctx) };
+    },
+
     applyCommand: (graph, command) => applyCommandWithPolicy(graph, command),
     applyPatch: (graph, patch) => applyPatchTo(graph, patch, ctx),
     invertPatch: (patch) => invertPatchOf(patch),

--- a/packages/keel-core/review4-a-save-can-refuse-a-graph-that-will-not-load.test.ts
+++ b/packages/keel-core/review4-a-save-can-refuse-a-graph-that-will-not-load.test.ts
@@ -1,0 +1,254 @@
+// Fourth review round — the audit had no production home.
+//
+// `findInvariantViolation` is the only thing that checks the ENGINE against
+// itself. Ingress cannot do that job: a wire document has no opinion about
+// `parentById`, `subtreeRevById` or the derived indexes, because ingress BUILDS
+// all three rather than reading them. Every audit-only code — `parent-index-
+// disagrees`, `missing-subtree-rev`, `derived-index-stale`,
+// `loaded-collection-missing-children-entry` — is about state only our own
+// mutation code can corrupt.
+//
+// And it ran nowhere in production. `EngineConfig.devChecks` is off by default,
+// so the one check positioned to catch an engine bug was absent from every
+// build where an engine bug would actually cost something.
+//
+// WHY THAT MATTERED. `serializeGraph` emits unreachable nodes deliberately —
+// dropping them is the worse loss — so a corrupt graph SAVES CLEANLY and
+// `deserialize` refuses the file afterwards, forever. The write succeeds and the
+// document is gone. That is not hypothetical: it is what the cyclic move patch
+// in #605 produced, and this test reproduces it through the public surface.
+//
+// WHY SAVE AND NOT EVERY COMMIT. The audit is a full pass — reachability, one
+// `sourceKey` per node, and a complete rebuild of both derived indexes to
+// compare. MEASURED against a single `edit-nodes` on the same graph:
+//
+//     10,501 nodes   commit  3.00 ms   audit   9.18 ms   3.1x
+//     26,251 nodes   commit  6.05 ms   audit  21.05 ms   3.5x
+//     52,501 nodes   commit 12.89 ms   audit  53.62 ms   4.2x
+//
+// Per keystroke that is a frame gone at the size `DEFAULT_INTERACTIVE_NODE_BUDGET`
+// already calls expensive, and the multiple GROWS with the document. Per save it
+// is 53 ms once, against a corruption that is otherwise permanent.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+import { applyPatch, verifyPatchApplies } from "./patches";
+import { buildRegistry } from "./graph";
+import { DEFAULT_MAX_NODES } from "./serialize";
+
+type Clip = Readonly<{ title: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const title = ({ ...raw } as Record<string, unknown>)["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const makeEngine = () =>
+  createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+
+/** root -> [Y(folder,[y1]), X(folder,[x1])]. Two sibling folders. */
+const twoSiblingFolders = {
+  formatVersion: 1 as const,
+  schemaVersions: { clip: 1, folder: 1 },
+  rootIds: ["root"],
+  nodes: [
+    {
+      id: "root",
+      kind: "folder",
+      data: { name: "Root" },
+      children: ["Y", "X"],
+    },
+    { id: "Y", kind: "folder", data: { name: "Y" }, children: ["y1"] },
+    { id: "y1", kind: "clip", data: { title: "y1" } },
+    { id: "X", kind: "folder", data: { name: "X" }, children: ["x1"] },
+    { id: "x1", kind: "clip", data: { title: "x1" } },
+  ],
+};
+
+/**
+ * A graph the engine itself produced and cannot load back.
+ *
+ * Built the only way it can be: `applyPatch` with a hand-built cyclic move. The
+ * REDUCER refuses this (`would-create-cycle`), and since #605 so does
+ * `verifyPatchApplies` — asserted below, because a corruption fixture that
+ * silently stops corrupting is a test that passes for the wrong reason.
+ */
+function corruptedGraph() {
+  const engine = makeEngine();
+  const loaded = engine.deserialize(twoSiblingFolders);
+  if (!loaded.ok) throw new Error("fixture failed to load");
+
+  const ctx = {
+    engineId: loaded.value.graph.engineId,
+    registry: buildRegistry(types),
+    summary,
+    onUnknownKind: "quarantine" as const,
+    onParseFailure: "quarantine" as const,
+    maxNodes: DEFAULT_MAX_NODES,
+    maxDepth: null,
+    mintId: (): string => "minted",
+    now: (): number => 0,
+    devChecks: false,
+  };
+
+  // STEP 1, entirely legal: move Y into X. Through the reducer, so there is no
+  // doubt it is a state the engine will really produce.
+  const store = engine.createStore(loaded.value.graph);
+  const moved = store.dispatch({
+    type: "move-nodes",
+    nodeIds: [parseNodeId("Y")],
+    toParentId: parseNodeId("X"),
+    toIndex: 0,
+  });
+  expect(moved.ok).toBe(true);
+  const afterFirst = store.getGraph();
+
+  // STEP 2: move X into Y, which now closes the ring. Both are CONTAINERS, so
+  // the resulting graph's only fault is the cycle — an earlier draft of this
+  // fixture moved X into a clip, and the audit reported `leaf-with-children`
+  // first, which is a different mess and would have tested the wrong thing.
+  const cyclicMove = {
+    type: "moved" as const,
+    moves: [
+      {
+        nodeId: parseNodeId("X"),
+        fromParentId: parseNodeId("root"),
+        fromIndex: 0,
+        toParentId: parseNodeId("Y"),
+        toIndex: 0,
+      },
+    ],
+  };
+
+  // The replay gate must still refuse it — that is #605's fix, and this fixture
+  // has to go around it deliberately rather than by accident.
+  const gated = verifyPatchApplies(afterFirst, cyclicMove, ctx);
+  expect(gated.ok).toBe(false);
+
+  return { engine, graph: applyPatch(afterFirst, cyclicMove, ctx) };
+}
+
+describe("a save can refuse a graph that will not load back", () => {
+  it("the corruption really does save cleanly and then never load", () => {
+    // The whole reason the checked door exists. Asserted first, so if
+    // `serializeGraph` ever starts dropping unreachable nodes this test says so
+    // rather than quietly protecting nothing.
+    const { engine, graph } = corruptedGraph();
+
+    expect(engine.findInvariantViolation(graph)).not.toBeNull();
+
+    const wire = engine.serialize(graph);
+    expect(wire.nodes.length).toBe(5);
+
+    const reloaded = engine.deserialize(wire);
+    expect(reloaded.ok).toBe(false);
+    if (reloaded.ok) return;
+    expect(reloaded.error.code).toBe("unreachable-node");
+  });
+
+  it("serializeChecked refuses it, and hands back the violation", () => {
+    const { engine, graph } = corruptedGraph();
+
+    const written = engine.serializeChecked(graph);
+    expect(written.ok).toBe(false);
+    if (written.ok) return;
+    // The violation itself, not a wrapper — the caller can report which node.
+    expect(written.error.code).toBe("unreachable-node");
+    expect(written.error.nodeId).toBeDefined();
+  });
+
+  it("serialize stays TOTAL, which is why the checked door is separate", () => {
+    // "A save path that throws loses the user's document" is `serializeGraph`'s
+    // own contract. Refusing is a save that did not happen, so the refusal has
+    // to be opt-in and the default has to keep writing.
+    const { engine, graph } = corruptedGraph();
+    expect(() => engine.serialize(graph)).not.toThrow();
+  });
+
+  it("a sound graph passes through unchanged", () => {
+    // The guard must not cost the traffic it sits in front of: same bytes as
+    // `serialize`, so a caller can switch doors without changing what is stored.
+    const engine = makeEngine();
+    const loaded = engine.deserialize(twoSiblingFolders);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const written = engine.serializeChecked(loaded.value.graph);
+    expect(written.ok).toBe(true);
+    if (!written.ok) return;
+    expect(written.value).toEqual(engine.serialize(loaded.value.graph));
+
+    // And it round-trips, which is the property the whole door is protecting.
+    expect(engine.deserialize(written.value).ok).toBe(true);
+  });
+});

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1706,6 +1706,48 @@ export type Engine<
   >;
   serialize(graph: Graph<Ts, S>): SerializedDocument;
 
+  /**
+   * `serialize`, refusing a graph that would not load back.
+   *
+   * THE FAILURE THIS EXISTS FOR is one this engine has actually produced: a
+   * cyclic move patch detached a document from every root, `serializeGraph`
+   * wrote all of it — it emits unreachable nodes deliberately rather than
+   * dropping them, because dropping is the worse loss — and `deserialize` then
+   * refused that file FOREVER with `unreachable-node`. The write succeeded and
+   * the document was gone.
+   *
+   * `serialize` stays TOTAL and unchanged. It has to: "a save path that throws
+   * loses the user's document" is its own contract, and a save that refuses is
+   * a save that did not happen. This is the door for a caller who would rather
+   * hear about a broken graph BEFORE writing it somewhere, and it hands back
+   * the violation instead of the bytes so that decision is theirs.
+   *
+   *   const written = engine.serializeChecked(store.getGraph());
+   *   if (!written.ok) return reportCorruption(written.error);
+   *   await storage.put(written.value);
+   *
+   * WHY SAVE AND NOT EVERY COMMIT. The audit is a full pass — reachability,
+   * one `sourceKey` call per node, and a complete rebuild of both derived
+   * indexes to compare. MEASURED against a single `edit-nodes` on the same
+   * graph:
+   *
+   *     10,501 nodes   commit  3.00 ms   audit   9.18 ms   3.1x
+   *     26,251 nodes   commit  6.05 ms   audit  21.05 ms   3.5x
+   *     52,501 nodes   commit 12.89 ms   audit  53.62 ms   4.2x
+   *
+   * Per keystroke that is a frame gone at the size `DEFAULT_INTERACTIVE_NODE_BUDGET`
+   * already calls expensive, and the multiple GROWS with the document. Per
+   * save it is 53 ms once, against a corruption that is otherwise permanent —
+   * which is the trade `EngineConfig.devChecks` cannot make, because it is off
+   * in production and this is exactly where production needs it.
+   *
+   * Not free and not automatic: `serialize` remains the default, and a consumer
+   * saving on every keystroke should keep using it.
+   */
+  serializeChecked(
+    graph: Graph<Ts, S>,
+  ): Result<SerializedDocument, Violation>;
+
   // ---- the pure core ----
   applyCommand(
     graph: Graph<Ts, S>,

--- a/packages/keel-core/types.ts
+++ b/packages/keel-core/types.ts
@@ -1726,6 +1726,24 @@ export type Engine<
    *   if (!written.ok) return reportCorruption(written.error);
    *   await storage.put(written.value);
    *
+   * BLOCK, DO NOT WRITE — the decided default, and the reason is worth keeping
+   * next to the door. When this refuses, the PREVIOUSLY saved document is still
+   * loadable; the one in memory is not. Writing anyway trades a good file for a
+   * dead one. Blocking costs the unsaved edits; saving costs the document.
+   *
+   * THE ALERT IS THE CONSUMER'S, and not by omission. This package has no React
+   * and no DOM below `./index` — that separation is what lets a route handler
+   * call `deserialize` without importing a client module — so nothing here can
+   * or should reach a user. What it owes the consumer instead is a violation
+   * worth acting on: `code` to branch on, `nodeId` to name the item in the
+   * consumer's own vocabulary. `message` is written for a developer and belongs
+   * in a log, not in front of a user.
+   *
+   * A REPAIR PATH, if one is ever wanted, is additive and needs nothing here:
+   * a separate `repair(graph)` door returning a corrected `Graph`, and the flow
+   * becomes refuse -> repair -> retry. Recorded so that adopting block-and-alert
+   * now is not a decision that has to be unpicked later.
+   *
    * WHY SAVE AND NOT EVERY COMMIT. The audit is a full pass — reachability,
    * one `sourceKey` call per node, and a complete rebuild of both derived
    * indexes to compare. MEASURED against a single `edit-nodes` on the same


### PR DESCRIPTION
Prototype of the audit-on-save idea, after measuring why audit-on-every-commit isn't viable.

## The gap

`findInvariantViolation` is the only thing that checks the **engine against itself**. Ingress can't do that job — a wire document has no opinion about `parentById`, `subtreeRevById` or the derived indexes, because ingress *builds* all three rather than reading them. Every audit-only code (`parent-index-disagrees`, `missing-subtree-rev`, `derived-index-stale`, …) is about state only our own mutation code can corrupt.

And it ran **nowhere in production**. `devChecks` is off by default, so the one check positioned to catch an engine bug was absent from every build where an engine bug costs something.

**Why that matters:** `serializeGraph` emits unreachable nodes deliberately — dropping them is the worse loss — so a corrupt graph **saves cleanly** and `deserialize` refuses that file afterwards, *forever*. The write succeeds and the document is gone. Not hypothetical: it's what #605's cyclic move produced, and the test reproduces it through the public surface.

## Why a second door rather than changing `serialize`

`serialize` stays total and unchanged. It has to — *"a save path that throws loses the user's document"* is its own contract, and a save that refuses is a save that did not happen.

`serializeChecked` returns `Result<SerializedDocument, Violation>`, handing back the violation instead of the bytes so the decision stays with the caller:

```ts
const written = engine.serializeChecked(store.getGraph());
if (!written.ok) return reportCorruption(written.error);
await storage.put(written.value);
```

## Why save and not every commit

Measured against one `edit-nodes` on the same graph:

| nodes | commit | audit | |
|--:|--:|--:|--:|
| 10,501 | 3.00 ms | 9.18 ms | **3.1×** |
| 26,251 | 6.05 ms | 21.05 ms | **3.5×** |
| 52,501 | 12.89 ms | 53.62 ms | **4.2×** |

Per keystroke that's a frame gone at the size `DEFAULT_INTERACTIVE_NODE_BUDGET` already calls expensive, and the multiple **grows** with the document — check 8 calls `sourceKey` per node, check 9 rebuilds both derived indexes to compare. Per save it's 53 ms once, against a corruption that is otherwise permanent.

The audit runs **before** the bytes: computing a document then discarding it would pay the whole serialize cost for a graph already known to be unwritable.

## Tests

4 cases. The first asserts the corruption **really does** save cleanly and then fail to load — if `serializeGraph` ever starts dropping unreachable nodes, that test says so rather than leaving the other three quietly protecting nothing. The fixture also asserts `verifyPatchApplies` still **refuses** the cyclic patch, so it's going around #605's gate deliberately rather than because the gate regressed.

An earlier draft of that fixture moved a folder into a **clip**, and the audit reported `leaf-with-children` first — a different corruption that would have tested the wrong thing. Both nodes are containers now.

## Verification

- `tsc --noEmit` clean for `keel-core` and `keel-react`, and under `--noUnusedLocals`
- both lints — 0 errors
- full `unit` project: **1,547 passing**

`Engine` gains a method. Additive, and no barrel change — it's a method on the engine object, not a module function.

## Open question for you

Whether the app should adopt it at its save site. I've deliberately not wired it up — that's a behaviour change in your persistence path, and it's worth deciding whether a refused save should block, warn, or fall back to `serialize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)