### PR TITLE
Graph-core review round five

### DIFF
--- a/packages/graph-core/commands/commands.fuzz.test.ts
+++ b/packages/graph-core/commands/commands.fuzz.test.ts
@@ -281,6 +281,9 @@ function makeCtx(): Ctx {
     onParseFailure: "seal",
     maxNodes: DEFAULT_MAX_NODES,
     maxDepth: null,
+    // Unbounded, so this fixture behaves exactly as it did before the
+    // id-length ceiling existed.
+    maxNodeIdLength: null,
     mintId: () => {
       minted += 1;
       // Never reused, and disjoint from every generated document id — so a

--- a/packages/graph-core/commands/commands.test.ts
+++ b/packages/graph-core/commands/commands.test.ts
@@ -364,6 +364,9 @@ function makeHarness(
     onParseFailure: "seal",
     maxNodes: DEFAULT_MAX_NODES,
     maxDepth: null,
+    // Unbounded, so this fixture behaves exactly as it did before the
+    // id-length ceiling existed.
+    maxNodeIdLength: null,
     mintId:
       overrides?.mintId ??
       ((): string => {

--- a/packages/graph-core/commands/edit.ts
+++ b/packages/graph-core/commands/edit.ts
@@ -22,6 +22,7 @@ import {
 import {
   ownsItsSubtree,
   getNode,
+  sourceKeyForData,
 } from "../graph";
 import { applyPatch } from "../patches";
 import { parseNodeData } from "../serialize";
@@ -285,7 +286,23 @@ export function planEdits<Ts extends readonly WidenedNodeType[], S>(
     // Total on its own terms: false for sealed, for a leaf, and for a
     // `reference` — subsuming the `stateOwnsSubtree` branch this replaced.
     if (ownsItsSubtree<Ts, S>(node)) {
-      const nextKey = nodeType.sourceKey?.(nextData) ?? null;
+      // THROUGH `sourceKeyForData`, never `nodeType.sourceKey` directly. This
+      // was the one place in the package that called a consumer key hook bare,
+      // and ./graph's wrapper exists precisely so "the `KeyHookFailure` wrapping
+      // stays in ONE place". `guardKeyHooks` catches that private tag ONLY and
+      // rethrows anything else — correctly, so an engine bug still crashes
+      // loudly — so a raw consumer throw from here escaped `dispatch`, a
+      // function whose entire contract is that it returns a `Result`. That is
+      // verbatim the failure review3 fixed for `contentKey` at the edit, insert
+      // and remove doors; the edit door's own `sourceKey` was left behind.
+      // MEASURED before this: `store.dispatch` threw "consumer sourceKey
+      // exploded" and returned nothing.
+      const nextKey = sourceKeyForData(
+        ctx.registry,
+        node.kind,
+        nextData,
+        edit.nodeId,
+      );
       if (nextKey !== null) {
         const owner = graph.ownerBySourceKey.get(nextKey);
         const claimed = claimedSourceKeys.get(nextKey);

--- a/packages/graph-core/commands/insert.ts
+++ b/packages/graph-core/commands/insert.ts
@@ -41,14 +41,28 @@ import { fail, ok } from "./results";
  * `mintId` that always returns the same string, or returns whitespace, is a
  * programmer error — but nothing in this module may throw, and an unbounded
  * retry loop is a hang, which is strictly worse than an ugly id.
+ *
+ * OVER-LONG COUNTS AS UNACCEPTABLE, exactly like whitespace, and that is what
+ * keeps the id-length ceiling from being an ingress-only rule. `deserialize`
+ * refuses an id past `maxNodeIdLength`; if minting could install one anyway,
+ * the graph would hold a node that saves cleanly and never loads again — the
+ * shape this package has already paid for at the node ceiling and at the depth
+ * one. The existing retry-then-fall-back is the whole mechanism; this only adds
+ * a term to what "acceptable" means. The fallback `graph-node-N` is short by
+ * construction, so it cannot itself trip the ceiling.
  */
 function mintFreshId<S>(
   taken: ReadonlySet<string>,
   ctx: EngineContext<S>,
 ): NodeId {
+  const fits = (id: string): boolean =>
+    ctx.maxNodeIdLength === null || id.length <= ctx.maxNodeIdLength;
+
   for (let attempt = 0; attempt < 64; attempt += 1) {
     const minted = tryParseNodeId(ctx.mintId());
-    if (minted.ok && !taken.has(minted.value)) return minted.value;
+    if (minted.ok && fits(minted.value) && !taken.has(minted.value)) {
+      return minted.value;
+    }
   }
   for (let counter = 0; ; counter += 1) {
     const candidate = `graph-node-${counter}`;

--- a/packages/graph-core/commands/move.ts
+++ b/packages/graph-core/commands/move.ts
@@ -17,6 +17,7 @@ import {
   getNode,
   getParent,
   isSameOrAncestor,
+  subtreeHeight,
 } from "../graph";
 import { applyPatch } from "../patches";
 
@@ -199,66 +200,6 @@ export function isNoOpMove(moves: readonly Move[]): boolean {
   );
 }
 
-/**
- * The tallest LIVE subtree under `id`, counting `id` itself as 1.
- *
- * `subtreeIds` descends only `loaded` collections, which is the right rule
- * here: an unloaded branch contributes its placeholder and nothing more,
- * exactly as it does when the ingress door measures the same graph. So a move
- * is judged on the depth the graph actually holds, and loading that branch
- * later is bounded by `loadChildrenInto`'s own check rather than pre-refused
- * here on a guess about what it might contain.
- */
-function tallestSubtree<Ts extends readonly WidenedNodeType[], S>(
-  graph: Graph<Ts, S>,
-  id: NodeId,
-): number {
-  if (!graph.nodesById.has(id)) return 1;
-
-  // ONE descent carrying depth, rather than an `ancestorChain` per descendant.
-  // The predecessor answered a SUBTREE question with N ROOT-walks: it read
-  // `parentById` once per ancestor of every descendant, and allocated a chain
-  // array for each one it threw away. MEASURED on a caterpillar subtree,
-  // counting `parentById.get` during one depth-checked move:
-  //
-  //     nodes  depth    reads before -> after
-  //       122     20         1,491 ->  9
-  //       242     40         5,371 ->  9
-  //       482     80        20,331 ->  9
-  //       962    160        79,051 ->  9
-  //
-  // FLAT, because the depth now comes from the descent itself and this function
-  // stops reading `parentById` at all. The 9 that remain belong to the rest of
-  // the move — `planMove` and `depthOf(graph, toParentId)` — and are a function
-  // of where the subtree is GOING, not of how big or deep it is.
-  //
-  // Explicit stack and a visit budget, matching `walkInDocumentOrder`: this
-  // function exists to measure depth, so depth is hostile input by
-  // construction, and the budget bounds the damage on an invalid graph instead
-  // of spinning on a cycle. Two parallel arrays rather than one array of
-  // objects — the pairing is local to this loop and allocating a wrapper per
-  // node is the cost being removed.
-  const budget = graph.nodesById.size;
-  const stack: NodeId[] = [id];
-  const depths: number[] = [1];
-  let visited = 0;
-  let tallest = 1;
-
-  while (stack.length > 0 && visited < budget) {
-    const current = stack.pop();
-    const depth = depths.pop();
-    if (current === undefined || depth === undefined) break;
-    visited += 1;
-    if (depth > tallest) tallest = depth;
-    for (const childId of getChildren(graph, current)) {
-      stack.push(childId);
-      depths.push(depth + 1);
-    }
-  }
-
-  return tallest;
-}
-
 export function applyMoveNodes<Ts extends readonly WidenedNodeType[], S>(
   graph: Graph<Ts, S>,
   nodeIds: readonly NodeId[],
@@ -284,7 +225,7 @@ export function applyMoveNodes<Ts extends readonly WidenedNodeType[], S>(
   if (ctx.maxDepth !== null) {
     const parentDepth = depthOf(graph, toParentId);
     for (const id of plan.orderedIds) {
-      const deepest = parentDepth + tallestSubtree<Ts, S>(graph, id);
+      const deepest = parentDepth + subtreeHeight<Ts, S>(graph, id);
       if (deepest > ctx.maxDepth) {
         return fail(
           "would-exceed-max-depth",

--- a/packages/graph-core/engine/index.ts
+++ b/packages/graph-core/engine/index.ts
@@ -400,6 +400,43 @@ export function createEngine<
   // The store
   // -------------------------------------------------------------------------
 
+  /**
+   * `applyPatch` returns a `Graph`, not a `Result`, and is documented as
+   * deliberately re-checking nothing because verify ran first. But verify does
+   * NOT read the two key hooks on every path `applyPatch` does — measured, a
+   * throwing `contentKey` cleared `verifyPatchApplies` and then threw out of
+   * `applyPatch`, so `undo()` broke its own `Result` contract even after the
+   * verify door was guarded.
+   *
+   * `instanceof` the private tag, like every other guard here.
+   *
+   * AT ENGINE SCOPE, not inside `createStore`, because `applyPatchChecked` on
+   * the engine surface owes a consumer driving its own replay exactly the
+   * guarantee `undo` and `redo` already had. It closes over `ctx` and nothing
+   * a store owns, which is what makes hoisting it a move rather than a copy —
+   * and a second copy is what would drift.
+   */
+  const applyReplayPatch = (
+    from: Graph<Ts, S>,
+    patch: Patch<Ts, S>,
+  ): Result<Graph<Ts, S>, ReplayRejection> => {
+    try {
+      return { ok: true, value: applyPatchTo(from, patch, ctx) };
+    } catch (thrown) {
+      if (thrown instanceof KeyHookFailure) {
+        return {
+          ok: false,
+          error: {
+            code: "node-type-threw",
+            message: keyHookMessage(thrown),
+            ...(thrown.nodeId === null ? {} : { nodeId: thrown.nodeId }),
+          },
+        };
+      }
+      throw thrown;
+    }
+  };
+
   const createStore = (initialGraph: Graph<Ts, S>): Store<Ts, S, F> => {
     let graph = initialGraph;
     let history: History<Ts, S> = createHistory<Ts, S>(config.historyLimit);
@@ -558,37 +595,6 @@ export function createEngine<
             `remaining subscribers still ran, but this callback must not throw.`,
           thrown,
         );
-      }
-    };
-
-    /**
-     * `applyPatch` returns a `Graph`, not a `Result`, and is documented as
-     * deliberately re-checking nothing because verify ran first. But verify does
-     * NOT read the two key hooks on every path `applyPatch` does — measured, a
-     * throwing `contentKey` cleared `verifyPatchApplies` and then threw out of
-     * `applyPatch`, so `undo()` broke its own `Result` contract even after the
-     * verify door was guarded.
-     *
-     * `instanceof` the private tag, like every other guard here.
-     */
-    const applyReplayPatch = (
-      from: Graph<Ts, S>,
-      patch: Patch<Ts, S>,
-    ): Result<Graph<Ts, S>, ReplayRejection> => {
-      try {
-        return { ok: true, value: applyPatchTo(from, patch, ctx) };
-      } catch (thrown) {
-        if (thrown instanceof KeyHookFailure) {
-          return {
-            ok: false,
-            error: {
-              code: "node-type-threw",
-              message: keyHookMessage(thrown),
-              ...(thrown.nodeId === null ? {} : { nodeId: thrown.nodeId }),
-            },
-          };
-        }
-        throw thrown;
       }
     };
 
@@ -1123,6 +1129,15 @@ export function createEngine<
 
     applyCommand: (graph, command) => applyCommandWithPolicy(graph, command),
     applyPatch: (graph, patch) => applyPatchTo(graph, patch, ctx),
+    // THE GATE FIRST, then the rewrite — the order `undo` and `redo` have
+    // always used internally, handed to a consumer driving its own replay as
+    // one call so the safe order is the one that is easy to write. See
+    // `Engine.applyPatch` for what skipping it costs.
+    applyPatchChecked: (graph, patch) => {
+      const verified = verifyPatchAppliesTo(graph, patch, ctx);
+      if (!verified.ok) return verified;
+      return applyReplayPatch(graph, patch);
+    },
     invertPatch: (patch) => invertPatchOf(patch),
     verifyPatchApplies: (graph, patch) =>
       verifyPatchAppliesTo(graph, patch, ctx),

--- a/packages/graph-core/engine/index.ts
+++ b/packages/graph-core/engine/index.ts
@@ -72,6 +72,7 @@ import {
   type ObservableFoldCache,
 } from "../folds";
 import {
+  DEFAULT_MAX_NODE_ID_LENGTH,
   DEFAULT_MAX_NODES,
   deserializeDocument,
   loadChildrenInto,
@@ -215,6 +216,11 @@ export function createEngine<
   for (const [name, value] of [
     ["maxNodes", config.maxNodes],
     ["maxDepth", config.maxDepth],
+    // The third ceiling, validated with its two siblings rather than beside
+    // them — `maxNodeIdLength: NaN` disables the bound exactly the way
+    // `maxNodes: NaN` does, and for the same reason: every `length > ceiling`
+    // comparison goes false.
+    ["maxNodeIdLength", config.maxNodeIdLength],
   ] as const) {
     if (value === undefined || value === null) continue;
     if (!Number.isInteger(value) || value <= 0) {
@@ -247,6 +253,13 @@ export function createEngine<
     // number — see `EngineConfig.maxDepth` for why depth is the consumer's
     // ceiling to set and not this package's to invent.
     maxDepth: config.maxDepth ?? null,
+    // `??`, not `?? null`: this one HAS a default, like `maxNodes` and unlike
+    // `maxDepth`, so omitting it takes the number and only an explicit `null`
+    // opts out. See `EngineConfig.maxNodeIdLength`.
+    maxNodeIdLength:
+      config.maxNodeIdLength === undefined
+        ? DEFAULT_MAX_NODE_ID_LENGTH
+        : config.maxNodeIdLength,
     mintId: config.mintId ?? defaultMintId,
     now: config.now ?? Date.now,
     devChecks: config.devChecks ?? false,

--- a/packages/graph-core/engine/warnings.ts
+++ b/packages/graph-core/engine/warnings.ts
@@ -6,13 +6,22 @@
 // store and the flag enforcing that is per-store state. `createStore` calls this
 // once, so the flags keep exactly the lifetime they had as closures inside it.
 //
-// Neither reads anything from the graph but its node count, so the parameter is
-// structural rather than a `Graph<Ts, S>` — these are diagnostics about SIZE and
+// Neither reads anything from the graph but two SIZES, so the parameter is
+// structural rather than a `Graph<Ts, S>` — these are diagnostics about size and
 // have no business being able to see the nodes.
 
 import { DEFAULT_INTERACTIVE_NODE_BUDGET, FOLD_CACHE_HEADROOM } from "./constants";
 
-type SizedGraph = Readonly<{ nodesById: Readonly<{ size: number }> }>;
+type SizedGraph = Readonly<{
+  nodesById: Readonly<{ size: number }>;
+  /**
+   * The tombstone store. Counted because a REMOVAL commit copies it whole
+   * alongside the other four maps, and its size is a function of the session's
+   * total deletions rather than of the document — see
+   * `warnIfCommitCostIsPastInteractive`.
+   */
+  deadRevById: Readonly<{ size: number }>;
+}>;
 
 /** Only `stats().limit` is read — the warning is about the cache's SIZE, and
  *  handing it the whole cache would let a diagnostic touch the memo table. */
@@ -94,15 +103,45 @@ const warnIfCommitCostIsPastInteractive = (candidate: SizedGraph): void => {
   // A named budget is a choice, and `0` is how that choice says "never".
   if (budget <= 0) return;
   const nodeCount = candidate.nodesById.size;
-  if (nodeCount <= budget) return;
+  // LIVE PLUS TOMBSTONED, and the second term is the whole reason this line
+  // changed. `applyRemoved` copies `deadRevById` whole on every removal commit,
+  // and that map holds one entry per id EVER removed from this store — so it is
+  // sized by the session's deletions, not by the document. A check that read
+  // only `nodesById.size` could not see it, and therefore could not fire in the
+  // one shape where the cost is invisible from the document: churn.
+  //
+  // MEASURED, insert-then-remove one node in a loop, live count pinned at 1
+  // throughout:
+  //
+  //     cycles   live   tombstoned   one removal
+  //      1,000      1        1,000      0.045 ms
+  //      4,000      1        4,000      0.195 ms
+  //      8,000      1        8,000      0.478 ms
+  //
+  // Linear in the tombstone count, on a ONE-NODE document. Against the table in
+  // `DEFAULT_INTERACTIVE_NODE_BUDGET` — 33.9 ms for an insert at 100,025 live
+  // nodes — the two terms are the same order, and only one of them was counted.
+  const deadCount = candidate.deadRevById.size;
+  const commitCost = nodeCount + deadCount;
+  if (commitCost <= budget) return;
   warnedAboutCommitCost = true;
+  // Both numbers, never the sum alone: they call for different answers. Live
+  // nodes past the budget means the DOCUMENT is large; tombstones past it mean
+  // the SESSION has been long, and a fresh store is the cheap fix.
+  const churn =
+    deadCount > nodeCount
+      ? ` Most of that is the tombstone store (${deadCount} ids removed this session against ` +
+        `${nodeCount} live), which is sized by how long this store has been open rather than ` +
+        `by the document — re-creating the store from a fresh deserialize clears it.`
+      : "";
   console.error(
-    `graph-core: this graph holds ${nodeCount} live nodes, past the ${budget} this engine ` +
-      `treats as interactive. A commit copies whole maps — every mutation copies ` +
-      `subtreeRevById, a data change also copies nodesById, an insert or removal copies ` +
-      `four — so a commit costs what the DOCUMENT costs, not what the edit costs: ` +
-      `measured at 3.3 ms per keystroke at 25,000 nodes and 17.1 ms at 100,000, where ` +
-      `one keystroke is a whole 60Hz frame before anything renders. Set ` +
+    `graph-core: this store commits against ${commitCost} entries (${nodeCount} live nodes ` +
+      `plus ${deadCount} tombstoned ids), past the ${budget} this engine treats as ` +
+      `interactive. A commit copies whole maps — every mutation copies subtreeRevById, a ` +
+      `data change also copies nodesById, an insert or removal copies four, and a removal ` +
+      `also copies deadRevById — so a commit costs what the STORE holds, not what the edit ` +
+      `costs: measured at 3.3 ms per keystroke at 25,000 nodes and 17.1 ms at 100,000, ` +
+      `where one keystroke is a whole 60Hz frame before anything renders.${churn} Set ` +
       `EngineConfig.interactiveNodeBudget to silence this once you have priced it.`,
   );
 };

--- a/packages/graph-core/folds/cache.ts
+++ b/packages/graph-core/folds/cache.ts
@@ -72,6 +72,15 @@ import type {
  * occupancy is ~30 MB — reachable only by a 16k-node graph that is itself the
  * same order of magnitude in memory.
  *
+ * THAT FIGURE RESTS ON A BOUNDED ID, and until `maxNodeIdLength` existed
+ * nothing enforced one. `cacheKey` below concatenates the node id into a fresh
+ * string per entry, so the per-entry size was the DOCUMENT's to choose while
+ * this limit counted only entries — 131,072 of them at the default. The graph's
+ * own maps are not exposed the same way: they key by the id, and a JavaScript
+ * string is shared by reference, so four maps cost four pointers and one copy.
+ * The memo table was the amplifier, and the ceiling is what turns ~232 bytes
+ * from a measurement of typical data into a bound.
+ *
  * Read that as a FLOOR, not a total. The entry is the key plus the `Folded`,
  * and `Folded<A>`'s `A` is whatever the consumer's fold returns — a duration is
  * a number, a preview-items rollup is an array of objects, and this package

--- a/packages/graph-core/folds/compute.ts
+++ b/packages/graph-core/folds/compute.ts
@@ -3,6 +3,7 @@
 // Split out of the former single-file `folds.ts`; see ./index.ts.
 
 import { getChildren, getNode, getSubtreeRev } from "../graph";
+import { describeThrown } from "../types";
 import type {
   GraphNode,
   ConsumerDefinedFold,
@@ -18,6 +19,38 @@ import type {
 // ---------------------------------------------------------------------------
 
 type Frame = Readonly<{ id: NodeId; expanded: boolean }>;
+
+/** Which of the five hooks a fold answered a node with. */
+type FoldHook = "sealed" | "leaf" | "missing" | "placeholder" | "collection";
+
+/**
+ * A consumer fold hook threw.
+ *
+ * PRIVATE BY CONSTRUCTION, exactly like `KeyHookFailure` in ./graph and for the
+ * same reason: it is not exported from ./index, so a consumer cannot construct
+ * one, and the catch below cannot be spoofed into reporting an engine bug as a
+ * fold's fault. It is narrower than that one — `KeyHookFailure` has to travel
+ * out to six Result-typed doors, while nothing catches this outside
+ * `computeFold`, so it never leaves this file.
+ */
+class FoldHookFailure extends Error {
+  readonly foldKey: string;
+  readonly hook: FoldHook;
+  readonly nodeId: NodeId;
+  readonly cause: unknown;
+
+  constructor(foldKey: string, hook: FoldHook, nodeId: NodeId, cause: unknown) {
+    super(
+      `graph-core: fold ${JSON.stringify(foldKey)}.${hook} threw for node ` +
+        `${JSON.stringify(nodeId)}. ${describeThrown(cause)}`,
+    );
+    this.name = "FoldHookFailure";
+    this.foldKey = foldKey;
+    this.hook = hook;
+    this.nodeId = nodeId;
+    this.cause = cause;
+  }
+}
 
 /**
  * THE ONLY cast in this module, and the erasure it crosses is intrinsic to
@@ -45,6 +78,42 @@ function readCachedFold<A>(
   const hit = cache.get(foldKey, nodeId, subtreeRev);
   if (!hit.hit) return undefined;
   return hit.value as Folded<A>;
+}
+
+/**
+ * Run ONE consumer fold hook, so that its throw arrives at the bottom of
+ * `computeFold` as this module's tag rather than as the caller's problem.
+ *
+ * `instanceof` a private class, never a bare `catch` around the walk. A bare
+ * catch would report a bug inside this engine as the consumer's fault and hide
+ * it behind an `undefined` nobody can act on — the same argument ./graph makes
+ * for `KeyHookFailure`, and the reason the tag is thrown HERE, beside the call,
+ * rather than inferred from a "which hook was running" variable at the catch.
+ *
+ * ONE CLOSURE PER NODE, not per hook — exactly one of the five runs for any
+ * given node, so this adds one allocation to a walk that already allocates a
+ * `Frame` and a `results` entry per node.
+ *
+ * NO WALL-CLOCK NUMBER IS CLAIMED HERE, deliberately. A cold fold over 100,000
+ * nodes measured 27.7-30.2 ms without this and 30.1-37.5 ms with it, on an
+ * interleaved best-of-7 — the two ranges overlap, so the honest reading is
+ * "within noise", not a percentage. This package has written three wall-clock
+ * bounds that CI then disproved; the reproducible fact is the one
+ * `tests/performance.test.ts` asserts, which is a COUNT, and this change leaves
+ * every one of those counts identical because it adds no hook calls, no node
+ * visits and no cache operations.
+ */
+function hooked<A>(
+  fold: Readonly<{ key: string }>,
+  hook: FoldHook,
+  nodeId: NodeId,
+  run: () => A,
+): A {
+  try {
+    return run();
+  } catch (thrown) {
+    throw new FoldHookFailure(fold.key, hook, nodeId, thrown);
+  }
 }
 
 /**
@@ -90,6 +159,32 @@ function isPlaceholderNode<Ts extends readonly WidenedNodeType[], S>(
  *
  * Returns `undefined` when `nodeId` is unknown. That is routine, not
  * exceptional — in React a card outlives its node by a frame on every removal.
+ * It is ALSO what a fold that threw answers with, for the reason below.
+ *
+ * TOTAL. A fold's five hooks are consumer code, and they were the last family
+ * in this package called with no guard at all: listeners go through
+ * `notifyOne`, `contentKey`/`sourceKey` through `KeyHookFailure`, and `parse`,
+ * `serialize` and `applyEdit` are each wrapped at their own door. Measured
+ * before this: a `fold.collection` that threw came straight out of
+ * `store.aggregate`, which React calls once per mounted card during render.
+ *
+ * `undefined`, NOT a rejection, because there is no other answer available.
+ * `Folded<A>`'s `A` is the consumer's own type and this module cannot
+ * manufacture a value of it, so there is nothing to return but "no answer" —
+ * which is a case every caller already handles, since a card outliving its node
+ * produces it on every removal.
+ *
+ * THE WHOLE WALK IS ABANDONED, not just the failing node. Dropping one node and
+ * folding on would hand the parent a subtree with a hole in it and report the
+ * result as `exact` — a wrong number that looks right, which is the exact
+ * failure the shadow cold refold exists to catch. Descendants already committed
+ * stay in the cache and stay correct: each was computed by a hook that returned,
+ * and each is keyed by its own `(fold.key, id, rev)`.
+ *
+ * REPORTED, never silent, for `notifyOne`'s reason — `undefined` otherwise
+ * means both "the node is gone" and "your fold crashed", and those need
+ * different fixes. One line per `aggregate` call rather than per node, because
+ * the first throw ends the walk.
  *
  * Pass `cache` to memoize; results are keyed by `(fold.key, id, subtreeRev)`,
  * so passing a cache can never change the answer, only the work.
@@ -127,6 +222,31 @@ export function computeFold<Ts extends readonly WidenedNodeType[], S, A>(
     }
   };
 
+  try {
+    return walk<Ts, S, A>(graph, fold, nodeId, cache, results, opened, stack, commit);
+  } catch (thrown) {
+    // THE TAG ONLY. Anything else is a bug in this engine and must keep
+    // crashing as itself rather than being reported as a fold's fault.
+    if (!(thrown instanceof FoldHookFailure)) throw thrown;
+    console.error(
+      `${thrown.message} The aggregate for ${JSON.stringify(nodeId)} is ` +
+        `unavailable; nothing else is affected and the graph is untouched.`,
+    );
+    return undefined;
+  }
+}
+
+/** The walk itself. Split out only so the guard above reads as a guard. */
+function walk<Ts extends readonly WidenedNodeType[], S, A>(
+  graph: Graph<Ts, S>,
+  fold: ConsumerDefinedFold<Ts, S, A>,
+  nodeId: NodeId,
+  cache: FoldCache | undefined,
+  results: Map<NodeId, Folded<A>>,
+  opened: Set<NodeId>,
+  stack: Frame[],
+  commit: (id: NodeId, value: Folded<A>) => void,
+): Folded<A> | undefined {
   while (stack.length > 0) {
     const frame = stack.pop();
     // `pop` is typed `Frame | undefined` regardless of the length guard, and
@@ -157,24 +277,30 @@ export function computeFold<Ts extends readonly WidenedNodeType[], S, A>(
     }
 
     if (node.sealed) {
-      commit(node.id, fold.sealed(node));
+      commit(node.id, hooked(fold, "sealed", node.id, () => fold.sealed(node)));
       continue;
     }
 
     if (!node.container) {
       // A leaf is always exact; only placeholders, sealing and a fold's own
       // judgement introduce uncertainty, so the evaluator wraps without asking.
-      commit(node.id, { value: fold.leaf(node), certainty: "exact" });
+      commit(node.id, {
+        value: hooked(fold, "leaf", node.id, () => fold.leaf(node)),
+        certainty: "exact",
+      });
       continue;
     }
 
     const state = node.children;
     if (state.status === "missing") {
-      commit(node.id, fold.missing(node));
+      commit(node.id, hooked(fold, "missing", node.id, () => fold.missing(node)));
       continue;
     }
     if (state.status === "unloaded" || state.status === "reference") {
-      commit(node.id, fold.placeholder(node));
+      commit(
+        node.id,
+        hooked(fold, "placeholder", node.id, () => fold.placeholder(node)),
+      );
       continue;
     }
 
@@ -209,7 +335,10 @@ export function computeFold<Ts extends readonly WidenedNodeType[], S, A>(
         placeholder: isPlaceholderNode(childNode),
       });
     }
-    commit(node.id, fold.collection(node, children));
+    commit(
+      node.id,
+      hooked(fold, "collection", node.id, () => fold.collection(node, children)),
+    );
   }
 
   return results.get(nodeId);

--- a/packages/graph-core/graph/index.ts
+++ b/packages/graph-core/graph/index.ts
@@ -50,6 +50,7 @@ export {
   isSameOrAncestor,
   nodeCount,
   stateOwnsSubtree,
+  subtreeHeight,
   subtreeIds,
 } from "./queries";
 

--- a/packages/graph-core/graph/queries.ts
+++ b/packages/graph-core/graph/queries.ts
@@ -274,6 +274,76 @@ export function subtreeIds<Ts extends readonly WidenedNodeType[], S>(
   return walkInDocumentOrder(graph, [id]);
 }
 
+/**
+ * The tallest LIVE subtree under `id`, counting `id` itself as 1.
+ *
+ * THE SINGLE ANSWER to "how much depth does relocating this node cost", for the
+ * same reason `ownsItsSubtree` is the single answer to ownership: it is read by
+ * the forward door (`applyMoveNodes` in ./commands) and by the replay door
+ * (`verifyMoved` in ./patches), and those two disagreeing about depth is
+ * exactly the drift that let a redo walk a graph past `maxDepth`. It lives here
+ * because ./commands imports ./patches, so the shared helper cannot live in
+ * either of them.
+ *
+ * `walkInDocumentOrder` descends only `loaded` collections, which is the right
+ * rule: an unloaded branch contributes its placeholder and nothing more,
+ * exactly as it does when the ingress door measures the same graph. So a move
+ * is judged on the depth the graph actually holds, and loading that branch
+ * later is bounded by `loadChildrenInto`'s own check rather than pre-refused
+ * here on a guess about what it might contain.
+ *
+ * ONE descent carrying depth, rather than an `ancestorChain` per descendant.
+ * The predecessor answered a SUBTREE question with N ROOT-walks: it read
+ * `parentById` once per ancestor of every descendant, and allocated a chain
+ * array for each one it threw away. MEASURED on a caterpillar subtree, counting
+ * `parentById.get` during one depth-checked move:
+ *
+ *     nodes  depth    reads before -> after
+ *       122     20         1,491 ->  9
+ *       242     40         5,371 ->  9
+ *       482     80        20,331 ->  9
+ *       962    160        79,051 ->  9
+ *
+ * FLAT, because the depth now comes from the descent itself and this function
+ * stops reading `parentById` at all.
+ *
+ * Explicit stack and a visit budget, matching `walkInDocumentOrder`: this
+ * function exists to measure depth, so depth is hostile input by construction,
+ * and the budget bounds the damage on an invalid graph instead of spinning on a
+ * cycle. Two parallel arrays rather than one array of objects — the pairing is
+ * local to this loop and allocating a wrapper per node is the cost being
+ * removed.
+ *
+ * `1` for an unknown node, matching what the callers need: a node the graph
+ * does not hold still occupies the slot it is being placed into.
+ */
+export function subtreeHeight<Ts extends readonly WidenedNodeType[], S>(
+  graph: Graph<Ts, S>,
+  id: NodeId,
+): number {
+  if (!graph.nodesById.has(id)) return 1;
+
+  const budget = graph.nodesById.size;
+  const stack: NodeId[] = [id];
+  const depths: number[] = [1];
+  let visited = 0;
+  let tallest = 1;
+
+  while (stack.length > 0 && visited < budget) {
+    const current = stack.pop();
+    const depth = depths.pop();
+    if (current === undefined || depth === undefined) break;
+    visited += 1;
+    if (depth > tallest) tallest = depth;
+    for (const childId of getChildren(graph, current)) {
+      stack.push(childId);
+      depths.push(depth + 1);
+    }
+  }
+
+  return tallest;
+}
+
 /** Pre-order across every root, in `rootIds` order. Backs `selectRange`, which
  *  is inclusive in DOCUMENT order — the reason selection is engine-owned rather
  *  than a consumer concern. */

--- a/packages/graph-core/index.ts
+++ b/packages/graph-core/index.ts
@@ -179,6 +179,10 @@ export {
   // deciding whether to raise `EngineConfig.maxNodes` needs to be able to see
   // what they are raising it FROM without reaching past the barrel.
   DEFAULT_MAX_NODES,
+  // The third ceiling's default, named for the reason the other two are: a
+  // consumer deciding whether to raise or clear `EngineConfig.maxNodeIdLength`
+  // needs to see what they are moving it from.
+  DEFAULT_MAX_NODE_ID_LENGTH,
   deserializeDocument,
   loadChildrenInto,
   parseNodeData,

--- a/packages/graph-core/patches/arms.ts
+++ b/packages/graph-core/patches/arms.ts
@@ -417,6 +417,39 @@ export function applyRemoved<Ts extends readonly WidenedNodeType[], S>(
   // graph's by reference, which is the whole point of the split: the map that
   // grows with a session's total deletions is no longer inside the map every
   // commit copies.
+  //
+  // IT IS STILL INSIDE THE MAP EVERY *REMOVAL* COMMIT COPIES, and that is the
+  // cost this line owns. The split moved the growth off the other three arms,
+  // not off this one. MEASURED, insert-then-remove one node in a loop with the
+  // live count pinned at 1:
+  //
+  //     cycles   live   tombstoned   one removal
+  //      1,000      1        1,000      0.045 ms
+  //      4,000      1        4,000      0.195 ms
+  //      8,000      1        8,000      0.478 ms
+  //
+  // Linear in the tombstone count, so a session of D separate deletions copies
+  // D^2/2 entries in total — 32.0 M for the 8,000 above. Per operation that is
+  // still well inside a frame at any size a session realistically reaches; the
+  // part that mattered was that NOTHING SAID SO. The interactive-cost warning
+  // read `nodesById.size`, which is 1 in the table above, so the one shape where
+  // commit cost is invisible from the document was also the one shape the
+  // diagnostic could not see. It now counts this map too.
+  //
+  // EVICTING FROM HERE IS NOT THE FIX, and it is worth writing down because it
+  // is the obvious one. A tombstone is what stops a RETURNING id from restarting
+  // at 0 and walking back onto revs its dead lineage already cached —
+  // `applyInserted` reads `deadRevById.get(node.id) ?? 0` — so dropping an entry
+  // reintroduces exactly the staleness this store exists to prevent, silently
+  // and permanently, and no eviction policy here can know whether the fold cache
+  // still holds an entry under one of those revs. The cache is a different
+  // structure with a different limit and no ordering relationship to this one.
+  //
+  // What WOULD remove the quadratic is replacing per-id tombstones with a single
+  // monotonic rev floor on the graph: a returning id starts above every rev ever
+  // issued, which is strictly stronger than starting above its own. That is a
+  // change to the fold cache's only invalidation mechanism — the one this file
+  // notes has shipped wrong twice — and it needs its own round, not a line here.
   const deadRevs = new Map<NodeId, number>(graph.deadRevById);
 
   const removedIds: NodeId[] = [];

--- a/packages/graph-core/patches/patches.test.ts
+++ b/packages/graph-core/patches/patches.test.ts
@@ -140,6 +140,9 @@ function makeCtx(engineId: symbol = ENGINE_ID): EngineContext<Summary> {
     onParseFailure: "seal",
     maxNodes: DEFAULT_MAX_NODES,
     maxDepth: null,
+    // Unbounded, so this fixture behaves exactly as it did before the
+    // id-length ceiling existed.
+    maxNodeIdLength: null,
     mintId: () => "minted",
     now: () => 0,
     devChecks: false,

--- a/packages/graph-core/patches/verify.ts
+++ b/packages/graph-core/patches/verify.ts
@@ -16,10 +16,12 @@ import {
   type Result,
 } from "../types";
 import {
+  ancestorChain,
   ownsItsSubtree,
   sourceKeyOf,
   sourceKeyForData,
   derivedIndexNeed,
+  subtreeHeight,
 } from "../graph";
 
 import { EMPTY_IDS, VERIFY_OK } from "./constants";
@@ -172,7 +174,7 @@ export function verifyPatchAppliesUnguarded<Ts extends readonly WidenedNodeType[
   }
   switch (patch.type) {
     case "moved":
-      return verifyMoved(graph, patch.moves);
+      return verifyMoved(graph, patch.moves, ctx);
     case "inserted":
       return verifyInserted(graph, patch.placements, ctx);
     case "removed":
@@ -185,6 +187,7 @@ export function verifyPatchAppliesUnguarded<Ts extends readonly WidenedNodeType[
 function verifyMoved<Ts extends readonly WidenedNodeType[], S>(
   graph: Graph<Ts, S>,
   moves: readonly Move[],
+  ctx: EngineContext<S>,
 ): Result<void, ReplayRejection> {
   const overlay = createChildrenOverlay(graph);
   const seen = new Set<NodeId>();
@@ -284,6 +287,82 @@ function verifyMoved<Ts extends readonly WidenedNodeType[], S>(
         );
       }
       cursor = nextParent.get(cursor);
+    }
+  }
+
+  // Phase 4: THE DEPTH CEILING, the exact twin of `verifyInserted`'s node
+  // ceiling and missing for as long as that one was present.
+  //
+  // AGAINST THE POST-STATE, for the reason phase 3 is: a batch can move a node
+  // under a parent that is itself moving, and the pre-state chain answers a
+  // question about a graph the patch is about to replace. `nextParent` is the
+  // map phase 3 just proved terminates, so the walk below needs no budget of
+  // its own beyond the one it inherits.
+  //
+  // `depthPost(toParentId) + subtreeHeight(graph, nodeId)` is verbatim the
+  // formula `applyMoveNodes` uses, out of the same `./graph` helper rather than
+  // a second copy — two doors computing depth independently is what let this
+  // through in the first place.
+  //
+  // COMPLETE despite only reading the moved nodes: a descendant that did not
+  // move travels with its ancestor, and `subtreeHeight` measures to the bottom
+  // of that subtree, so the deepest node under any moved id is covered by that
+  // id's own check. A node moved INTO a moved subtree is checked at its own
+  // final position by its own entry. Anything under neither keeps the depth it
+  // already had.
+  if (ctx.maxDepth !== null) {
+    const depthCache = new Map<NodeId, number>();
+    const depthPost = (id: NodeId): number | null => {
+      const memo = depthCache.get(id);
+      if (memo !== undefined) return memo;
+      const path: NodeId[] = [];
+      let depth = 0;
+      let cursor: NodeId | null | undefined = id;
+      while (cursor !== null && cursor !== undefined) {
+        const hit = depthCache.get(cursor);
+        if (hit !== undefined) {
+          depth = hit;
+          break;
+        }
+        if (path.length > nextParent.size) return null;
+        path.push(cursor);
+        cursor = nextParent.get(cursor) ?? null;
+      }
+      // Back down the path it just walked up, so a batch sharing one chain pays
+      // for it once.
+      for (let i = path.length - 1; i >= 0; i -= 1) {
+        depth += 1;
+        const step = path[i];
+        if (step !== undefined) depthCache.set(step, depth);
+      }
+      return depth;
+    };
+
+    for (const move of moves) {
+      const parentDepth = depthPost(move.toParentId);
+      if (parentDepth === null) {
+        // Unreachable — phase 3 refused every non-terminating chain — but
+        // refused rather than guessed, because the alternative is a ceiling
+        // silently computed from a number this function could not derive.
+        return replayError(
+          "would-create-cycle",
+          `The parent chain above ${move.toParentId} does not terminate.`,
+          { nodeId: move.nodeId, parentId: move.toParentId },
+        );
+      }
+      const deepest = parentDepth + subtreeHeight<Ts, S>(graph, move.nodeId);
+      if (deepest > ctx.maxDepth) {
+        return replayError(
+          "would-exceed-max-depth",
+          `Replaying this move would nest ${move.nodeId} ${deepest} levels, past the ${ctx.maxDepth} ceiling.`,
+          {
+            nodeId: move.nodeId,
+            parentId: move.toParentId,
+            limit: ctx.maxDepth,
+            actual: deepest,
+          },
+        );
+      }
     }
   }
 
@@ -412,6 +491,30 @@ function verifyInserted<Ts extends readonly WidenedNodeType[], S>(
   const overlay = createChildrenOverlay(graph);
   const willExist = new Set<NodeId>();
 
+  // THE DEPTH CEILING, the twin of the node ceiling above, checked INSIDE the
+  // structural loop rather than after it.
+  //
+  // Placements arrive parents-first in document order — the property the
+  // `parentIsNew` branch below already relies on — so each one's depth is its
+  // parent's plus one, and the parent's is either already computed here (an
+  // earlier placement) or read once from the graph. That makes the whole pass
+  // O(placements + one ancestor chain per distinct pre-existing parent), which
+  // is why it can afford to be exact rather than reuse the forward door's
+  // `depthOf(parent) + tallestSeed(seeds)` estimate.
+  //
+  // Only assembled when a ceiling was named: `maxDepth` is `null` by default,
+  // and undo of a bulk insert is the path this file has already spent two
+  // rounds making linear.
+  const depth =
+    ctx.maxDepth === null
+      ? null
+      : {
+          /** A placement created earlier in this same patch. */
+          byNew: new Map<NodeId, number>(),
+          /** A parent the graph already held — one ancestor chain per parent. */
+          ofExisting: new Map<NodeId, number>(),
+        };
+
   for (const placement of placements) {
     const { node, parentId, index } = placement;
     if (graph.nodesById.has(node.id) || willExist.has(node.id)) {
@@ -445,6 +548,36 @@ function verifyInserted<Ts extends readonly WidenedNodeType[], S>(
         { nodeId: node.id, parentId, index },
       );
     }
+    if (depth !== null && ctx.maxDepth !== null) {
+      let parentDepth = depth.byNew.get(parentId);
+      if (parentDepth === undefined) {
+        const cached = depth.ofExisting.get(parentId);
+        if (cached !== undefined) parentDepth = cached;
+        else {
+          // `ancestorChain` is bounded by `nodesById.size` and excludes the node
+          // itself, so this is the same `depthOf` the forward door computes —
+          // one chain per distinct pre-existing parent, memoised because a bulk
+          // insert names one parent thousands of times.
+          parentDepth = ancestorChain(graph, parentId).length + 1;
+          depth.ofExisting.set(parentId, parentDepth);
+        }
+      }
+      const level = parentDepth + 1;
+      if (level > ctx.maxDepth) {
+        return replayError(
+          "would-exceed-max-depth",
+          `Replaying this insert would nest ${node.id} ${level} levels, past the ${ctx.maxDepth} ceiling.`,
+          {
+            nodeId: node.id,
+            parentId,
+            limit: ctx.maxDepth,
+            actual: level,
+          },
+        );
+      }
+      depth.byNew.set(node.id, level);
+    }
+
     overlay.insert(parentId, index, node.id);
     willExist.add(node.id);
     if (isLoadedContainer(node)) overlay.seedLoaded(node.id);

--- a/packages/graph-core/serialize/constants.ts
+++ b/packages/graph-core/serialize/constants.ts
@@ -39,3 +39,38 @@
  * are buying, which is the whole reason it refuses loudly instead of trimming.
  */
 export const DEFAULT_MAX_NODES = 100_000;
+
+/**
+ * The default ceiling on the LENGTH of one node id.
+ *
+ * THE THIRD CEILING, and the one the other two do not cover. `maxNodes` bounds
+ * how MANY nodes a document may hold and `maxDepth` how deeply they nest;
+ * neither says anything about how big one of them may be, and `tryParseNodeId`
+ * refuses only the empty and whitespace-only string. So the size of a node id
+ * was the sender's to choose, without limit, under ceilings that read as
+ * complete.
+ *
+ * WHERE THAT AMPLIFIES, and it is not where it looks. The graph's four maps key
+ * by the id, but a JavaScript string is immutable and shared by reference, so
+ * holding one id in four maps costs four pointers and one copy of the bytes.
+ * The memo table is different: `cacheKey` CONCATENATES the id into a fresh
+ * string per `(foldKey, nodeId, subtreeRev)` entry, and `foldCacheLimit` bounds
+ * that table by ENTRY COUNT. At the defaults that is 131,072 entries whose
+ * per-entry size the document decides — and ./folds measures ~232 bytes an
+ * entry, a figure taken with ordinary ids and, until this ceiling existed,
+ * resting on an assumption nothing enforced.
+ *
+ * 1024, which is not a round number chosen for looking generous: it is ~28x a
+ * UUID and ~16x the longest id-shaped string in this repo's own fixtures and
+ * app code (a 64-character storage path). Nothing legitimate is within an order
+ * of magnitude of it, and it caps the memo table's worst case at a size the
+ * `maxNodes` ceiling is already the same order as.
+ *
+ * A CEILING WITH A DEFAULT, unlike `maxDepth`, and for `maxNodes`' reason: this
+ * one can be defended without knowing the consumer's data, because there is no
+ * legitimate id near it. `null` opts out, and the refusal names the config to
+ * raise — the same escape hatch `maxNodes` offers, and it matters more here,
+ * because a read-side ceiling that refuses a STORED document is worse than the
+ * hazard it prevents.
+ */
+export const DEFAULT_MAX_NODE_ID_LENGTH = 1024;

--- a/packages/graph-core/serialize/document.ts
+++ b/packages/graph-core/serialize/document.ts
@@ -61,6 +61,39 @@ type BuiltDocument<Ts extends readonly WidenedNodeType[], S> = Readonly<{
  * sub-document's `rootIds` name the nodes that BECOME some target's children,
  * and a child may perfectly well be a leaf.
  */
+/**
+ * THE ID-LENGTH CEILING, applied wherever this document's ids are adopted.
+ *
+ * One helper for all three sites — `nodes[].id`, `rootIds[]` and
+ * `children[]` — because a ceiling enforced at two of the three is a ceiling
+ * with a door left open, and each of those three is somewhere a sender chooses
+ * a string. See `EngineConfig.maxNodeIdLength` for what it protects, which is
+ * the memo table rather than the graph.
+ *
+ * BEFORE `tryParseNodeId`, not after, and for `quoteFromWire`'s reason: the
+ * only thing done with an over-long id should be measuring it. Parsing it first
+ * would brand a megabyte on the way to refusing it.
+ *
+ * `null` when the id fits, so the caller reads it as "no complaint".
+ */
+function idTooLong<S>(
+  raw: string,
+  ctx: EngineContext<S>,
+  where: string,
+): StructuralError | null {
+  if (ctx.maxNodeIdLength === null) return null;
+  if (raw.length <= ctx.maxNodeIdLength) return null;
+  return {
+    code: "node-id-too-long",
+    message:
+      `${where} presents a node id of ${raw.length} characters, above the ` +
+      `${ctx.maxNodeIdLength} ceiling. Raise or clear EngineConfig.maxNodeIdLength ` +
+      `if this id is legitimate.`,
+    limit: ctx.maxNodeIdLength,
+    actual: raw.length,
+  };
+}
+
 export function buildDocument<Ts extends readonly WidenedNodeType[], S>(
   raw: unknown,
   ctx: EngineContext<S>,
@@ -106,6 +139,8 @@ export function buildDocument<Ts extends readonly WidenedNodeType[], S>(
   // --- Pass A: adopt the wire's ids -----------------------------------------
   const wireById = new Map<NodeId, SerializedNode>();
   for (const node of doc.nodes) {
+    const tooLong = idTooLong(node.id, ctx, "nodes");
+    if (tooLong !== null) return fail(tooLong);
     const id = tryParseNodeId(node.id);
     if (!id.ok) {
       return fail({
@@ -129,6 +164,8 @@ export function buildDocument<Ts extends readonly WidenedNodeType[], S>(
   const rootIds: NodeId[] = [];
   const rootSet = new Set<NodeId>();
   for (const rawRootId of doc.rootIds) {
+    const tooLong = idTooLong(rawRootId, ctx, "rootIds");
+    if (tooLong !== null) return fail(tooLong);
     const id = tryParseNodeId(rawRootId);
     if (!id.ok) {
       return fail({
@@ -240,6 +277,8 @@ export function buildDocument<Ts extends readonly WidenedNodeType[], S>(
     if (node.children === undefined) continue;
     const kids: NodeId[] = [];
     for (const rawChildId of node.children) {
+      const tooLongChild = idTooLong(rawChildId, ctx, "children");
+      if (tooLongChild !== null) return fail(tooLongChild);
       const child = tryParseNodeId(rawChildId);
       if (!child.ok) {
         return fail({

--- a/packages/graph-core/serialize/index.ts
+++ b/packages/graph-core/serialize/index.ts
@@ -55,7 +55,7 @@
 // ---------------------------------------------------------------------------
 
 export { parseSerializedDocument } from "./shape";
-export { DEFAULT_MAX_NODES } from "./constants";
+export { DEFAULT_MAX_NODE_ID_LENGTH, DEFAULT_MAX_NODES } from "./constants";
 export { parseNodeData } from "./content";
 export { serializeGraph } from "./write";
 export { deserializeDocument, loadChildrenInto } from "./guards";

--- a/packages/graph-core/serialize/serialize.test.ts
+++ b/packages/graph-core/serialize/serialize.test.ts
@@ -224,6 +224,9 @@ function makeCtx(
     onParseFailure: "seal",
     maxNodes: DEFAULT_MAX_NODES,
     maxDepth: null,
+    // Unbounded, so this fixture behaves exactly as it did before the
+    // id-length ceiling existed.
+    maxNodeIdLength: null,
     mintId: () => "minted",
     now: () => 0,
     devChecks: false,

--- a/packages/graph-core/serialize/shape.ts
+++ b/packages/graph-core/serialize/shape.ts
@@ -185,13 +185,31 @@ export function parseSerializedDocument(
   };
 }
 
+/**
+ * EVERY REFUSAL HERE QUOTES THROUGH `quoteFromWire`, never `JSON.stringify`.
+ *
+ * The fourth round introduced that helper and described it as covering "every
+ * ingress refusal". It had not covered this function, which is the FIRST door a
+ * payload meets — `parseSerializedDocument` runs before `buildDocument` adopts
+ * any id, so these messages were reached before the id-length ceiling could
+ * refuse anything. MEASURED with a 1,000,000-character id, at the DEFAULT
+ * config with that ceiling in force:
+ *
+ *   non-string kind      malformed-document       1,000,030 characters
+ *   bad childrenState    invalid-children-state   1,000,085
+ *   non-array children   malformed-document       1,000,034
+ *
+ * against 169 for the `dangling-child` refusal the fourth round did fix. The
+ * ceiling narrows this and cannot close it: it does not run until the shape is
+ * known, and `maxNodeIdLength: null` is a supported configuration.
+ */
 function parseSerializedNode(
   raw: unknown,
 ): Result<SerializedNode, StructuralError> {
   if (!isRecord(raw)) return malformed("Each node must be an object");
   if (typeof raw.id !== "string") return malformed("node.id must be a string");
   if (typeof raw.kind !== "string") {
-    return malformed(`node ${JSON.stringify(raw.id)}: kind must be a string`);
+    return malformed(`node ${quoteFromWire(raw.id)}: kind must be a string`);
   }
 
   // A missing `data` key is READ AS `undefined`, not rejected. JSON.stringify
@@ -209,13 +227,13 @@ function parseSerializedNode(
 
   if (raw.children !== undefined) {
     if (!Array.isArray(raw.children)) {
-      return malformed(`node ${JSON.stringify(raw.id)}: children must be an array`);
+      return malformed(`node ${quoteFromWire(raw.id)}: children must be an array`);
     }
     const children: string[] = [];
     for (const childId of raw.children) {
       if (typeof childId !== "string") {
         return malformed(
-          `node ${JSON.stringify(raw.id)}: children must contain only strings`,
+          `node ${quoteFromWire(raw.id)}: children must contain only strings`,
         );
       }
       children.push(childId);
@@ -227,7 +245,7 @@ function parseSerializedNode(
     if (!isWireChildrenState(raw.childrenState)) {
       return fail({
         code: "invalid-children-state",
-        message: `node ${JSON.stringify(raw.id)}: childrenState must be "unloaded", "reference" or "missing", received ${describeValue(raw.childrenState)}`,
+        message: `node ${quoteFromWire(raw.id)}: childrenState must be "unloaded", "reference" or "missing", received ${describeValue(raw.childrenState)}`,
         rawId: raw.id,
       });
     }
@@ -239,7 +257,7 @@ function parseSerializedNode(
   if (raw.schemaVersion !== undefined) {
     if (typeof raw.schemaVersion !== "number" || !Number.isFinite(raw.schemaVersion)) {
       return malformed(
-        `node ${JSON.stringify(raw.id)}: schemaVersion must be a finite number`,
+        `node ${quoteFromWire(raw.id)}: schemaVersion must be a finite number`,
       );
     }
     draft.schemaVersion = raw.schemaVersion;
@@ -248,7 +266,7 @@ function parseSerializedNode(
   if (raw.missingReason !== undefined) {
     if (typeof raw.missingReason !== "string") {
       return malformed(
-        `node ${JSON.stringify(raw.id)}: missingReason must be a string`,
+        `node ${quoteFromWire(raw.id)}: missingReason must be a string`,
       );
     }
     draft.missingReason = raw.missingReason;

--- a/packages/graph-core/tests/move-cost.test.ts
+++ b/packages/graph-core/tests/move-cost.test.ts
@@ -176,6 +176,9 @@ function makeCtx(registry: ReadonlyMap<string, WidenedNodeType>): EngineContext<
     onParseFailure: "seal",
     maxNodes: DEFAULT_MAX_NODES,
     maxDepth: null,
+    // Unbounded, so this fixture behaves exactly as it did before the
+    // id-length ceiling existed.
+    maxNodeIdLength: null,
     mintId: () => "minted",
     now: () => 0,
     devChecks: false,

--- a/packages/graph-core/tests/review-f3.test.ts
+++ b/packages/graph-core/tests/review-f3.test.ts
@@ -119,6 +119,9 @@ function makeCtx(
     onParseFailure: "seal",
     maxNodes: DEFAULT_MAX_NODES,
     maxDepth: null,
+    // Unbounded, so this fixture behaves exactly as it did before the
+    // id-length ceiling existed.
+    maxNodeIdLength: null,
     mintId: () => "minted",
     now: () => 0,
     devChecks: false,

--- a/packages/graph-core/tests/review-f4.test.ts
+++ b/packages/graph-core/tests/review-f4.test.ts
@@ -133,6 +133,9 @@ function ctxWith(summary: ConsumerDefinedSummaryType<Summary>): EngineContext<Su
     onParseFailure: "seal",
     maxNodes: DEFAULT_MAX_NODES,
     maxDepth: null,
+    // Unbounded, so this fixture behaves exactly as it did before the
+    // id-length ceiling existed.
+    maxNodeIdLength: null,
     mintId: () => "minted",
     now: () => 0,
     devChecks: false,

--- a/packages/graph-core/tests/review4-a-refusal-message-is-bounded.test.ts
+++ b/packages/graph-core/tests/review4-a-refusal-message-is-bounded.test.ts
@@ -27,6 +27,7 @@ import {
   parseNodeId,
 } from "../types";
 import { createEngine } from "../engine";
+import { DEFAULT_MAX_NODE_ID_LENGTH } from "../serialize";
 
 type Folder = Readonly<{ name: string }>;
 type FolderEdit = Readonly<{ name?: string }>;
@@ -73,8 +74,29 @@ const summary: ConsumerDefinedSummaryType<Summary> = {
   },
 };
 
-const makeEngine = () =>
-  createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+const makeEngine = (maxNodeIdLength: number | null = null) =>
+  createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    maxNodeIdLength,
+  });
+
+// UNBOUNDED BY DEFAULT IN THIS FILE, which is a deliberate inversion of the
+// engine's own default and the only way these cases keep testing what they were
+// written to test.
+//
+// The fifth round added `maxNodeIdLength`, defaulting to 1024, so a 200,000-
+// character id is now refused by the CEILING before it ever reaches the
+// refusals below — and the clamp these cases exist for would go untested while
+// every one of them still passed on a different code. That is the shape of a
+// test quietly measuring nothing.
+//
+// So the clamp is exercised with the ceiling OFF, which is not a contrivance:
+// `maxNodeIdLength: null` is a supported configuration, and it is exactly the
+// one where a sender still chooses how long an id is. The ceiling's own path is
+// pinned separately at the bottom of this file.
+
 
 /** Comfortably above the 120-char clamp, comfortably below anything slow. */
 const HUGE = "x".repeat(200_000);
@@ -119,6 +141,31 @@ describe("a refusal message is bounded by the engine, not by the sender", () => 
     if (loaded.ok) return;
     expect(loaded.error.code).toBe("duplicate-node-id");
     expect(loaded.error.message.length).toBeLessThan(REASONABLE);
+  });
+
+  it("the id-length ceiling refuses with a bounded message too", () => {
+    // The DEFAULT path, and the stronger property the fifth round added: with a
+    // ceiling in force the huge id is refused before it reaches any of the
+    // refusals above, and that refusal must be bounded on the same terms — it
+    // reports the LENGTH rather than quoting the id, so there is nothing of the
+    // sender's in it at all.
+    const engine = makeEngine(DEFAULT_MAX_NODE_ID_LENGTH);
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: [HUGE] },
+        { id: HUGE, kind: "folder", data: { name: "A" }, children: [] },
+      ],
+    });
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    expect(loaded.error.code).toBe("node-id-too-long");
+    expect(loaded.error.message.length).toBeLessThan(REASONABLE);
+    expect(loaded.error.message).not.toContain("xxx");
+    expect(loaded.error.limit).toBe(DEFAULT_MAX_NODE_ID_LENGTH);
+    expect(loaded.error.actual).toBe(HUGE.length);
   });
 
   it("a huge KIND, which is the other string the wire chooses", () => {

--- a/packages/graph-core/tests/review4-a-save-can-refuse-a-graph-that-will-not-load.test.ts
+++ b/packages/graph-core/tests/review4-a-save-can-refuse-a-graph-that-will-not-load.test.ts
@@ -156,6 +156,7 @@ function corruptedGraph() {
     onParseFailure: "seal" as const,
     maxNodes: DEFAULT_MAX_NODES,
     maxDepth: null,
+    maxNodeIdLength: null,
     mintId: (): string => "minted",
     now: (): number => 0,
     devChecks: false,

--- a/packages/graph-core/tests/review4-a-throwing-key-hook-cannot-escape-either.test.ts
+++ b/packages/graph-core/tests/review4-a-throwing-key-hook-cannot-escape-either.test.ts
@@ -237,6 +237,52 @@ describe("a throwing contentKey/sourceKey refuses rather than escaping", () => {
         }
       });
 
+      // THE CASE THE LOOP ABOVE CANNOT REACH, and the reason it could not.
+      //
+      // Every edit in that loop targets `c1`, which is a CLIP — a leaf. The
+      // edit door's own ownership check is `if (ownsItsSubtree(node))`, and a
+      // leaf owns nothing, so the `sourceKey` call guarded by it never ran and
+      // the throw came from somewhere already wrapped. The test asserted the
+      // property and the fixture kept it away from the one call site that
+      // lacked it: `planEdits` read `nodeType.sourceKey?.(nextData)` BARE, the
+      // only un-wrapped consumer key hook left in the package.
+      //
+      // `guardKeyHooks` catches the private `KeyHookFailure` tag ONLY and
+      // rethrows anything else — correctly, so an engine bug still crashes as
+      // itself — so a raw consumer throw walked straight out of `dispatch`.
+      // MEASURED before the fix: `store.dispatch` threw "sourceKey exploded"
+      // and returned nothing.
+      //
+      // `box` is a folder with a `source`, so it is a container that owns its
+      // subtree and the ownership branch actually executes.
+      it("dispatch refuses when the edited node is a container that OWNS its subtree", () => {
+        const { store } = calmStore();
+        explode[hook] = true;
+        let thrown: unknown = null;
+        let result: ReturnType<typeof store.dispatch> | null = null;
+        try {
+          result = store.dispatch({
+            type: "edit-nodes",
+            edits: [
+              {
+                nodeId: parseNodeId("box"),
+                kind: "folder" as const,
+                edit: { source: "s-moved" },
+              },
+            ],
+          });
+        } catch (caught) {
+          thrown = caught;
+        }
+        resetExplosions();
+
+        expect(thrown).toBeNull();
+        expect(result).not.toBeNull();
+        if (result === null || result.ok) return;
+        expect(result.error.code).toBe("node-type-threw");
+        expect(result.error.message).toContain(hook);
+      });
+
       it("undo refuses, and does not eat the entry", () => {
         const { store } = calmStore();
         expect(

--- a/packages/graph-core/tests/review4-subtree-height-is-one-descent.test.ts
+++ b/packages/graph-core/tests/review4-subtree-height-is-one-descent.test.ts
@@ -97,6 +97,7 @@ function moveProbe(depth: number, branch: number, maxDepth: number) {
     onUnknownKind: "seal" as const,
     onParseFailure: "seal" as const,
     maxNodes: DEFAULT_MAX_NODES,
+    maxNodeIdLength: null,
     maxDepth,
     mintId: (): string => "x",
     now: (): number => 0,

--- a/packages/graph-core/tests/review5-a-node-id-has-a-length-ceiling.test.ts
+++ b/packages/graph-core/tests/review5-a-node-id-has-a-length-ceiling.test.ts
@@ -1,0 +1,286 @@
+// Fifth review round — the third ceiling.
+//
+// `maxNodes` bounds how MANY nodes a document holds; `maxDepth` bounds how
+// deeply they nest. Neither says anything about how large ONE of them is, and
+// `tryParseNodeId` refuses only the empty and whitespace-only string. So the
+// length of a node id was the sender's to choose, without limit, under ceilings
+// that read as complete.
+//
+// WHERE THAT AMPLIFIES is not where it looks. The graph's four maps key by the
+// id, but a JavaScript string is immutable and shared by reference, so holding
+// one id in four maps costs four pointers and one copy of the bytes. The memo
+// table is different: `cacheKey` CONCATENATES the id into a fresh string per
+// `(foldKey, nodeId, subtreeRev)` entry, and `foldCacheLimit` bounds that table
+// by ENTRY COUNT — 131,072 at the default. So the document chose the per-entry
+// size, and ./folds' measured "~232 bytes an entry, stable to the byte across
+// three runs" was a measurement of ordinary data resting on an assumption
+// nothing enforced.
+//
+// ENFORCED AT INGRESS AND AT MINTING BOTH. A ceiling applied only to documents
+// would let `insert-nodes` put an id into the graph that `deserialize` then
+// refuses — the "saves cleanly, will not load" shape this package has already
+// paid for at the node ceiling and at the depth one. `mintFreshId` treats an
+// over-long id from a consumer `mintId` exactly as it treats a whitespace one.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  DEFAULT_MAX_NODE_ID_LENGTH,
+  defineNodeType,
+  parseNodeId,
+} from "../index";
+import { createEngine } from "../engine";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+type Config = Readonly<{
+  maxNodeIdLength?: number | null;
+  mintId?: () => string;
+}>;
+
+const makeEngine = (config: Config = {}) =>
+  createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    ...(config.maxNodeIdLength === undefined
+      ? {}
+      : { maxNodeIdLength: config.maxNodeIdLength }),
+    ...(config.mintId === undefined ? {} : { mintId: config.mintId }),
+  });
+
+const node = (id: string, children: string[]) => ({
+  id,
+  kind: "folder",
+  data: { name: "n" },
+  children,
+});
+
+const rootId = parseNodeId("root");
+
+describe("a node id has a length ceiling", () => {
+  it("refuses an over-long id at each of the three places the wire names one", () => {
+    // All three, because a ceiling enforced at two of them is a ceiling with a
+    // door left open: `nodes[].id`, `rootIds[]` and `children[]` are each a
+    // string the sender chooses.
+    const long = "x".repeat(64);
+    const engine = makeEngine({ maxNodeIdLength: 32 });
+
+    const inNodes = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [node("root", [long]), node(long, [])],
+    });
+    expect(inNodes.ok).toBe(false);
+    if (!inNodes.ok) expect(inNodes.error.code).toBe("node-id-too-long");
+
+    const inRoots = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: [long],
+      nodes: [node(long, [])],
+    });
+    expect(inRoots.ok).toBe(false);
+    if (!inRoots.ok) expect(inRoots.error.code).toBe("node-id-too-long");
+
+    // `children` names an id the `nodes` pass never sees, so it needs its own
+    // check rather than inheriting one.
+    const inChildren = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [node("root", [long])],
+    });
+    expect(inChildren.ok).toBe(false);
+    if (!inChildren.ok) expect(inChildren.error.code).toBe("node-id-too-long");
+  });
+
+  it("carries limit and actual, like the two ceilings it joins", () => {
+    const long = "x".repeat(99);
+    const engine = makeEngine({ maxNodeIdLength: 32 });
+    const refused = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [node("root", []), node(long, [])],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.limit).toBe(32);
+    expect(refused.error.actual).toBe(99);
+    // The message reports the LENGTH rather than quoting the id, so a refusal
+    // about an over-long string does not itself carry one.
+    expect(refused.error.message).not.toContain("xxx");
+    expect(refused.error.message).toContain("maxNodeIdLength");
+  });
+
+  it("the lazy door is bounded too, not only the eager one", () => {
+    // `loadChildrenInto` runs the same `buildDocument` pass, which is what makes
+    // this hold — but the two doors have diverged before (see
+    // `review3-the-ceilings-bound-the-graph-not-one-payload`), so it is pinned.
+    const engine = makeEngine({ maxNodeIdLength: 32 });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "R" },
+          childrenState: "unloaded" as const,
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    const filled = store.load(rootId, {
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["x".repeat(64)],
+      nodes: [node("x".repeat(64), [])],
+    });
+    expect(filled.ok).toBe(false);
+    if (filled.ok) return;
+    expect(filled.error.code).toBe("malformed-document");
+    // The structural cause is carried, so a consumer can tell an over-long id
+    // apart from every other reason a payload is unusable.
+    expect(filled.error.cause?.code).toBe("node-id-too-long");
+  });
+
+  it("minting cannot install an id the ingress door would refuse", () => {
+    // THE ASYMMETRY THAT WOULD OTHERWISE BITE. A ceiling on documents only would
+    // let a consumer `mintId` put an id into the graph that `deserialize` then
+    // refuses — a document that saves cleanly and never loads again.
+    const engine = makeEngine({
+      maxNodeIdLength: 32,
+      mintId: () => "m".repeat(200),
+    });
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [node("root", [])],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    const inserted = engine.applyCommand(loaded.value.graph, {
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "folder", data: { name: "N" } }],
+    });
+    // It SUCCEEDS — the fallback is what the retry falls through to, exactly as
+    // it does for a `mintId` that returns whitespace. What must not happen is an
+    // over-long id landing in the graph.
+    expect(inserted.ok).toBe(true);
+    if (!inserted.ok) return;
+
+    for (const id of inserted.value.graph.nodesById.keys()) {
+      expect(id.length).toBeLessThanOrEqual(32);
+    }
+    // And the round trip closes: what the engine wrote, it can read back.
+    const written = engine.serialize(inserted.value.graph);
+    expect(engine.deserialize(written).ok).toBe(true);
+  });
+
+  it("null opts out, and a bad ceiling is refused at construction", () => {
+    const long = "x".repeat(5_000);
+    const unbounded = makeEngine({ maxNodeIdLength: null });
+    const loaded = unbounded.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [node("root", [long]), node(long, [])],
+    });
+    expect(loaded.ok).toBe(true);
+
+    // NaN and Infinity make every `length > ceiling` comparison false, which
+    // disables the limit while looking like one — the same argument `maxNodes`
+    // and `maxDepth` are validated on.
+    for (const bad of [0, -1, 2.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => makeEngine({ maxNodeIdLength: bad })).toThrow(
+        "maxNodeIdLength",
+      );
+    }
+  });
+
+  it("the default admits every id this repo actually stores", () => {
+    // The ceiling is a trust boundary, not a style rule: a read-side limit that
+    // refuses a STORED document is worse than the hazard it prevents. The
+    // longest id-shaped string in this repo's fixtures and app code is a
+    // 64-character storage path, so the default clears real data by ~16x.
+    const realistic = [
+      "root",
+      "timeline-mslx1z52zghx1d",
+      "graph-a1b2c3d4-1f-9k2m4p",
+      "timeline-gstudio001/user-project-list/project-a/Scenes/frame-1",
+      "scene/a",
+      "timeline-e2e,comma",
+    ];
+    expect(Math.max(...realistic.map((id) => id.length))).toBeLessThan(
+      DEFAULT_MAX_NODE_ID_LENGTH / 8,
+    );
+
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        node("root", realistic.filter((id) => id !== "root")),
+        ...realistic.filter((id) => id !== "root").map((id) => node(id, [])),
+      ],
+    });
+    expect(loaded.ok).toBe(true);
+  });
+});

--- a/packages/graph-core/tests/review5-a-throwing-fold-cannot-escape-aggregate.test.ts
+++ b/packages/graph-core/tests/review5-a-throwing-fold-cannot-escape-aggregate.test.ts
@@ -1,0 +1,335 @@
+// Fifth review round — the last consumer hook family called with no guard.
+//
+// review3 established the rule — "dispatch promises a `Result`. A node type that
+// throws ... turned that into an unhandled exception out of a React event
+// handler, at every call site that correctly wrote `if (!result.ok)`" — and
+// review4 closed the last two key hooks with `KeyHookFailure`. By then every
+// consumer callback in the package was contained: listeners through
+// `notifyOne`, `parse` / `serialize` / `applyEdit` each at their own door, and
+// even the dev-only shadow refold wraps its own `computeFold` call.
+//
+// A fold's five hooks were not. `computeFold` called `fold.sealed`, `fold.leaf`,
+// `fold.missing`, `fold.placeholder` and `fold.collection` bare, and `aggregate`
+// is the one read path React runs during RENDER — once per mounted card.
+// Measured before this: `store.aggregate` threw "fold collection exploded" and
+// returned nothing.
+//
+// `undefined` IS the answer here, not a rejection. `Folded<A>`'s `A` is the
+// consumer's own type and this module cannot manufacture a value of it, so there
+// is nothing to hand back but "no answer" — a case every caller already handles,
+// because a card outliving its node by a frame produces it on every removal.
+// What must not happen is a throw.
+//
+// THE WHOLE WALK IS ABANDONED rather than the failing node dropped. Folding on
+// past it would hand the parent a subtree with a hole in it and report the total
+// as `exact` — a wrong number that looks right, which is the failure the shadow
+// cold refold exists to catch.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type ConsumerDefinedFold,
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type NodeId,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "../types";
+import { createEngine } from "../engine";
+
+/** Which hook detonates, and optionally on which node only. */
+const explode: { hook: string | null; onNode: string | null } = {
+  hook: null,
+  onNode: null,
+};
+
+function reset(): void {
+  explode.hook = null;
+  explode.onNode = null;
+}
+
+function detonate(hook: string, nodeId: string): void {
+  if (
+    explode.hook === hook &&
+    (explode.onNode === null || explode.onNode === nodeId)
+  ) {
+    throw new Error(`fold ${hook} exploded`);
+  }
+}
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+type Clip = Readonly<{ title: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const title = ({ ...raw } as Record<string, unknown>)["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, title: edit.title ?? data.title } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+/** Counts live nodes. Any one of its five hooks can be made to throw. */
+const sizeFold: ConsumerDefinedFold<Types, Summary, number> = {
+  key: "size",
+  leaf(node) {
+    detonate("leaf", node.id);
+    return 1;
+  },
+  collection(node, children) {
+    detonate("collection", node.id);
+    let total = 1;
+    for (const child of children) total += child.value;
+    return { value: total, certainty: "exact" };
+  },
+  placeholder(node) {
+    detonate("placeholder", node.id);
+    return { value: 0, certainty: "partial" };
+  },
+  missing(node) {
+    detonate("missing", node.id);
+    return { value: 0, certainty: "partial" };
+  },
+  sealed(node) {
+    detonate("sealed", node.id);
+    return { value: 0, certainty: "partial" };
+  },
+};
+
+type Folds = { size: typeof sizeFold };
+
+// root -> box -> (c1, c2), plus an unloaded container, a missing one, and a
+// node of a kind nothing registers — so all five hooks are on one walk.
+// `onUnknownKind` defaults to "seal", which is what puts `sealed` there.
+const doc = {
+  formatVersion: 1 as const,
+  schemaVersions: { folder: 1, clip: 1 },
+  rootIds: ["root"],
+  nodes: [
+    {
+      id: "root",
+      kind: "folder",
+      data: { name: "R" },
+      children: ["box", "lazy", "gone", "odd"],
+    },
+    { id: "box", kind: "folder", data: { name: "B" }, children: ["c1", "c2"] },
+    { id: "c1", kind: "clip", data: { title: "One" } },
+    { id: "c2", kind: "clip", data: { title: "Two" } },
+    {
+      id: "lazy",
+      kind: "folder",
+      data: { name: "L" },
+      childrenState: "unloaded" as const,
+    },
+    {
+      id: "gone",
+      kind: "folder",
+      data: { name: "G" },
+      childrenState: "missing" as const,
+    },
+    // No node type claims "mystery", so ingress seals it and `fold.sealed`
+    // answers for it.
+    { id: "odd", kind: "mystery", data: { anything: true } },
+  ],
+};
+
+function makeStore() {
+  reset();
+  const engine = createEngine<Types, Summary, Folds>({
+    types,
+    summary,
+    folds: { size: sizeFold },
+  });
+  const loaded = engine.deserialize(doc);
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return { engine, store: engine.createStore(loaded.value.graph) };
+}
+
+const rootId = parseNodeId("root");
+
+/** root + box + c1 + c2. `lazy`, `gone` and `odd` each contribute 0, through
+ *  `placeholder`, `missing` and `sealed` respectively. */
+const HEALTHY_TOTAL = 4;
+
+describe("a throwing fold hook refuses rather than escaping", () => {
+  for (const hook of [
+    "leaf",
+    "collection",
+    "placeholder",
+    "missing",
+    "sealed",
+  ] as const) {
+    it(`store.aggregate answers undefined when ${hook} throws, and does not throw`, () => {
+      const { store } = makeStore();
+      const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+      explode.hook = hook;
+
+      let thrown: unknown = null;
+      let answer: unknown = "unset";
+      try {
+        answer = store.aggregate("size", rootId);
+      } catch (caught) {
+        thrown = caught;
+      }
+      reset();
+      const messages = logged.mock.calls.map((call) => String(call[0])).join("\n");
+      logged.mockRestore();
+
+      expect(thrown).toBeNull();
+      expect(answer).toBeUndefined();
+      // Reported, never silent: `undefined` otherwise means both "the node is
+      // gone" and "your fold crashed", and those need different fixes. The line
+      // names the hook and the fold key so the consumer can find it.
+      expect(messages).toContain(hook);
+      expect(messages).toContain("size");
+    });
+  }
+
+  it("the engine-level aggregate is guarded too, not only the store's", () => {
+    const { engine, store } = makeStore();
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    explode.hook = "collection";
+
+    let thrown: unknown = null;
+    let answer: unknown = "unset";
+    try {
+      answer = engine.aggregate(store.getGraph(), "size", rootId);
+    } catch (caught) {
+      thrown = caught;
+    }
+    reset();
+    logged.mockRestore();
+
+    expect(thrown).toBeNull();
+    expect(answer).toBeUndefined();
+  });
+
+  it("abandons the whole walk rather than folding on past the hole", () => {
+    // Only `box` throws. The root must NOT come back with a total that silently
+    // omits box's subtree — a wrong number reported as `exact` is worse than no
+    // number, and is precisely what the shadow cold refold exists to catch.
+    const { store } = makeStore();
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    explode.hook = "collection";
+    explode.onNode = "box";
+
+    const answer = store.aggregate("size", rootId);
+    reset();
+    logged.mockRestore();
+
+    expect(answer).toBeUndefined();
+  });
+
+  it("a later read succeeds once the fold stops throwing", () => {
+    // The failure is not latched, and the entries committed before the throw are
+    // correct values keyed by their own `(fold.key, id, rev)` — so recovery is a
+    // plain re-read rather than anything the consumer has to reset.
+    const { store } = makeStore();
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    explode.hook = "collection";
+    explode.onNode = "box";
+    expect(store.aggregate("size", rootId)).toBeUndefined();
+    reset();
+    logged.mockRestore();
+
+    const answer = store.aggregate("size", rootId);
+    expect(answer).not.toBeUndefined();
+    expect(answer?.value).toBe(HEALTHY_TOTAL);
+  });
+
+  it("a genuine engine bug is NOT swallowed as a fold failure", () => {
+    // The catch is `instanceof` a private tag, never bare. A throw that is not
+    // that tag must keep crashing as itself — otherwise a bug inside this
+    // package is reported as the consumer's fault and hidden behind an
+    // `undefined` nobody can act on. The same guarantee
+    // `review4-a-throwing-key-hook-cannot-escape-either` pins for `KeyHookFailure`.
+    const { store } = makeStore();
+    const graph = store.getGraph();
+    const children = graph.childrenById;
+    const original = children.get.bind(children);
+    let armed = true;
+    const patched = (key: NodeId): readonly NodeId[] | undefined => {
+      if (armed && (key as string) === "box") {
+        armed = false;
+        throw new Error("engine bug, not a fold");
+      }
+      return original(key);
+    };
+    (children as { get: typeof patched }).get = patched;
+
+    expect(() => store.aggregate("size", rootId)).toThrow("engine bug, not a fold");
+
+    (children as { get: typeof original }).get = original;
+  });
+
+  it("a fold that behaves is completely unaffected", () => {
+    const { store } = makeStore();
+    const answer = store.aggregate("size", rootId);
+    expect(answer?.value).toBe(HEALTHY_TOTAL);
+    // `exact`, not `partial`, and the distinction is worth pinning: weakest-wins
+    // is `foldMonoid`'s behaviour, not the evaluator's. A hand-written
+    // `ConsumerDefinedFold` declares its own certainty, and this one's
+    // `collection` says `exact` unconditionally — so `lazy` and `gone` answering
+    // `partial` does not propagate. Nothing in this round changes that; it is
+    // asserted so a future guard cannot quietly start rewriting certainty.
+    expect(answer?.certainty).toBe("exact");
+  });
+});

--- a/packages/graph-core/tests/review5-the-commit-cost-warning-counts-tombstones.test.ts
+++ b/packages/graph-core/tests/review5-the-commit-cost-warning-counts-tombstones.test.ts
@@ -1,0 +1,241 @@
+// Fifth review round — the one shape the commit-cost warning could not see.
+//
+// `DEFAULT_INTERACTIVE_NODE_BUDGET` says a commit "copies whole maps ... so
+// commit cost is proportional to how many nodes the document HOLDS and not at
+// all to how small the edit was". True, and incomplete: a REMOVAL also copies
+// `deadRevById`, which holds one entry per id ever removed from this store. That
+// map is sized by the session's deletions, not by the document.
+//
+// So there is a shape where commit cost is invisible from the document — churn.
+// MEASURED, insert-then-remove one node in a loop, live count pinned at 1:
+//
+//     cycles   live   tombstoned   one removal
+//      1,000      1        1,000      0.045 ms
+//      4,000      1        4,000      0.195 ms
+//      8,000      1        8,000      0.478 ms
+//
+// Linear in the tombstone count, on a ONE-NODE document, so D separate deletions
+// copy D^2/2 entries in total — 32.0 M for the 8,000 above. Per operation that
+// stays inside a frame at any size a session realistically reaches. The defect
+// was the SILENCE: `warnIfCommitCostIsPastInteractive` read `nodesById.size`,
+// which is 1 in that table, so the diagnostic that exists for exactly this could
+// not fire for it.
+//
+// NOT FIXED BY EVICTION, and the code says why at length: a tombstone is what
+// stops a returning id from restarting at 0 and walking back onto revs its dead
+// lineage cached, so dropping one reintroduces the staleness it exists to
+// prevent. This round makes the cost audible; removing it needs a different
+// mechanism and its own round.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "../index";
+import { createEngine } from "../engine";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const rootId = parseNodeId("root");
+
+function makeStore(interactiveNodeBudget: number) {
+  const engine = createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    interactiveNodeBudget,
+  });
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { folder: 1 },
+    rootIds: ["root"],
+    nodes: [{ id: "root", kind: "folder", data: { name: "R" }, children: [] }],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return engine.createStore(loaded.value.graph);
+}
+
+/** One insert-then-remove cycle. Leaves the document exactly as it found it and
+ *  the tombstone store one entry larger. */
+function churn(store: ReturnType<typeof makeStore>, times: number): void {
+  for (let i = 0; i < times; i += 1) {
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "folder", data: { name: "N" } }],
+    });
+    if (!inserted.ok) throw new Error(`insert: ${inserted.error.code}`);
+    const kids = store.getGraph().childrenById.get(rootId) ?? [];
+    const id = kids[0];
+    if (id === undefined) throw new Error("child missing");
+    const removed = store.dispatch({ type: "remove-nodes", nodeIds: [id] });
+    if (!removed.ok) throw new Error(`remove: ${removed.error.code}`);
+    // The undo stack would otherwise retain every patch; the subject here is the
+    // tombstone store, not the history.
+    store.clearHistory();
+  }
+}
+
+describe("the commit-cost warning counts tombstones", () => {
+  it("fires on churn, where the document never grows at all", () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = makeStore(20);
+    churn(store, 40);
+    const messages = logged.mock.calls.map((call) => String(call[0])).join("\n");
+    logged.mockRestore();
+
+    // The document is one node the whole way through — which is exactly why the
+    // old check, reading `nodesById.size`, stayed silent.
+    expect(store.getGraph().nodesById.size).toBe(1);
+    expect(store.getGraph().deadRevById.size).toBe(40);
+
+    expect(messages).toContain("interactive");
+
+    // BOTH NUMBERS, not the sum alone: live-past-budget and tombstoned-past-
+    // budget call for different answers, and the message must say which this is.
+    //
+    // Read out of the message rather than hardcoded, because the warning latches
+    // at the FIRST commit to cross the budget and that lands mid-cycle, while
+    // the churned node is momentarily live. The property is that tombstones
+    // dominate, not that live is any particular number.
+    const counts = /\((\d+) live nodes plus (\d+) tombstoned ids\)/.exec(messages);
+    expect(counts).not.toBeNull();
+    const live = Number(counts?.[1]);
+    const dead = Number(counts?.[2]);
+    expect(dead).toBeGreaterThan(live);
+    expect(messages).toContain("re-creating the store");
+  });
+
+  it("still fires on a large document, and does not blame churn for it", () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = makeStore(4);
+    const seeds = Array.from({ length: 10 }, () => ({
+      kind: "folder" as const,
+      data: { name: "N" },
+    }));
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds,
+    });
+    expect(inserted.ok).toBe(true);
+    const messages = logged.mock.calls.map((call) => String(call[0])).join("\n");
+    logged.mockRestore();
+
+    expect(store.getGraph().deadRevById.size).toBe(0);
+    expect(messages).toContain("interactive");
+    expect(messages).toContain("11 live nodes plus 0 tombstoned");
+    // The churn sentence is conditional on tombstones dominating, so a genuinely
+    // large document must not be told to re-create its store.
+    expect(messages).not.toContain("re-creating the store");
+  });
+
+  it("stays silent below the budget, and once above it", () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = makeStore(1_000);
+    churn(store, 20);
+    expect(logged.mock.calls.length).toBe(0);
+
+    // LATCHED, like both warnings have always been: one integer compare behind a
+    // boolean after the first crossing.
+    const loud = makeStore(5);
+    churn(loud, 30);
+    const first = logged.mock.calls.length;
+    churn(loud, 30);
+    logged.mockRestore();
+    expect(first).toBe(1);
+  });
+
+  it("a budget of 0 silences it, tombstones included", () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = makeStore(0);
+    churn(store, 50);
+    const calls = logged.mock.calls.length;
+    logged.mockRestore();
+    expect(store.getGraph().deadRevById.size).toBe(50);
+    expect(calls).toBe(0);
+  });
+
+  it("the tombstone a returning id needs is still there", () => {
+    // The guard against "fixing" this by evicting: a re-inserted id must resume
+    // ABOVE every revision its dead lineage could have cached, and that is the
+    // property any future change here has to keep.
+    const store = makeStore(0);
+    const inserted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [{ kind: "folder", data: { name: "N" } }],
+    });
+    if (!inserted.ok) throw new Error("insert failed");
+    const kids = store.getGraph().childrenById.get(rootId) ?? [];
+    const id = kids[0];
+    if (id === undefined) throw new Error("child missing");
+
+    // Move its revision along, then remove it.
+    store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: id, kind: "folder", edit: { name: "edited" } }],
+    });
+    const revWhileLive = store.getGraph().subtreeRevById.get(id) ?? 0;
+    store.dispatch({ type: "remove-nodes", nodeIds: [id] });
+
+    const tombstone = store.getGraph().deadRevById.get(id);
+    expect(tombstone).not.toBeUndefined();
+    expect(tombstone ?? 0).toBeGreaterThan(revWhileLive);
+
+    // And undo brings it back strictly above where it died.
+    expect(store.undo().ok).toBe(true);
+    expect(store.getGraph().subtreeRevById.get(id) ?? 0).toBeGreaterThanOrEqual(
+      tombstone ?? 0,
+    );
+  });
+});

--- a/packages/graph-core/tests/review5-the-message-bound-reaches-the-first-door.test.ts
+++ b/packages/graph-core/tests/review5-the-message-bound-reaches-the-first-door.test.ts
@@ -1,0 +1,215 @@
+// Fifth review round — the message bound stopped short of the first door.
+//
+// The fourth round introduced `quoteFromWire`, which clamps before it quotes,
+// and applied it across the ingress refusals. Its own note describes the pattern
+// it was replacing as "`JSON.stringify(node.id)` ... at every ingress refusal".
+// Two places kept it.
+//
+// `parseSerializedNode` in ./serialize/shape is the FIRST door a payload meets —
+// `parseSerializedDocument` runs before `buildDocument` adopts a single id — so
+// its six refusals were reached before anything else could refuse, including the
+// fifth round's own `maxNodeIdLength`. MEASURED with a 1,000,000-character id AT
+// THE DEFAULT CONFIG, with that ceiling in force at 1024:
+//
+//   non-string kind      malformed-document       1,000,030 characters
+//   bad childrenState    invalid-children-state   1,000,085
+//   non-array children   malformed-document       1,000,034
+//   (dangling child, fixed in round four)   dangling-child      169
+//
+// `tryParseNodeId` in ./types is the other, and it hid differently: it does not
+// SIT at a refusal site, it is relayed verbatim by three of them, so those three
+// inherited an unbounded quote however carefully they were written and a sweep
+// for `JSON.stringify` at the refusal sites could not see it. A 1,000,000-space
+// id is legal JSON, fails the `trim()` test, and produced a 1,000,063-character
+// message.
+//
+// THE CEILING IS NOT A SUBSTITUTE, which is the reason this is its own round
+// rather than a note on that one. It cannot run before the shape is known, and
+// `maxNodeIdLength: null` is a supported configuration — so both controls are
+// needed, and this file pins the one that holds when the other is off.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+  tryParseNodeId,
+} from "../index";
+import { createEngine } from "../engine";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+/** Both engines, because the two controls are independent and each must hold on
+ *  its own: the ceiling in force, and the ceiling explicitly off. */
+const bounded = () =>
+  createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+const unbounded = () =>
+  createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    maxNodeIdLength: null,
+  });
+
+const HUGE = "x".repeat(1_000_000);
+const SPACES = " ".repeat(1_000_000);
+
+/** A message is a sentence with a clamped name in it, and the sentence has a
+ *  length too. Far below the payload, far above any real message. */
+const REASONABLE = 1_000;
+
+describe("the message bound reaches the first door", () => {
+  it("shape refusals are bounded, with the ceiling on AND off", () => {
+    // Each of these is reached by `parseSerializedNode` before any id is
+    // adopted, so the id-length ceiling is not what saves them.
+    const payloads: readonly [string, unknown][] = [
+      ["non-string kind", { id: HUGE, kind: 5 }],
+      [
+        "bad childrenState",
+        { id: HUGE, kind: "folder", data: { name: "A" }, childrenState: "bogus" },
+      ],
+      [
+        "non-array children",
+        { id: HUGE, kind: "folder", data: { name: "A" }, children: 7 },
+      ],
+      [
+        "non-string child id",
+        { id: HUGE, kind: "folder", data: { name: "A" }, children: [7] },
+      ],
+      [
+        "non-finite schemaVersion",
+        {
+          id: HUGE,
+          kind: "folder",
+          data: { name: "A" },
+          schemaVersion: Number.NaN,
+        },
+      ],
+      [
+        "non-string missingReason",
+        { id: HUGE, kind: "folder", data: { name: "A" }, missingReason: 7 },
+      ],
+    ];
+
+    for (const [label, node] of payloads) {
+      for (const engine of [bounded(), unbounded()]) {
+        const loaded = engine.deserialize({
+          formatVersion: 1,
+          schemaVersions: { folder: 1 },
+          rootIds: ["root"],
+          nodes: [node],
+        });
+        expect(loaded.ok, label).toBe(false);
+        if (loaded.ok) continue;
+        // Labelled, so a failure names which of the six payloads regressed
+        // rather than only which line.
+        expect(loaded.error.message.length, label).toBeLessThan(REASONABLE);
+        // CLAMPED, NOT WITHHELD. A refusal that says nothing about which node it
+        // means is a different bug — the fourth round makes the same point.
+        expect(loaded.error.message).toContain("xxx");
+      }
+    }
+  });
+
+  it("a whitespace id is bounded even with the ceiling off", () => {
+    // The relayed message. The ceiling refuses an over-LONG id first where it is
+    // set, so this is the configuration that exercises the clamp itself.
+    const loaded = unbounded().deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: [SPACES] },
+        { id: SPACES, kind: "folder", data: { name: "A" }, children: [] },
+      ],
+    });
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    expect(loaded.error.code).toBe("invalid-node-id");
+    expect(loaded.error.message.length).toBeLessThan(REASONABLE);
+  });
+
+  it("the id door bounds its own message, at both of its forms", () => {
+    // `tryParseNodeId` is where the relayed message is BUILT, so the bound
+    // belongs there rather than at each of the three sites that pass it on.
+    const refused = tryParseNodeId(SPACES);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.message.length).toBeLessThan(REASONABLE);
+
+    // `parseNodeId` throws that same string, so it was carrying the megabyte too.
+    let thrown: unknown = null;
+    try {
+      parseNodeId(SPACES);
+    } catch (caught) {
+      thrown = caught;
+    }
+    expect(thrown).not.toBeNull();
+    expect(String((thrown as Error).message).length).toBeLessThan(REASONABLE);
+  });
+
+  it("an ordinary refusal still names the node in full", () => {
+    // The clamp must not cost legibility for real ids, which are far under it.
+    const loaded = bounded().deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        {
+          id: "root",
+          kind: "folder",
+          data: { name: "R" },
+          children: ["scene/a-missing"],
+        },
+      ],
+    });
+    expect(loaded.ok).toBe(false);
+    if (loaded.ok) return;
+    expect(loaded.error.message).toContain("scene/a-missing");
+  });
+});

--- a/packages/graph-core/tests/review5-the-replay-gate-must-enforce-the-depth-ceiling.test.ts
+++ b/packages/graph-core/tests/review5-the-replay-gate-must-enforce-the-depth-ceiling.test.ts
@@ -1,0 +1,288 @@
+// Fifth review round — the replay gate held one ceiling and not its twin.
+//
+// `verifyPatchApplies` gained a `maxNodes` check in the fourth round, added as
+// "the third growth door and it was the one without the check". `maxDepth`
+// never got the same treatment. Before this test it was enforced at exactly
+// three forward doors — `applyInsertNodes`, `applyMoveNodes`, and
+// `buildDocument` for both ingress paths — and at none of the replay ones. The
+// vocabulary said so out loud: `RejectionCode` carried both
+// `would-exceed-max-nodes` and `would-exceed-max-depth`, while
+// `ReplayRejectionCode` carried only the first.
+//
+// So the ceiling held against every command and against every document, and not
+// against undo or redo.
+//
+// REACHABLE BY THE LEVER THE NODE CEILING ALREADY NAMES: `Store.load` touches
+// neither history stack, so it can change the graph under a sleeping patch.
+// Move an UNLOADED container somewhere legal — `subtreeHeight` counts it as one
+// level, correctly, because an unloaded branch contributes its placeholder and
+// nothing more — then undo, fill it two levels deep while it sits shallow, then
+// redo. Every step is legal on its own and the redo was not checked at all.
+//
+// MEASURED before the fix, at `maxDepth: 4`:
+//
+//   redo accepted     : true
+//   depth before redo : 4
+//   depth after redo  : 6
+//   serializeGraph    : wrote it happily
+//   deserialize, same config : document-too-deep
+//
+// That is the same terminal state the node-ceiling round describes — "a graph
+// the audit calls valid, `serializeGraph` writes happily, and `deserialize`
+// refuses at that config forever". `findInvariantViolation` cannot catch it
+// either: `ViolationCode` has no depth member, because depth is a ceiling a
+// consumer chose rather than a structural truth about the graph.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Graph,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "../types";
+import { createEngine } from "../engine";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const loadedNode = (id: string, children: string[]) => ({
+  id,
+  kind: "folder",
+  data: { name: id },
+  children,
+});
+const unloadedNode = (id: string) => ({
+  id,
+  kind: "folder",
+  data: { name: id },
+  childrenState: "unloaded" as const,
+});
+
+/** Deepest live level, counting a root as 1. Read from the structure rather
+ *  than from any engine helper, so the assertion cannot be satisfied by the
+ *  same bug it is testing for. */
+function deepestLevel<S>(graph: Graph<Types, S>): number {
+  let deepest = 0;
+  const walk = (id: string, level: number): void => {
+    if (level > deepest) deepest = level;
+    for (const child of graph.childrenById.get(id as never) ?? []) {
+      walk(child, level + 1);
+    }
+  };
+  for (const root of graph.rootIds) walk(root, 1);
+  return deepest;
+}
+
+const makeEngine = (maxDepth: number) =>
+  createEngine<Types, Summary, {}>({ types, summary, folds: {}, maxDepth });
+
+// root(1) -> A(2) -> B(3);  root(1) -> X(2), X an unloaded container.
+const doc = {
+  formatVersion: 1 as const,
+  schemaVersions: { folder: 1 },
+  rootIds: ["root"],
+  nodes: [
+    loadedNode("root", ["A", "X", "C"]),
+    loadedNode("A", ["B"]),
+    loadedNode("B", []),
+    unloadedNode("X"),
+    // A second LOADED branch at level 2, so the insert-arm case below has
+    // somewhere legal to relocate A to. `X` cannot serve: `planMove` refuses an
+    // unloaded target, which is the whole reason it works as the MOVED node in
+    // the cases above and not as the destination here.
+    loadedNode("C", []),
+  ],
+};
+
+describe("the replay gate enforces maxDepth, not only maxNodes", () => {
+  it("refuses a redo whose subtree grew while the patch slept", () => {
+    const engine = makeEngine(4);
+    const loaded = engine.deserialize(doc);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    // 1. Legal: X is unloaded, so it costs one level. depth(B)=3 + 1 = 4.
+    const moved = store.dispatch({
+      type: "move-nodes",
+      nodeIds: [parseNodeId("X")],
+      toParentId: parseNodeId("B"),
+      toIndex: 0,
+    });
+    expect(moved.ok).toBe(true);
+
+    // 2. The move patch is now asleep on the redo stack.
+    expect(store.undo().ok).toBe(true);
+    expect(store.canRedo()).toBe(true);
+
+    // 3. `Store.load` touches neither stack, so the redo entry stays put while
+    //    X — back at depth 2 — is filled two levels deep. Legal on its own.
+    const filled = store.load(parseNodeId("X"), {
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["L"],
+      nodes: [loadedNode("L", ["M"]), loadedNode("M", [])],
+    });
+    expect(filled.ok).toBe(true);
+    expect(deepestLevel(store.getGraph())).toBe(4);
+
+    // 4. THE GATE. Replaying the move would put M at level 6.
+    const redone = store.redo();
+    expect(redone.ok).toBe(false);
+    if (redone.ok) return;
+    expect(redone.error.code).toBe("would-exceed-max-depth");
+    expect(redone.error.limit).toBe(4);
+    expect(redone.error.actual).toBe(6);
+
+    // The graph is untouched and the document still loads at the same config —
+    // the whole point of refusing rather than applying.
+    expect(deepestLevel(store.getGraph())).toBe(4);
+    const rewritten = engine.deserialize(engine.serialize(store.getGraph()));
+    expect(rewritten.ok).toBe(true);
+  });
+
+  it("leaves the refused entry on the stack rather than eating it", () => {
+    // The same discipline `review4-a-refused-undo-must-not-be-a-dead-end`
+    // establishes: a transient refusal must not destroy the step.
+    const engine = makeEngine(4);
+    const loaded = engine.deserialize(doc);
+    if (!loaded.ok) return;
+    const store = engine.createStore(loaded.value.graph);
+
+    store.dispatch({
+      type: "move-nodes",
+      nodeIds: [parseNodeId("X")],
+      toParentId: parseNodeId("B"),
+      toIndex: 0,
+    });
+    store.undo();
+    store.load(parseNodeId("X"), {
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["L"],
+      nodes: [loadedNode("L", ["M"]), loadedNode("M", [])],
+    });
+
+    expect(store.redo().ok).toBe(false);
+    expect(store.canRedo()).toBe(true);
+  });
+
+  it("refuses the insert arm through the replay door", () => {
+    // The engine-level pair is exported precisely so a consumer can drive their
+    // own replay, and that is the reachable path for this arm: the store's own
+    // stacks are ordered, so a sleeping removal's parent cannot deepen without
+    // the move that deepened it being undone first.
+    const engine = makeEngine(3);
+    const loaded = engine.deserialize(doc);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    // Remove B (level 3) to get a real "removed" patch, then invert it into the
+    // insert that would put B back.
+    const removed = engine.applyCommand(loaded.value.graph, {
+      type: "remove-nodes",
+      nodeIds: [parseNodeId("B")],
+    });
+    expect(removed.ok).toBe(true);
+    if (!removed.ok) return;
+    const restore = engine.invertPatch(removed.value.patch);
+
+    // Against the graph B came out of, the restore is fine.
+    expect(engine.verifyPatchApplies(removed.value.graph, restore).ok).toBe(true);
+
+    // Move A under C so B's parent now sits one level deeper. Legal on its own:
+    // with B gone, A's subtree is one level, and depth(C) 2 + 1 = 3 fits.
+    const deeper = engine.applyCommand(removed.value.graph, {
+      type: "move-nodes",
+      nodeIds: [parseNodeId("A")],
+      toParentId: parseNodeId("C"),
+      toIndex: 0,
+    });
+    expect(deeper.ok).toBe(true);
+    if (!deeper.ok) return;
+
+    const verdict = engine.verifyPatchApplies(deeper.value.graph, restore);
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.error.code).toBe("would-exceed-max-depth");
+    expect(verdict.error.limit).toBe(3);
+    expect(verdict.error.actual).toBe(4);
+  });
+
+  it("does not refuse a replay that fits, and stays silent with no ceiling", () => {
+    // The guard against a fix that refuses everything. Same gesture, one more
+    // level of headroom, and again with `maxDepth` left unset — the default,
+    // which means unbounded and must cost nothing.
+    for (const maxDepth of [5, undefined]) {
+      const engine =
+        maxDepth === undefined
+          ? createEngine<Types, Summary, {}>({ types, summary, folds: {} })
+          : makeEngine(maxDepth);
+      const loaded = engine.deserialize(doc);
+      if (!loaded.ok) return;
+      const store = engine.createStore(loaded.value.graph);
+
+      store.dispatch({
+        type: "move-nodes",
+        nodeIds: [parseNodeId("X")],
+        toParentId: parseNodeId("B"),
+        toIndex: 0,
+      });
+      store.undo();
+      store.load(parseNodeId("X"), {
+        formatVersion: 1,
+        schemaVersions: { folder: 1 },
+        rootIds: ["L"],
+        nodes: [loadedNode("L", []), loadedNode("M", [])].slice(0, 1),
+      });
+
+      const redone = store.redo();
+      expect(redone.ok).toBe(true);
+      expect(deepestLevel(store.getGraph())).toBe(5);
+    }
+  });
+});

--- a/packages/graph-core/tests/review5-the-replay-pair-has-a-one-call-door.test.ts
+++ b/packages/graph-core/tests/review5-the-replay-pair-has-a-one-call-door.test.ts
@@ -1,0 +1,253 @@
+// Fifth review round — the precondition that lived only in the implementation.
+//
+// `applyPatch` says, in ./patches: "PRECONDITION: `verifyPatchApplies` returned
+// ok. This function assumes the patch applies and does not re-check — re-checking
+// here would either duplicate verify (and drift from it) or tempt a caller to
+// skip verify because 'apply validates anyway', which is exactly how the
+// dormant-patch corruptions happened."
+//
+// The PUBLIC contract said none of that. `Engine.applyPatch` carried one line —
+// "THE ONE index rewriter — forward application and undo share it" — and returns
+// a `Graph`, not a `Result`, so it reads as total. The barrel exports
+// `applyPatch`, `invertPatch` and `verifyPatchApplies` as peers with nothing
+// linking them, which is precisely the shape a consumer driving its own replay
+// picks up.
+//
+// MEASURED before this round, undoing an insert whose node has since gained a
+// child — the case `verifyPatchApplies` exists to answer:
+//
+//   verifyPatchApplies      ->  node-not-empty
+//   applyPatch              ->  did not throw, returned a graph
+//   nodes                   ->  3 before, 2 after, the child orphaned
+//   findInvariantViolation  ->  parent-index-disagrees
+//
+// Nothing rejects and nothing throws. `serializeGraph` then writes the result —
+// it emits unreachable nodes rather than dropping them — so the document saves
+// cleanly and `deserialize` refuses it afterwards.
+//
+// TWO THINGS FIX IT, and neither alone. The precondition moves onto the public
+// type, where the caller reading the contract will meet it. And
+// `applyPatchChecked` pairs the gate with the rewrite in one call, the same way
+// `serializeChecked` pairs the audit with the bytes — because the two-step
+// version being correct does not help if the one-step version is what a caller
+// reaches for.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Patch,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "../types";
+import { createEngine } from "../engine";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const makeEngine = () =>
+  createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+
+const rootId = parseNodeId("root");
+
+/**
+ * The stale-patch fixture: insert X under root, then give X a child, so the
+ * insert patch's inverse would un-insert a node that is no longer empty.
+ */
+function staleUndo() {
+  const engine = makeEngine();
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { folder: 1 },
+    rootIds: ["root"],
+    nodes: [{ id: "root", kind: "folder", data: { name: "R" }, children: [] }],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to load");
+
+  const inserted = engine.applyCommand(loaded.value.graph, {
+    type: "insert-nodes",
+    toParentId: rootId,
+    toIndex: 0,
+    seeds: [{ kind: "folder", data: { name: "X" } }],
+  });
+  if (!inserted.ok) throw new Error("fixture insert failed");
+
+  // The engine minted X's id, so read it back rather than assuming one.
+  const xId = engine
+    .serialize(inserted.value.graph)
+    .nodes.map((node) => node.id)
+    .find((id) => id !== "root");
+  if (xId === undefined) throw new Error("fixture lost X");
+
+  const withChild = engine.applyCommand(inserted.value.graph, {
+    type: "insert-nodes",
+    toParentId: parseNodeId(xId),
+    toIndex: 0,
+    seeds: [{ kind: "folder", data: { name: "C" } }],
+  });
+  if (!withChild.ok) throw new Error("fixture child insert failed");
+
+  const undoPatch: Patch<Types, Summary> = engine.invertPatch(
+    inserted.value.patch,
+  );
+  return { engine, graph: withChild.value.graph, undoPatch };
+}
+
+describe("the replay pair has a one-call door", () => {
+  it("applyPatchChecked refuses what verifyPatchApplies refuses", () => {
+    const { engine, graph, undoPatch } = staleUndo();
+
+    const gate = engine.verifyPatchApplies(graph, undoPatch);
+    expect(gate.ok).toBe(false);
+    if (gate.ok) return;
+
+    const checked = engine.applyPatchChecked(graph, undoPatch);
+    expect(checked.ok).toBe(false);
+    if (checked.ok) return;
+    // The SAME rejection, relayed rather than re-coded — a consumer branching on
+    // `node-not-empty` reads the same code whichever of the two doors it used.
+    expect(checked.error.code).toBe(gate.error.code);
+    expect(checked.error.code).toBe("node-not-empty");
+  });
+
+  it("the graph is untouched by a refusal", () => {
+    const { engine, graph, undoPatch } = staleUndo();
+    const before = graph.nodesById.size;
+    const refused = engine.applyPatchChecked(graph, undoPatch);
+    expect(refused.ok).toBe(false);
+    expect(graph.nodesById.size).toBe(before);
+    expect(engine.findInvariantViolation(graph)).toBeNull();
+  });
+
+  it("the unchecked door still corrupts — which is what the doc now says", () => {
+    // NOT a bug being pinned as correct: `applyPatch` is documented as assuming
+    // its precondition, and this is the cost of skipping it, held executable so
+    // the paragraph on `Engine.applyPatch` cannot quietly stop being true.
+    const { engine, graph, undoPatch } = staleUndo();
+
+    const corrupted = engine.applyPatch(graph, undoPatch);
+
+    expect(graph.nodesById.size).toBe(3);
+    expect(corrupted.nodesById.size).toBe(2);
+    const violation = engine.findInvariantViolation(corrupted);
+    expect(violation).not.toBeNull();
+    expect(violation?.code).toBe("parent-index-disagrees");
+  });
+
+  it("applies, and returns the same graph the two-step version would", () => {
+    // A patch that DOES apply must go through untouched, and must agree with
+    // hand-rolling the pair — otherwise the one-call door is a second
+    // implementation rather than the same one.
+    const engine = makeEngine();
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [
+        { id: "root", kind: "folder", data: { name: "R" }, children: ["a"] },
+        { id: "a", kind: "folder", data: { name: "A" }, children: [] },
+      ],
+    });
+    if (!loaded.ok) throw new Error("fixture failed to load");
+
+    const inserted = engine.applyCommand(loaded.value.graph, {
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 1,
+      seeds: [{ kind: "folder", data: { name: "B" } }],
+    });
+    if (!inserted.ok) throw new Error("insert failed");
+
+    const undoPatch = engine.invertPatch(inserted.value.patch);
+    const graph = inserted.value.graph;
+
+    const checked = engine.applyPatchChecked(graph, undoPatch);
+    expect(checked.ok).toBe(true);
+    if (!checked.ok) return;
+
+    const byHand = engine.verifyPatchApplies(graph, undoPatch);
+    expect(byHand.ok).toBe(true);
+    const unchecked = engine.applyPatch(graph, undoPatch);
+
+    expect(checked.value.nodesById.size).toBe(unchecked.nodesById.size);
+    expect([...checked.value.nodesById.keys()].sort()).toEqual(
+      [...unchecked.nodesById.keys()].sort(),
+    );
+    expect(engine.findInvariantViolation(checked.value)).toBeNull();
+  });
+
+  it("inherits the cross-engine guards from the gate it routes through", () => {
+    // `verifyPatchApplies` owns these, so routing through it is what gives the
+    // checked door them for free — the unchecked door has never had either.
+    //
+    // TWO DIFFERENT GUARDS, and they are worth keeping apart because the first
+    // draft of this test conflated them and asserted the wrong code.
+    // `foreign-graph` compares the GRAPH's `engineId` against the engine's; a
+    // foreign PATCH on a native graph passes that check and is caught one layer
+    // in, by the patch naming nodes this graph does not hold.
+    const { graph, undoPatch } = staleUndo();
+    const other = makeEngine();
+    const loaded = other.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [{ id: "root", kind: "folder", data: { name: "R" }, children: [] }],
+    });
+    if (!loaded.ok) throw new Error("fixture failed to load");
+
+    // A graph from another engine.
+    const foreignGraph = other.applyPatchChecked(graph, undoPatch);
+    expect(foreignGraph.ok).toBe(false);
+    if (foreignGraph.ok) return;
+    expect(foreignGraph.error.code).toBe("foreign-graph");
+
+    // A patch from another engine, against a graph of this one's.
+    const foreignPatch = other.applyPatchChecked(loaded.value.graph, undoPatch);
+    expect(foreignPatch.ok).toBe(false);
+    if (foreignPatch.ok) return;
+    expect(foreignPatch.error.code).toBe("node-missing");
+  });
+});

