### PR TITLE
Graph-core review round five: the tail

### DIFF
--- a/packages/graph-core/engine/index.ts
+++ b/packages/graph-core/engine/index.ts
@@ -369,23 +369,33 @@ export function createEngine<
    * never left believing an audit is running after it has gone quiet.
    */
   let shadowsLeft = SHADOW_REFOLD_BUDGET;
-  const shadowCheck = (
+  /**
+   * Whether any comparison actually disagreed, so the sign-off below can say
+   * which happened.
+   *
+   * The message used to assert "Everything it checked agreed" UNCONDITIONALLY —
+   * printed on exhaustion whether or not a stale entry had already been reported
+   * above it. A diagnostic whose closing line contradicts its own findings is
+   * worse than one that says nothing, because the summary is what a reader
+   * scrolling a console keeps.
+   */
+  let shadowFoundStale = false;
+
+  /**
+   * ONE comparison. Split out so the budget accounting around it is a
+   * three-line function rather than something the early returns can escape.
+   *
+   * Every path here returns without announcing anything about the budget —
+   * that is `shadowCheck`'s job, and it was the entanglement of the two that
+   * produced the off-by-one below.
+   */
+  const compareShadow = (
     graph: Graph<Ts, S>,
     fold: WidenedFold<Ts, S>,
     id: NodeId,
     cachedValue: unknown,
     key: string,
   ): void => {
-    if (shadowsLeft <= 0) return;
-    shadowsLeft -= 1;
-    if (shadowsLeft === 0) {
-      console.error(
-        `graph dev check: the shadow cold refold has spent its budget of ` +
-          `${SHADOW_REFOLD_BUDGET} comparisons and is now OFF for this engine. ` +
-          `Everything it checked agreed; later reads are no longer audited.`,
-      );
-      return;
-    }
     // NO CACHE ARGUMENT — that is what makes it cold. Passing one would let the
     // shadow populate the very table it is auditing, and it would then be
     // comparing an entry against itself.
@@ -401,12 +411,43 @@ export function createEngine<
     }
     if (fresh === undefined) return;
     if (structurallyEqualBounded(fresh.value, cachedValue) !== false) return;
+    shadowFoundStale = true;
     console.error(
       `graph dev check: the memo table served a STALE ${JSON.stringify(key)} for node ` +
         `${JSON.stringify(id)}. Cached and freshly folded values disagree, which means an ` +
         `entry outlived the revision that should have made it unreachable. ` +
         `cached=${describeValue(cachedValue)} fresh=${describeValue(fresh.value)}`,
     );
+  };
+
+  const shadowCheck = (
+    graph: Graph<Ts, S>,
+    fold: WidenedFold<Ts, S>,
+    id: NodeId,
+    cachedValue: unknown,
+    key: string,
+  ): void => {
+    if (shadowsLeft <= 0) return;
+    shadowsLeft -= 1;
+    // THE COMPARISON FIRST, THEN THE SIGN-OFF, and that order is the fix rather
+    // than a rearrangement. The announcement used to sit between the decrement
+    // and the work, with a `return` after it, so the call that took the counter
+    // from 1 to 0 announced the budget spent and then DID NOT COMPARE. The
+    // engine ran 999 of the 1,000 it reported, and the one it skipped was a real
+    // audited read — silently, on the audit whose whole purpose is that a stale
+    // entry is otherwise served forever.
+    compareShadow(graph, fold, id, cachedValue, key);
+    if (shadowsLeft === 0) {
+      console.error(
+        `graph dev check: the shadow cold refold has spent its budget of ` +
+          `${SHADOW_REFOLD_BUDGET} comparisons and is now OFF for this engine. ` +
+          `${
+            shadowFoundStale
+              ? "It reported at least one STALE entry above; later reads are no longer audited."
+              : "Everything it checked agreed; later reads are no longer audited."
+          }`,
+      );
+    }
   };
 
   // -------------------------------------------------------------------------
@@ -732,10 +773,32 @@ export function createEngine<
       }
     };
 
