### PR TITLE
A lazy page checks its arrivals, not the whole graph

### DIFF
--- a/packages/graph-core/review4-a-lazy-page-checks-the-arrivals-not-the-graph.test.ts
+++ b/packages/graph-core/review4-a-lazy-page-checks-the-arrivals-not-the-graph.test.ts
@@ -1,0 +1,174 @@
+// Fourth review round — a lazy page validated itself against the whole graph.
+//
+// `loadChildrenInto` ran TWO O(resident) passes to admit O(page) nodes:
+// `findDuplicateOwner` over the merged graph, then `rebuildDerivedIndexes` over
+// it again. Both call CONSUMER node types per node, which is the cost that
+// matters — `sourceKey` and `contentKey` are arbitrary user code, not map reads.
+//
+// This fixes the first pass only. MEASURED, page held at 200 nodes, counting
+// hook invocations rather than milliseconds:
+//
+//   resident    sourceKey before -> after    contentKey (unchanged)
+//      4,002         504 ->   252                 3,950
+//     16,002       2,004 -> 1,002                15,200
+//     64,002       8,004 -> 4,002                60,200
+//
+// WHAT WAS TRIED AND REJECTED. The obvious second half — swap
+// `rebuildDerivedIndexes` for `placementsAfterInsert`/`ownersAfterInsert`, the
+// updaters `applyInserted` already uses — was implemented and MEASURED SLOWER:
+// 57.88ms against 37.08ms at 64k resident. Those updaters are built for
+// arrivals that contribute NO content key, where they return the map by
+// identity. When arrivals land in buckets that already hold incumbents they
+// must build `documentOrderComparator(post)` and merge each bucket — O(resident)
+// again — and they can then DECLINE (`return null`) into the full rebuild,
+// paying for both. Reverted. Do not re-attempt without a plan for the merge.
+//
+// Also measured: four `new Map(...)` copies of the resident graph account for
+// 21.73ms of the 37ms at 64k. Even deleting the index work entirely caps the
+// available win near 40%.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType, type Issue, type Result,
+  defineNodeType, parseNodeId,
+} from "./types";
+import { createEngine } from "./engine";
+
+const calls = { source: 0 };
+
+type Clip = Readonly<{ title: string }>;
+const clipType = defineNodeType<Clip, Readonly<{ title?: string }>>()({
+  kind: "clip", container: false, schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    const t = ({ ...(raw as object) } as Record<string, unknown>)["title"];
+    return typeof t === "string" ? { ok: true, value: { title: t } } : { ok: false, error: [{ path: "$", message: "t" }] };
+  },
+  serialize: (d) => ({ title: d.title }),
+  applyEdit: (d, e) => ({ ok: true, value: { ...d, title: e.title ?? d.title } }),
+});
+
+type Folder = Readonly<{ name: string; src: string }>;
+const folderType = defineNodeType<Folder, Readonly<{ name?: string }>>()({
+  kind: "folder", container: true, schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    const r = { ...(raw as object) } as Record<string, unknown>;
+    return typeof r["name"] === "string" && typeof r["src"] === "string"
+      ? { ok: true, value: { name: r["name"], src: r["src"] } }
+      : { ok: false, error: [{ path: "$", message: "n" }] };
+  },
+  serialize: (d) => ({ name: d.name, src: d.src }),
+  applyEdit: (d, e) => ({ ok: true, value: { ...d, name: e.name ?? d.name } }),
+  // Counted: the consumer code the walk called once per RESIDENT container in
+  // order to admit a page containing none of them.
+  sourceKey: (d) => { calls.source += 1; return d.src; },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse: (raw) => { const n = ({ ...(raw as object) } as Record<string, unknown>)["n"];
+    return typeof n === "number" ? { ok: true, value: { n } } : { ok: false, error: [{ path: "$", message: "n" }] }; },
+  serialize: (v) => ({ n: v.n }),
+};
+
+const lazyId = parseNodeId("lazy");
+
+function residentGraph(folders: number) {
+  const nodes: unknown[] = [
+    { id: "root", kind: "folder", data: { name: "R", src: "src-root" },
+      children: [...Array.from({ length: folders }, (_, f) => "f" + f), "lazy"] },
+    { id: "lazy", kind: "folder", data: { name: "L", src: "src-lazy" }, childrenState: "unloaded" },
+  ];
+  for (let f = 0; f < folders; f++) {
+    nodes.push({ id: "f" + f, kind: "folder", data: { name: "f" + f, src: "src-f" + f }, children: ["c" + f] });
+    nodes.push({ id: "c" + f, kind: "clip", data: { title: "c" + f } });
+  }
+  return { formatVersion: 1 as const, schemaVersions: { clip: 1, folder: 1 }, rootIds: ["root"], nodes };
+}
+
+function engineWith(folders: number) {
+  const engine = createEngine<Types, Summary, {}>({ types, summary, folds: {}, maxNodes: 500_000 });
+  const loaded = engine.deserialize(residentGraph(folders));
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return { engine, graph: loaded.value.graph };
+}
+
+/** A page of plain clips, carrying no ownership of its own. */
+function clipPage(n: number) {
+  return {
+    formatVersion: 1 as const, schemaVersions: { clip: 1, folder: 1 },
+    rootIds: Array.from({ length: n }, (_, i) => "p" + i),
+    nodes: Array.from({ length: n }, (_, i) => ({ id: "p" + i, kind: "clip", data: { title: "p" + i } })),
+  };
+}
+
+describe("a lazy page is checked against its arrivals, not the whole graph", () => {
+  it("halves the ownership walk, counted rather than timed", () => {
+    // A COUNT of consumer-code invocations, not a duration — this repo has
+    // thrown away three wall-clock gates that could not survive CI, and a call
+    // count is the same fact without the variance.
+    const { engine, graph } = engineWith(3200);
+    const residentContainers = 3202; // f0..f3199, plus root and lazy
+
+    calls.source = 0;
+    expect(engine.loadChildren(graph, lazyId, clipPage(200)).ok).toBe(true);
+
+    // BEFORE: two walks, so ~2x residentContainers (measured 8,004 against
+    // 4,002 containers). AFTER: the rebuild's single walk. Asserted as a bound
+    // under 2x rather than an equality, so reducing the REMAINING walk later
+    // strengthens this test instead of breaking it.
+    expect(calls.source).toBeGreaterThan(0);
+    expect(calls.source).toBeLessThan(residentContainers * 2);
+    expect(calls.source).toBeLessThanOrEqual(residentContainers + 200);
+  }, 120_000);
+
+  it("still REFUSES a page whose owner collides with an incumbent", () => {
+    // The whole reason the old walk existed. Halving the work must not cost
+    // the check.
+    const { engine, graph } = engineWith(10);
+    const refused = engine.loadChildren(graph, lazyId, {
+      formatVersion: 1 as const, schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["dup"],
+      nodes: [{ id: "dup", kind: "folder", data: { name: "dup", src: "src-f3" }, children: [] }],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("malformed-document");
+    expect(refused.error.message).toContain("src-f3");
+  });
+
+  it("still REFUSES two arrivals claiming the same key as each other", () => {
+    // The incumbent map cannot catch this one — both are new. The arrivals-only
+    // check carries its own claimed set, and this is the test that says so.
+    const { engine, graph } = engineWith(10);
+    const refused = engine.loadChildren(graph, lazyId, {
+      formatVersion: 1 as const, schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["a", "b"],
+      nodes: [
+        { id: "a", kind: "folder", data: { name: "a", src: "src-twin" }, children: [] },
+        { id: "b", kind: "folder", data: { name: "b", src: "src-twin" }, children: [] },
+      ],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.message).toContain("src-twin");
+  });
+
+  it("accepts a page owning keys nobody holds, and stays sound", () => {
+    // The guard must not cost the traffic it sits in front of.
+    const { engine, graph } = engineWith(10);
+    const loaded = engine.loadChildren(graph, lazyId, {
+      formatVersion: 1 as const, schemaVersions: { clip: 1, folder: 1 },
+      rootIds: ["n1", "n2"],
+      nodes: [
+        { id: "n1", kind: "folder", data: { name: "n1", src: "src-new1" }, children: [] },
+        { id: "n2", kind: "folder", data: { name: "n2", src: "src-new2" }, children: [] },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(engine.findInvariantViolation(loaded.value.graph)).toBeNull();
+    expect(loaded.value.graph.ownerBySourceKey.get("src-new1")).toBe(parseNodeId("n1"));
+  });
+});

--- a/packages/graph-core/serialize.ts
+++ b/packages/graph-core/serialize.ts
@@ -1209,6 +1209,54 @@ function findDuplicateOwner<Ts extends readonly WidenedNodeType[], S>(
   return null;
 }
 
+/**
+ * The duplicate-owner check a LAZY PAGE needs, over the ARRIVALS alone.
+ *
+ * `findDuplicateOwner` answers the same question by walking every node in the
+ * merged graph and calling `sourceKeyOf` on each — O(resident) node-type calls
+ * to admit a page of 200. This is O(arrivals), and sound for the reason the
+ * incremental index updaters are: a load ADDS nodes and changes no existing
+ * node's `data`, so no incumbent's `sourceKey` moves, and the target's own
+ * ownership is unchanged because `unloaded` and `loaded` BOTH own — only
+ * `reference` disclaims (`stateOwnsSubtree`). The only conflicts a load can
+ * create are therefore arrival-vs-incumbent and arrival-vs-arrival, and both
+ * are visible from the arrivals plus the pre-load `ownerBySourceKey`.
+ *
+ * WHAT THIS DELIBERATELY STOPS DOING: re-auditing the WHOLE graph on every page
+ * load. A duplicate already sitting among resident nodes is not this door's to
+ * find — `ownerBySourceKey` cannot represent one, `findInvariantViolation`
+ * check 8 is what names it, and `applyInserted` has always trusted that map the
+ * same way.
+ *
+ * Message and shape are identical to `findDuplicateOwner`'s, so which door
+ * refused is not something a consumer can tell from the rejection.
+ */
+function findDuplicateOwnerAmongArrivals<
+  Ts extends readonly WidenedNodeType[],
+  S,
+>(
+  ownerBySourceKey: ReadonlyMap<string, NodeId>,
+  registry: NodeTypeRegistry,
+  arrived: readonly GraphNode<Ts, S>[],
+): StructuralError | null {
+  const claimed = new Map<string, NodeId>();
+  for (const node of arrived) {
+    if (!ownsItsSubtree<Ts, S>(node)) continue;
+    const key = sourceKeyOf<Ts, S>(registry, node);
+    if (key === null) continue;
+    const existing = ownerBySourceKey.get(key) ?? claimed.get(key);
+    if (existing !== undefined) {
+      return {
+        code: "duplicate-owner",
+        message: `sourceKey ${quoteFromWire(key)} is owned by both ${quoteFromWire(existing)} and ${quoteFromWire(node.id)}; the second placement must be a reference`,
+        nodeId: node.id,
+      };
+    }
+    claimed.set(key, node.id);
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // 4. deserializeDocument
 // ---------------------------------------------------------------------------
@@ -1599,10 +1647,16 @@ function loadChildrenIntoUnguarded<Ts extends readonly WidenedNodeType[], S>(
     ownerBySourceKey: new Map(),
   };
 
-  // Checked over the MERGED graph: the payload may name a sourceKey some other
-  // placement already owns, which is a conflict that only exists once the two
-  // documents are in the same graph.
-  const duplicate = findDuplicateOwner(base, ctx.registry);
+  // The payload may name a sourceKey some other placement already owns — a
+  // conflict that only exists once the two documents are in the same graph, and
+  // still refused here. Over the ARRIVALS rather than the merged graph: see
+  // `findDuplicateOwnerAmongArrivals` for why that is the same answer.
+  const arrived = [...payload.nodesById.values()];
+  const duplicate = findDuplicateOwnerAmongArrivals<Ts, S>(
+    graph.ownerBySourceKey,
+    ctx.registry,
+    arrived,
+  );
   if (duplicate !== null) {
     return loadRejection({
       code: "malformed-document",


### PR DESCRIPTION
`loadChildrenInto` ran **two O(resident) passes to admit O(page) nodes**: `findDuplicateOwner` over the merged graph, then `rebuildDerivedIndexes` over it again. Both call *consumer* node types per node — `sourceKey` and `contentKey` are arbitrary user code, not map reads.

This replaces the first pass with an arrivals-only check.

**Why that's the same answer:** a load ADDS nodes and changes no existing node's `data`, so no incumbent's `sourceKey` moves — and the target's own ownership is unchanged, because `unloaded` and `loaded` both own (only `reference` disclaims). The only conflicts a load can create are arrival-vs-incumbent and arrival-vs-arrival, both visible from the arrivals plus the pre-load `ownerBySourceKey`.

## Measured, by counting hook invocations

Page held at 200 nodes:

| resident | `sourceKey` before | after | `contentKey` (unchanged) |
|--:|--:|--:|--:|
| 4,002 | 504 | 252 | 3,950 |
| 16,002 | 2,004 | 1,002 | 15,200 |
| 64,002 | **8,004** | **4,002** | 60,200 |

Counted rather than timed deliberately — this repo has deleted three wall-clock gates that couldn't survive CI. The regression test reads **6,404** against the old code and fails its bound; the three behaviour tests beside it pass on both builds, which is what makes them worth keeping.

## What was tried and rejected

Recorded in the test header so it isn't re-attempted.

The obvious second half — swap `rebuildDerivedIndexes` for `placementsAfterInsert`/`ownersAfterInsert`, the updaters `applyInserted` already uses — was implemented and **measured slower: 57.88 ms vs 37.08 ms at 64k resident.**

Those updaters are built for arrivals contributing *no* content key, where they hand the map back by identity. When arrivals land in buckets that already hold incumbents they must build `documentOrderComparator(post)` and merge every bucket — O(resident) again — and can then *decline* and fall back to the full rebuild, paying for both. Reverted.

## The original finding was partly mis-attributed

Worth correcting on the record: **four `new Map(...)` copies of the resident graph account for 21.73 ms of the 37 ms at 64k.** The index work is the minority term, so even deleting it entirely caps the available win near 40%. The remaining 60,200 `contentKey` calls per page need a different approach than the existing updaters.

## Gate

7/7 packages typecheck · `lint:packages` 0 errors · 1551 unit · 312 story

🤖 Generated with [Claude Code](https://claude.com/claude-code)