--- a/packages/graph-core/types/describe.ts
+++ b/packages/graph-core/types/describe.ts
@@ -77,6 +77,23 @@ function clamp(text: string): string {
  * payload produced a 1,000,049-character `error.message`, which the consumer
  * then puts in a log line, a toast, or an error report.
  *
+ * "AT EVERY INGRESS REFUSAL" WAS THE CLAIM AND NOT THE FACT, and the gap
+ * outlived the fix by a round. Two places kept the raw form:
+ *
+ *   - `parseSerializedNode` in ./serialize/shape, the FIRST door a payload
+ *     meets. Six refusals, all reached before `buildDocument` adopts any id —
+ *     so before `maxNodeIdLength` can refuse either. Measured at the default
+ *     config: 1,000,030 characters for a non-string `kind`.
+ *   - `tryParseNodeId` in ./primitives, which does not sit at a refusal site at
+ *     all. It is RELAYED by three of them, so those three inherited an
+ *     unbounded quote however carefully they were written — and a sweep for
+ *     `JSON.stringify` at the refusal sites could not see it. Measured: a
+ *     1,000,000-space id, which is legal JSON and fails the `trim()` test,
+ *     produced 1,000,063 characters.
+ *
+ * Both now quote through this function. The lesson worth keeping is the second
+ * one: a bound belongs where the message is BUILT, not where it is returned.
+ *
  * CLAMPS BEFORE IT QUOTES, not after. Quoting first would allocate the full
  * megabyte and escape every character of it before throwing the result away,
  * which is most of the cost the bound is for.

--- a/packages/graph-core/types/engine.ts
+++ b/packages/graph-core/types/engine.ts
@@ -422,8 +422,57 @@ export type Engine<
     graph: Graph<Ts, S>,
     command: Command<Ts, S>,
   ): Result<Readonly<{ graph: Graph<Ts, S>; patch: Patch<Ts, S> }>, Rejection>;