+    /**
+     * THE ONE PLACE the selection is written, and therefore the one place the
+     * destroyed check belongs — `set`, `toggle`, `clear` and `selectRange` all
+     * funnel through here, and guarding four entry points is how three of them
+     * stay guarded and the fourth quietly does not.
+     *
+     * A SILENT NO-OP, not a rejection, matching `markMissing` rather than
+     * `dispatch`: these return `void`, so there is nothing to reject WITH, and
+     * inventing a throw for an unmount race would be the opposite of what the
+     * write doors decided. `dispatch`, `undo`, `redo`, `load` and
+     * `applyNonUndoableWrite` all return a `Result` and refuse with
+     * `"store-destroyed"`; `markMissing` returns void and simply does not write.
+     * Selection is the second of that second kind.
+     *
+     * It was UNGUARDED, and the argument the write doors make applies unchanged:
+     * `destroy()` clears every listener, so a post-destroy `selection.set` moved
+     * `selectedIds` and `selectedSet` and then notified an empty set — a zombie
+     * write whose only symptom is a later `selection.get()` disagreeing with a
+     * UI that has already torn down. Measured: `dispatch` after `destroy()`
+     * refused with `"store-destroyed"` while `selection.set([a])` mutated.
+     */
     const setSelection = (
       ids: readonly NodeId[],
       nextAnchor: NodeId | null,
     ): void => {
+      if (destroyed) return;
       const seen = new Set<NodeId>();
       const deduped: NodeId[] = [];
       for (const id of ids) {

--- a/packages/graph-core/patches/apply.ts
+++ b/packages/graph-core/patches/apply.ts
@@ -39,18 +39,14 @@ export function applyPatch<Ts extends readonly WidenedNodeType[], S>(
 }
 
 
-/**
- * Copy-on-write removal BY IDENTITY, not by index.
- *
- * Deliberate: a "moved" patch removes several nodes before inserting any, and
- * index-based removal would need every subsequent index rebased. Identity
- * removal is order-independent, so the recorded `fromIndex` is needed only by
- * the inverse — which is precisely what makes swapping endpoints a complete
- * inversion.
- */
-
-
-
+// The block that stood here documented a copy-on-write removal helper that left
+// with the folder split, and described it as though it were still below. Its
+// two claims both live with the code now: "removal by identity is
+// order-independent" is argued at `spliceOutMany` in ./splicing, where the
+// single pass depends on it, and "the recorded `fromIndex` is needed only by the
+// inverse" is argued at `invertPatch`, which is what swaps the endpoints. A
+// third copy attached to nothing is how a reader ends up looking for a function
+// that is not here.
 
 
 // ---------------------------------------------------------------------------

--- a/packages/graph-core/tests/review5-a-destroyed-store-writes-nothing-and-the-audit-counts-honestly.test.ts
+++ b/packages/graph-core/tests/review5-a-destroyed-store-writes-nothing-and-the-audit-counts-honestly.test.ts
@@ -1,0 +1,278 @@
+// Fifth review round — the tail: two places where the code and its own account
+// of itself had come apart.
+//
+// SELECTION AFTER DESTROY. `destroy()` clears every listener and the fold cache,
+// and each write door argues the same thing for refusing afterwards: "a mutation
+// after it lands in a graph nothing is subscribed to and no cache reflects — a
+// zombie write whose only symptom is a later read disagreeing with the UI".
+// `dispatch`, `undo`, `redo`, `load` and `applyNonUndoableWrite` all refuse.
+// `selection.set` / `toggle` / `clear` / `selectRange` did not: they moved
+// `selectedIds` and `selectedSet` and then notified an empty listener set.
+// Measured before this: `dispatch` refused with `"store-destroyed"` on the same
+// store where `selection.set([a])` mutated.
+//
+// The guard goes on `setSelection`, the single place the selection is written,
+// rather than on the four entry points — guarding four is how three stay guarded
+// and the fourth quietly does not. A silent no-op rather than a rejection,
+// matching `markMissing`: these return `void`, so there is nothing to reject
+// with.
+//
+// THE SHADOW BUDGET. `shadowCheck` decremented, announced exhaustion, and
+// returned — so the call that took the counter from 1 to 0 reported the budget
+// spent and then did not compare. The engine ran 999 of the 1,000 it claimed,
+// and the skipped one was a real audited read, on the audit that exists because
+// a stale memo entry is otherwise served forever. Worse, that announcement
+// asserted "Everything it checked agreed" unconditionally — printed even when a
+// STALE entry had already been reported above it. A diagnostic whose closing
+// line contradicts its own findings is worse than one that says nothing, because
+// the summary is what a reader keeps.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type ConsumerDefinedFold,
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "../index";
+import { createEngine } from "../engine";
+import { SHADOW_REFOLD_BUDGET } from "../engine/constants";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const doc = {
+  formatVersion: 1 as const,
+  schemaVersions: { folder: 1 },
+  rootIds: ["root"],
+  nodes: [
+    { id: "root", kind: "folder", data: { name: "R" }, children: ["a", "b"] },
+    { id: "a", kind: "folder", data: { name: "A" }, children: [] },
+    { id: "b", kind: "folder", data: { name: "B" }, children: [] },
+  ],
+};
+
+const aId = parseNodeId("a");
+const bId = parseNodeId("b");
+
+function makeStore() {
+  const engine = createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+  const loaded = engine.deserialize(doc);
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return engine.createStore(loaded.value.graph);
+}
+
+describe("a destroyed store writes nothing, selection included", () => {
+  it("every selection writer is a no-op after destroy", () => {
+    const store = makeStore();
+    store.selection.set([aId]);
+    expect(store.selection.get()).toEqual([aId]);
+
+    store.destroy();
+
+    // All four, because the guard sits at the one place they share and this is
+    // what proves they actually share it.
+    store.selection.set([bId]);
+    expect(store.selection.get()).toEqual([aId]);
+
+    store.selection.toggle(bId);
+    expect(store.selection.get()).toEqual([aId]);
+
+    store.selection.selectRange(aId, bId);
+    expect(store.selection.get()).toEqual([aId]);
+
+    store.selection.clear();
+    expect(store.selection.get()).toEqual([aId]);
+    expect(store.selection.has(aId)).toBe(true);
+  });
+
+  it("matches the write doors it sits beside", () => {
+    // `dispatch` REFUSES with a code; selection is silent. Both are "does not
+    // write", and the difference is only that one has a `Result` to say it in.
+    const store = makeStore();
+    store.destroy();
+
+    const dispatched = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: aId, kind: "folder", edit: { name: "Z" } }],
+    });
+    expect(dispatched.ok).toBe(false);
+    if (!dispatched.ok) expect(dispatched.error.code).toBe("store-destroyed");
+
+    store.selection.set([aId]);
+    expect(store.selection.get()).toEqual([]);
+  });
+
+  it("a live store is completely unaffected", () => {
+    const store = makeStore();
+    store.selection.set([aId]);
+    store.selection.toggle(bId);
+    expect(store.selection.get()).toEqual([aId, bId]);
+    store.selection.clear();
+    expect(store.selection.get()).toEqual([]);
+    store.selection.selectRange(aId, bId);
+    expect(store.selection.get()).toEqual([aId, bId]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("the shadow budget spends what it reports", () => {
+  /**
+   * The real budget, read from the constant rather than restated — 1,000
+   * shadowed reads is well under a second on a three-node graph, so the
+   * off-by-one can be pinned directly instead of inferred.
+   */
+  function shadowedReads(
+    count: number,
+    goStaleAt: number | null,
+  ): Readonly<{ comparisons: number; messages: string }> {
+    let comparisons = 0;
+    let reads = 0;
+    let inShadow = false;
+    let lying = false;
+
+    const fold: ConsumerDefinedFold<Types, Summary, number> = {
+      key: "size",
+      leaf() {
+        return 1;
+      },
+      collection(node, children) {
+        // ONE PER REFOLD, not one per node: this fixture's root and both of its
+        // children are containers, so a cold refold calls `collection` three
+        // times and counting every call would report 3x the comparisons. The
+        // root is the node the shadow was asked about, so it marks the refold.
+        //
+        // Counted only while a shadow is running — the live read is a cache hit
+        // and never reaches here at all.
+        if (inShadow && node.id === "root") comparisons += 1;
+        let total = lying ? 1_000 : 1;
+        for (const child of children) total += child.value;
+        return { value: total, certainty: "exact" };
+      },
+      placeholder() {
+        return { value: 0, certainty: "partial" };
+      },
+      missing() {
+        return { value: 0, certainty: "partial" };
+      },
+      sealed() {
+        return { value: 0, certainty: "partial" };
+      },
+    };
+
+    const engine = createEngine<Types, Summary, { size: typeof fold }>({
+      types,
+      summary,
+      folds: { size: fold },
+      devChecks: true,
+    });
+    const loaded = engine.deserialize(doc);
+    if (!loaded.ok) throw new Error("fixture failed to load");
+    const store = engine.createStore(loaded.value.graph);
+    const rootId = parseNodeId("root");
+
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    // The first read MISSES and fills the table; only a hit is shadowed.
+    store.aggregate("size", rootId);
+    inShadow = true;
+    for (reads = 0; reads < count; reads += 1) {
+      if (goStaleAt !== null && reads === goStaleAt) lying = true;
+      store.aggregate("size", rootId);
+    }
+    const messages = logged.mock.calls.map((call) => String(call[0])).join(String.fromCharCode(10));
+    logged.mockRestore();
+
+    // One `collection` call per node the cold refold walks (root, a, b -> the
+    // two leaves use `leaf`), so comparisons are counted in whole refolds.
+    return { comparisons, messages };
+  }
+
+  it("runs the comparison on the call that exhausts the budget", () => {
+    // THE OFF-BY-ONE. The announcement used to sit between the decrement and the
+    // work, with a `return` after it, so the call that took the counter from 1
+    // to 0 reported the budget spent and then did not compare: 999 of the 1,000
+    // it claimed, with the skipped one a real audited read.
+    const upTo = SHADOW_REFOLD_BUDGET;
+    const { comparisons, messages } = shadowedReads(upTo, null);
+
+    // Every one of the 1,000 shadowed reads folded cold — including the last.
+    expect(comparisons).toBe(upTo);
+    expect(messages).toContain("spent its budget");
+    expect(messages).toContain(String(upTo));
+  });
+
+  it("stops after the budget rather than merely announcing it", () => {
+    const upTo = SHADOW_REFOLD_BUDGET;
+    const { comparisons } = shadowedReads(upTo + 50, null);
+    // The extra 50 reads are served from the table and audited by nothing.
+    expect(comparisons).toBe(upTo);
+  });
+
+  it("does not sign off with 'everything agreed' when it found a stale entry", () => {
+    // THE FALSE SIGN-OFF. That sentence was printed unconditionally on
+    // exhaustion, so a run that had already reported a STALE entry closed by
+    // contradicting itself — and the summary is what a reader scrolling a
+    // console keeps.
+    const { messages } = shadowedReads(SHADOW_REFOLD_BUDGET, 10);
+    expect(messages).toContain("STALE");
+    expect(messages).toContain("spent its budget");
+    expect(messages).toContain("reported at least one STALE entry");
+    expect(messages).not.toContain("Everything it checked agreed");
+  });
+
+  it("still signs off with 'everything agreed' when nothing disagreed", () => {
+    // The other branch, so the fix is not just "never say it".
+    const { messages } = shadowedReads(SHADOW_REFOLD_BUDGET, null);
+    expect(messages).toContain("Everything it checked agreed");
+    expect(messages).not.toContain("STALE");
+  });
+
+  it("stays silent when the table and a cold refold agree, before the budget", () => {
+    const { messages } = shadowedReads(3, null);
+    expect(messages).toBe("");
+  });
+});


### PR DESCRIPTION
The last three findings from the round-five review of `packages/graph-core`, after #629 took the seven substantive ones. Each is a place where the code and its own account of itself had come apart — small, but this package's comments are its specification, so a comment that lies is a defect in the specification.

## A destroyed store writes nothing, selection included

Every write door argues the same thing for refusing once `destroy()` has run: *"a mutation after it lands in a graph nothing is subscribed to and no cache reflects — a zombie write whose only symptom is a later read disagreeing with the UI"*. `dispatch`, `undo`, `redo`, `load` and `applyNonUndoableWrite` all refuse. `selection.set` / `toggle` / `clear` / `selectRange` did not — they moved `selectedIds` and `selectedSet` and then notified an emptied listener set.

Measured: on one destroyed store, `dispatch` refused with `"store-destroyed"` while `selection.set([a])` mutated.

The guard goes on `setSelection`, the single place the selection is written, rather than on the four entry points — guarding four is how three stay guarded and the fourth quietly does not. A **silent no-op rather than a rejection**, matching `markMissing` rather than `dispatch`: these return `void`, so there is nothing to reject *with*, and inventing a throw for an unmount race would be the opposite of what the write doors decided.

## The shadow budget spends what it reports

Two defects one line apart, in the audit whose whole purpose is that a stale memo entry is otherwise served silently and forever.

`shadowCheck` decremented, announced exhaustion, and returned — so the call taking the counter from 1 to 0 reported the budget spent **and then did not compare**. The engine ran 999 of the 1,000 it claimed, and the skipped one was a real audited read. The comparison now runs first and the sign-off after it, with the comparison split into its own function so its early returns cannot escape the accounting again.

And that sign-off asserted something false: *"Everything it checked agreed"* was printed unconditionally, including on a run that had already reported a STALE entry above it. A diagnostic whose closing line contradicts its own findings is worse than one that says nothing, because the summary is what a reader scrolling a console keeps. It now says which happened.

## A dangling JSDoc

`patches/apply.ts` carried a block describing a copy-on-write removal helper that left with the folder split, written as though it were still below it. Checked before deleting: both its claims live with the code now — *"removal by identity is order-independent"* is argued at `spliceOutMany`, where the single pass depends on it, and *"the recorded `fromIndex` is needed only by the inverse"* is argued at `invertPatch`, which is what swaps the endpoints. Nothing was lost. A third copy attached to nothing is how a reader ends up looking for a function that is not there.

## Verification

`tsc --noEmit` clean, **1600/1600** package tests, `lint:packages` 0 errors.

Fail-first verified by stashing the source and re-running: 5 of the 8 new cases fail without these, the budget one with `expected 999 to be 1000`. The other 3 are controls — a live store unaffected, silence below the budget, and the agreeing branch of the sign-off, which passed before only because it was the only branch there was.

Worth noting on process: my first draft of the shadow tests passed both with and without the fix, which is a test measuring nothing. They were rewritten to drive the real 1,000-read budget directly, which is what produced the `999 to be 1000` failure above.

With this, all ten findings from the review are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)