-  /** THE ONE index rewriter — forward application and undo share it. */
+  /**
+   * THE ONE index rewriter — forward application and undo share it.
+   *
+   * PRECONDITION: `verifyPatchApplies` returned ok for THIS graph and THIS
+   * patch. This function re-checks nothing, and that is deliberate — re-checking
+   * would either duplicate the gate and drift from it, or tempt a caller to skip
+   * the gate because "apply validates anyway", which is how the dormant-patch
+   * corruptions happened in the first place.
+   *
+   * SO IT IS UNSAFE ON ITS OWN, and the signature cannot say so: it returns a
+   * `Graph`, not a `Result`, because with the precondition met there is nothing
+   * to reject. That reads as total, and this paragraph is the only thing
+   * standing between that reading and a silently corrupt graph. MEASURED, undo
+   * of an insert whose node has since gained a child — the exact case
+   * `verifyPatchApplies` answers `node-not-empty` for:
+   *
+   *     verifyPatchApplies  ->  node-not-empty
+   *     applyPatch          ->  did not throw, returned a graph
+   *     nodes               ->  3 before, 2 after, the child orphaned
+   *     findInvariantViolation -> parent-index-disagrees
+   *
+   * Nothing rejects, nothing throws, and `serializeGraph` then writes the
+   * result — it emits unreachable nodes rather than dropping them — so the
+   * document saves cleanly and `deserialize` refuses it afterwards.
+   *
+   * USE `applyPatchChecked` UNLESS YOU HAVE ALREADY VERIFIED. This door stays
+   * for the caller who verified once and applies to the same graph, and for the
+   * reducer's own arms, which establish their preconditions by planning rather
+   * than by replay.
+   */
   applyPatch(graph: Graph<Ts, S>, patch: Patch<Ts, S>): Graph<Ts, S>;
+  /**
+   * `verifyPatchApplies` and then `applyPatch`, in that order, as one call.
+   *
+   * The same pairing `serializeChecked` makes with `findInvariantViolation`, and
+   * added for the same reason: the two-step version is correct and the one-step
+   * version is what a caller reaches for, so the safe order should be the one
+   * that is easy to write. `undo` and `redo` have always done exactly this
+   * internally; a consumer driving its own replay — which is why `applyPatch`,
+   * `invertPatch` and `verifyPatchApplies` are exported as peers at all — had to
+   * reassemble it from the parts and could silently omit the gate.
+   *
+   * Costs what verification costs, which is O(patch) rather than O(graph): the
+   * gate reads the nodes the patch names, not the document. That is a different
+   * trade from `serializeChecked`, whose audit is a full pass — so there is no
+   * "keep using the unchecked one for speed" caveat here.
+   */
+  applyPatchChecked(
+    graph: Graph<Ts, S>,
+    patch: Patch<Ts, S>,
+  ): Result<Graph<Ts, S>, ReplayRejection>;
   invertPatch(patch: Patch<Ts, S>): Patch<Ts, S>;
   verifyPatchApplies(
     graph: Graph<Ts, S>,

--- a/packages/graph-core/types/engine.ts
+++ b/packages/graph-core/types/engine.ts
@@ -299,6 +299,34 @@ export type EngineConfig<
    */
   maxDepth?: number;
   /**
+   * Ceiling on the LENGTH of one node id. Defaults to
+   * `DEFAULT_MAX_NODE_ID_LENGTH`; `null` is unbounded.
+   *
+   * THE THIRD CEILING, and unlike `maxDepth` it ships with a number, for
+   * `maxNodes`' reason: it can be defended without knowing your data, because
+   * no legitimate id is within an order of magnitude of it. `maxNodes` bounds
+   * how many nodes a document holds and `maxDepth` how deeply they nest;
+   * neither bounds how large ONE of them is, and `tryParseNodeId` refuses only
+   * the empty and whitespace-only string — so id size was the sender's to
+   * choose under ceilings that read as complete.
+   *
+   * It is the memo table this protects, not the graph. The graph's maps key by
+   * the id and a JavaScript string is shared by reference, so four maps cost
+   * four pointers. `cacheKey` in ./folds CONCATENATES the id into a fresh
+   * string per `(foldKey, nodeId, subtreeRev)` entry, and `foldCacheLimit`
+   * bounds that table by ENTRY COUNT — so before this ceiling, the document
+   * chose the per-entry size and ./folds' measured ~232 bytes an entry rested
+   * on an assumption nothing enforced.
+   *
+   * ENFORCED AT INGRESS AND AT MINTING BOTH, which is the part worth knowing.
+   * A ceiling applied only to documents would let `insert-nodes` put an id in
+   * the graph that `deserialize` then refuses — the "saves cleanly, will not
+   * load" shape this package has already paid for twice. So `mintFreshId`
+   * treats an over-long id from a consumer `mintId` exactly as it treats a
+   * whitespace one: not acceptable, retry, then fall back.
+   */
+  maxNodeIdLength?: number | null;
+  /**
    * Ceiling on EACH STORE's fold memo table. Defaults to
    * `DEFAULT_FOLD_CACHE_LIMIT`.
    *

--- a/packages/graph-core/types/primitives.ts
+++ b/packages/graph-core/types/primitives.ts
@@ -1,5 +1,7 @@
 // Graph — part of the former single-file `types.ts`; see ./index.ts.
 
+import { quoteFromWire } from "./describe";
+
 // ---------------------------------------------------------------------------
 // 1. Primitives
 // ---------------------------------------------------------------------------
@@ -45,16 +47,31 @@ export function parseNodeId(id: string): NodeId {
   return parsed.value;
 }
 
-/** The non-throwing form. Every ingress path uses this one. */
+/**
+ * The non-throwing form. Every ingress path uses this one.
+ *
+ * QUOTED THROUGH `quoteFromWire`, which clamps before it quotes. This message is
+ * not built at a refusal site — it is RELAYED verbatim by three of them in
+ * ./serialize — so those three inherited an unbounded quote however carefully
+ * they were written, and the fourth round's sweep could not see it, because
+ * there is no `JSON.stringify` at the sites it audited.
+ *
+ * The string that reaches here both refused AND enormous is whitespace: a
+ * 1,000,000-space id is legal JSON, fails the `trim()` test, and produced a
+ * 1,000,063-character `error.message`. MEASURED, and reachable at any
+ * `maxNodeIdLength` — the ceiling refuses over-long ids first where it is set,
+ * but `null` is supported, and this door is also `parseNodeId`'s, whose THROW
+ * carried the same string.
+ */
 export function tryParseNodeId(id: string): Result<NodeId, Issue> {
   if (typeof id !== "string" || id.trim() === "") {
     return {
       ok: false,
       error: {
         path: "$.id",
-        message: `Invalid NodeId: ${JSON.stringify(
-          id,
-        )} (must be a non-empty, non-whitespace string)`,
+        message:
+          `Invalid NodeId: ${quoteFromWire(String(id))} ` +
+          `(must be a non-empty, non-whitespace string)`,
       },
     };
   }

--- a/packages/graph-core/types/rejections.ts
+++ b/packages/graph-core/types/rejections.ts
@@ -265,6 +265,14 @@ export type StructuralErrorCode =
   | "document-too-large"
   /** Nested deeper than `EngineConfig.maxDepth`, which is opt-in. */
   | "document-too-deep"
+  /**
+   * A node id longer than `EngineConfig.maxNodeIdLength`.
+   *
+   * The third of the ingress ceilings, and the one the other two do not imply:
+   * they bound how many nodes a document holds and how deeply they nest, never
+   * how large one of them is. Carries `limit`/`actual` like its two siblings.
+   */
+  | "node-id-too-long"
   /** A consumer `contentKey`/`sourceKey` threw. See `RejectionCode`. */
   | "node-type-threw";
 
@@ -277,10 +285,11 @@ export type StructuralError = Readonly<{
   issues?: readonly Issue[];
   /** Present on `"ingress-rejected"`. */
   ingress?: readonly IngressError[];
-  /** Present on the two bound refusals: the ceiling that was in force, and
-   *  what the document actually presented. A consumer telling a person why
-   *  their document was refused needs both, and parsing them back out of
-   *  `message` is not an interface. */
+  /** Present on the three bound refusals — `"document-too-large"`,
+   *  `"document-too-deep"` and `"node-id-too-long"`: the ceiling that was in
+   *  force, and what the document actually presented. A consumer telling a
+   *  person why their document was refused needs both, and parsing them back
+   *  out of `message` is not an interface. */
   limit?: number;
   actual?: number;
 }>;

--- a/packages/graph-core/types/rejections.ts
+++ b/packages/graph-core/types/rejections.ts
@@ -165,6 +165,28 @@ export type ReplayRejectionCode =
    * for the same reason it does.
    */
   | "would-exceed-max-nodes"
+  /**
+   * Replaying this insert or move patch would nest past `maxDepth`.
+   *
+   * THE TWIN OF `"would-exceed-max-nodes"`, and it was missing while that one
+   * was not — which is the whole shape of the defect. `maxDepth` was enforced
+   * at three forward doors (`applyInsertNodes`, `applyMoveNodes`, and both
+   * ingress doors) and at none of the replay ones, so the ceiling held against
+   * every command and against every document, and not against undo or redo.
+   *
+   * Reachable by the same lever the node ceiling names, because `Store.load`
+   * touches neither stack: move an UNLOADED container somewhere legal (it
+   * counts as one level), undo that move, fill the container two levels deep
+   * while it sits shallow, then redo. MEASURED before this existed, at
+   * `maxDepth: 4` — the redo was accepted, the graph reached depth 6,
+   * `serializeGraph` wrote it, and `deserialize` at the same config then
+   * answered `document-too-deep` forever. `findInvariantViolation` cannot catch
+   * it either: `ViolationCode` has no depth member, because depth is a ceiling
+   * a consumer chose and not a structural truth about the graph.
+   *
+   * Carries `limit`/`actual` for the reason its twin does.
+   */
+  | "would-exceed-max-depth"
   /** The store was destroyed. Every mutating call refuses rather than writing
    *  into a graph nothing is listening to — see `Store.destroy`. */
   | "store-destroyed";
@@ -175,11 +197,12 @@ export type ReplayRejection = Readonly<{
   nodeId?: NodeId;
   parentId?: NodeId;
   index?: number;
-  /** The ceiling that was hit, on `"would-exceed-max-nodes"`. Named the same as
-   *  `Rejection`'s pair so a consumer reporting a limit to the user reads it the
-   *  same way whichever door refused. */
+  /** The ceiling that was hit, on `"would-exceed-max-nodes"` and
+   *  `"would-exceed-max-depth"`. Named the same as `Rejection`'s pair so a
+   *  consumer reporting a limit to the user reads it the same way whichever
+   *  door refused. */
   limit?: number;
-  /** What the graph WOULD have reached. */
+  /** What the graph WOULD have reached — nodes or levels, per the code. */
   actual?: number;
 }>;
 

--- a/packages/graph-core/types/wire.ts
+++ b/packages/graph-core/types/wire.ts
@@ -102,6 +102,9 @@ export type EngineContext<S> = Readonly<{
   /** Ceiling on nesting depth, or `null` for unbounded. See
    *  `EngineConfig.maxDepth`. */
   maxDepth: number | null;
+  /** Ceiling on the LENGTH of one node id, or `null` for unbounded. See
+   *  `EngineConfig.maxNodeIdLength`. */
+  maxNodeIdLength: number | null;
   mintId(): string;
   now(): number;
   /**


### PR DESCRIPTION
A review of `packages/graph-core` — security, performance, TypeScript, design — and the seven findings worth acting on. Tests and stories were out of scope.

The package is in good shape. `tsc --noEmit` is clean under `strict` + `noUncheckedIndexedAccess`, there is no `any`, and every consumer callback family was already contained. Almost everything below is a **mirror that did not get finished**: a rule enforced on one door and not its twin.

Every fix was verified fail-first — the source stashed, the new tests re-run, and the failure recorded — because a regression test that never failed is a test measuring nothing. Three of these were found by probing rather than reading, and the numbers are in the commit messages.

## The two that could lose a document

**`b96f5e7` — the replay gate enforces `maxDepth`, not only `maxNodes`.** The node ceiling was checked on replay; the depth ceiling was not, at either arm. `ReplayRejectionCode` said so out loud — it carried `would-exceed-max-nodes` and not its twin. Reachable with no hand-built patch, using the lever the node-ceiling fix names (`Store.load` touches neither stack): move an unloaded container somewhere legal, undo, fill it two levels deep while it sits shallow, then redo. At `maxDepth: 4` the redo was accepted, the graph reached depth 6, `serializeGraph` wrote it, and `deserialize` at the same config then answered `document-too-deep` — permanently.

`tallestSubtree` moved from `./commands` into `./graph` as `subtreeHeight` so the forward door and the replay door read one answer. Two doors computing depth independently is what let this through.

**`77aa32c` — a throwing `sourceKey` cannot escape the edit door.** `planEdits` was the one site in the package calling a consumer key hook bare. `guardKeyHooks` catches the private `KeyHookFailure` tag only — correctly, so engine bugs still crash as themselves — so a raw consumer throw walked straight out of `dispatch`. `review4-a-throwing-key-hook-cannot-escape-either` already asserted "dispatch refuses" and passed the whole time: its fixture edits a leaf, and the bare call sits behind `if (ownsItsSubtree(node))`.

## Contract holes

**`2e78a00` — a throwing fold cannot escape `aggregate`.** The last consumer hook family with no guard, on the one read path React runs during render. Answers `undefined` — there is no value of the consumer's `A` to manufacture — and abandons the whole walk rather than handing a parent a subtree with a hole and labelling the total `exact`.

**`27a190f` — `applyPatchChecked`, and a precondition that is written down.** `applyPatch` states its precondition in `./patches`; the public type said one line and returns `Graph` rather than `Result`, so it reads as total. Undoing an insert whose node has gained a child: verify says `node-not-empty`, `applyPatch` returns a graph, 3 nodes become 2 with an orphan, and the audit reports `parent-index-disagrees`. The new door pairs the gate with the rewrite the way `serializeChecked` pairs the audit with the bytes.

**`68fbf04` — node ids get a length ceiling.** `maxNodes` bounds how many, `maxDepth` how deep; neither bounds how large one is. The graph's maps share strings by reference, so this is about the memo table: `cacheKey` concatenates the id into a fresh string per entry, and `foldCacheLimit` counts entries — so the document chose the per-entry size, and the measured "~232 bytes an entry" rested on an unenforced assumption. Enforced at all three places the wire names an id, **and at minting**, so the graph cannot hold an id `deserialize` would refuse.

## Bounds and diagnostics

**`0f0c2e7` — the message bound reaches the first door.** Round four's `quoteFromWire` note says it covered "every ingress refusal". Two places kept the raw form. `parseSerializedNode` is the first door a payload meets, before any id is adopted and so before the new ceiling can refuse: 1,000,030 characters for a non-string `kind`, at the default config. And `tryParseNodeId` does not sit at a refusal site at all — it is relayed by three of them, so a sweep for `JSON.stringify` at the refusal sites structurally could not find it. **A bound belongs where the message is built, not where it is returned.**

**`4d57e34` — the commit-cost warning counts tombstones.** A removal also copies `deadRevById`, sized by the session's deletions rather than by the document. Insert-then-remove in a loop with live pinned at 1: 0.045 ms per delete at 1,000 tombstones, 0.478 ms at 8,000. Per operation that stays inside a frame — the defect was that `warnIfCommitCostIsPastInteractive` read `nodesById.size`, which is `1` there, so the diagnostic built for this cost could not fire for it.

The obvious fix is wrong and is now written down as such: evicting a tombstone lets a returning id restart at rev 0 and walk back onto revs its dead lineage cached. Removing the quadratic needs a single monotonic rev floor instead of per-id tombstones — a change to the fold cache's only invalidation mechanism, which that file records as having shipped wrong twice, so it is noted and left for its own round.

## Verification

`tsc --noEmit` clean on `graph-core` and `graph-react`; **1592/1592** package tests (from 1555, +37); **1408/1408** app tests; `lint:packages` 0 errors.

Two existing tests changed, both deliberately. `review4-a-refusal-message-is-bounded` now builds its engine with `maxNodeIdLength: null` — its 200,000-character ids would otherwise be refused by the new ceiling before reaching the refusals whose *clamp* they exist to test, and would have kept passing on a different code while measuring nothing. `review4-a-throwing-key-hook-cannot-escape-either` gained the container case its leaf fixture could not reach.

## Left open

Three minor findings, deliberately not in this branch: selection writes are not refused after `destroy()` while every other write is; `shadowCheck` spends 999 of its 1000 budget and prints "everything it checked agreed" unconditionally; and a dangling JSDoc in `patches/apply.ts` documents a function that moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)