### PR TITLE
A build step, verified against what it would publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ apps/backend/.venv/
 __pycache__/
 *.pyc
 .vercel
+
+# Build output — emitted by scripts/build-nested-collections.mjs
+packages/nested-collections/dist/

--- a/apps/storybook/vitest.config.ts
+++ b/apps/storybook/vitest.config.ts
@@ -11,6 +11,23 @@ const dirname =
     : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  // The package's `exports` name `dist/`, because that is what npm publishes.
+  // Nothing in this repo imports it by specifier today — the two halves reach
+  // each other relatively — but the moment something does, TypeScript would
+  // resolve it to SOURCE (via the `paths` in tsconfig.json) while the runtime
+  // resolved it to a `dist/` that may not be built. Types and runtime
+  // disagreeing is the quiet kind of wrong, so they are pinned to the same
+  // place here.
+  resolve: {
+    alias: {
+      "@storyboard/nested-collections/react": fileURLToPath(
+        new URL("../../packages/nested-collections/react/index.ts", import.meta.url),
+      ),
+      "@storyboard/nested-collections": fileURLToPath(
+        new URL("../../packages/nested-collections/core/index.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     coverage: {
       allowExternal: true,

--- a/packages/nested-collections/core/tests/the-build-output-is-publishable.test.ts
+++ b/packages/nested-collections/core/tests/the-build-output-is-publishable.test.ts
@@ -1,0 +1,179 @@
+// What `npm publish` would actually ship, asserted against the BUILT output.
+//
+// Every other guard in this package reads source. None of them can see the two
+// ways the build silently produces a broken package, because both happen during
+// the bundle:
+//
+//   1. `"use client"` GOES MISSING, or arrives TWICE. Lose it and the React
+//      entry becomes a SERVER module: it typechecks, it imports, and it fails at
+//      request time — the same failure the boundary guard prevents in the other
+//      direction, and just as invisible.
+//
+//      The first version of this file asserted only that the directive was
+//      PRESENT, and the build re-attached it with a banner in the belief that
+//      esbuild strips it. Both were wrong: esbuild hoists the entry's directive
+//      itself, so the banner emitted a second copy and the assertion could not
+//      fail — deleting the banner changed nothing the test could see. Counting
+//      is what gives it teeth.
+//
+//   2. THE CORE GETS INLINED INTO THE REACT BUNDLE. `engine/defaults.ts` keeps a
+//      module-level `mintCounter`, documented as "process-wide, not per-engine,
+//      and that is the point" — it is what makes an intra-process id collision
+//      impossible regardless of what `Math.random` does. Two copies of the core
+//      in one process is two counters, and that guarantee quietly degrades to
+//      the random suffix alone.
+//
+// IT BUILDS RATHER THAN READING `dist/`. A test that asserted on a checked-in
+// or previously-built `dist/` would skip when absent and pass forever — the
+// fail-open shape this package has already been bitten by twice. Building into a
+// temp directory costs about a second and cannot go quiet.
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const { buildTo } = (await import(
+  new URL("../../../../scripts/build-nested-collections.mjs", import.meta.url).href
+)) as { buildTo: (outDir: string) => Promise<Record<string, string>> };
+
+const PACKAGE_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+let outDir = "";
+let built: Record<string, string> = {};
+const read = (file: string): string => readFileSync(file, "utf8");
+
+beforeAll(async () => {
+  outDir = mkdtempSync(join(tmpdir(), "nc-build-"));
+  built = await buildTo(outDir);
+}, 120_000);
+
+afterAll(() => {
+  if (outDir !== "") rmSync(outDir, { recursive: true, force: true });
+});
+
+describe("the build output is publishable", () => {
+  it("emits both entries and both declaration trees", () => {
+    // The vacuity check: everything below reads these files, so if the build
+    // silently produced nothing, every other assertion would be about "".
+    for (const [label, file] of Object.entries(built)) {
+      expect(existsSync(file), label).toBe(true);
+      expect(read(file).length, label).toBeGreaterThan(100);
+    }
+  });
+
+  it('keeps "use client" on the react entry, first and exactly once', () => {
+    const text = read(built["react"] ?? "");
+    // POSITION, asserted with `startsWith` rather than by splitting lines: a
+    // directive that is not the first thing in the file is just a string
+    // expression, and every bundler ignores it.
+    expect(text.startsWith('"use client";')).toBe(true);
+    // COUNT: the assertion with teeth. Presence alone passed while the build
+    // emitted the directive TWICE — once hoisted by esbuild, once from a banner
+    // added on a wrong belief about what esbuild does — so deleting that banner
+    // changed nothing this test could see.
+    expect([...text.matchAll(/["']use client["']/g)]).toHaveLength(1);
+  });
+
+  it("does NOT put the directive on the core entry", () => {
+    // The other direction. A core that announces itself as a client module is
+    // exactly as broken, and would make `createEngine` unusable from a route
+    // handler — the thing the whole two-entry layout exists to protect.
+    expect(read(built["core"] ?? "")).not.toContain("use client");
+  });
+
+  it("leaves the core out of the react bundle rather than inlining it", () => {
+    const react = read(built["react"] ?? "");
+    const core = read(built["core"] ?? "");
+    // It IMPORTS the core...
+    expect(react).toMatch(/from\s*["']\.\.\/core\/index\.js["']/);
+    // ...and does not carry a copy of it. `mintCounter` is the specific thing
+    // that must exist once per process; asserting on size alone would pass a
+    // build that inlined half of it.
+    expect(core).toContain("mintCounter");
+    expect(react).not.toContain("mintCounter");
+    expect(react.length).toBeLessThan(core.length / 4);
+  });
+
+  it("keeps react external, since it is an optional peer dependency", () => {
+    const react = read(built["react"] ?? "");
+    expect(react).toMatch(/from\s*["']react["']/);
+    // A consumer who never touches the React entry must not be made to install
+    // it, which only holds while the core has no idea React exists.
+    expect(read(built["core"] ?? "")).not.toMatch(/from\s*["']react["']/);
+  });
+
+  it("emits runnable ESM, not extensionless imports Node cannot resolve", () => {
+    // The reason the build bundles at all: the source imports `../types`, which
+    // `moduleResolution: "bundler"` permits and Node's resolver rejects. A
+    // relative specifier surviving into the output would import nothing.
+    for (const label of ["core", "react"]) {
+      const text = read(built[label] ?? "");
+      const relative = [...text.matchAll(/from\s*["'](\.[^"']*)["']/g)].map((m) => m[1]);
+      const extensionless = relative.filter((spec) => spec !== undefined && !spec.endsWith(".js"));
+      expect(extensionless, label).toEqual([]);
+    }
+  });
+
+  it("the manifest points at what the build actually writes", () => {
+    // The two halves of publishing that can drift apart: what is emitted, and
+    // what `exports` claims is emitted. Neither one checks the other.
+    const manifest = JSON.parse(
+      read(join(PACKAGE_ROOT, "package.json")),
+    ) as Readonly<{
+      type?: string;
+      files?: readonly string[];
+      exports?: Record<string, { types?: string; default?: string }>;
+      main?: string;
+      types?: string;
+    }>;
+
+    // `type: module` is not cosmetic — without it Node guesses, warns, and
+    // reparses every import of this package.
+    expect(manifest.type).toBe("module");
+    expect(manifest.files).toEqual(["dist"]);
+
+    const entries = manifest.exports ?? {};
+    expect(Object.keys(entries).sort()).toEqual([".", "./react"]);
+
+    // Every path the manifest names must exist in a fresh build, resolved
+    // against the temp output rather than a stale `dist/`.
+    const named = [
+      entries["."]?.default,
+      entries["."]?.types,
+      entries["./react"]?.default,
+      entries["./react"]?.types,
+      manifest.main,
+      manifest.types,
+    ];
+    for (const rel of named) {
+      expect(rel, "manifest path").toBeDefined();
+      const inBuild = join(outDir, (rel ?? "").replace(/^\.\/dist\//, "").replace(/^\.\//, ""));
+      expect(existsSync(inBuild), rel).toBe(true);
+    }
+  });
+
+  it("ships no TypeScript source, only declarations", () => {
+    // `files: ["dist"]` covers this, but `main`/`types` pointing at a `.ts` file
+    // would drag it into the tarball anyway — npm includes whatever they name,
+    // whatever `files` says. That is how the first version of this manifest
+    // leaked `core/index.ts` into the pack.
+    const manifest = JSON.parse(read(join(PACKAGE_ROOT, "package.json"))) as Readonly<{
+      main?: string;
+      types?: string;
+      exports?: Record<string, { types?: string; default?: string }>;
+    }>;
+    const paths = [
+      manifest.main,
+      manifest.types,
+      ...Object.values(manifest.exports ?? {}).flatMap((e) => [e.types, e.default]),
+    ].filter((p): p is string => p !== undefined);
+
+    for (const p of paths) {
+      expect(p.endsWith(".ts") && !p.endsWith(".d.ts"), p).toBe(false);
+      expect(p.startsWith("./dist/"), p).toBe(true);
+    }
+  });
+});

--- a/packages/nested-collections/core/tests/the-core-entry-cannot-reach-the-react-half.test.ts
+++ b/packages/nested-collections/core/tests/the-core-entry-cannot-reach-the-react-half.test.ts
@@ -139,17 +139,38 @@ describe("the core entry cannot reach the react half", () => {
     expect(fromReact.map(show)).toContain("core/index.ts");
   });
 
-  it("the exports map names exactly the two entries", () => {
-    // The map is what makes the walk above meaningful to a consumer: `.` must
-    // not resolve anywhere near `react/`.
+  it("the exports map keeps the two entries apart", () => {
+    // The map is what makes the walk above meaningful to a CONSUMER: `.` must
+    // not resolve anywhere near `react/`, or the module graph proven clean here
+    // is not the one they get.
+    //
+    // SHAPE-AGNOSTIC on purpose. This asserted the literal strings of a flat
+    // map and broke the moment `exports` became conditional for publishing —
+    // which changes HOW the entries resolve, not WHETHER they are separate,
+    // and separateness is the only thing this file has an opinion about.
     const manifest: unknown = JSON.parse(
       readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8"),
     );
     const exportsMap = (manifest as { exports?: Record<string, unknown> }).exports;
     expect(exportsMap).toBeDefined();
     expect(Object.keys(exportsMap ?? {}).sort()).toEqual([".", "./react"]);
-    expect(exportsMap?.["."]).toBe("./core/index.ts");
-    expect(exportsMap?.["./react"]).toBe("./react/index.ts");
+
+    // Every path an entry resolves to, whatever conditions wrap it.
+    const pathsUnder = (entry: unknown): readonly string[] => {
+      if (typeof entry === "string") return [entry];
+      const nested = (entry ?? {}) as Record<string, unknown>;
+      return Object.values(nested).flatMap(pathsUnder);
+    };
+
+    const corePaths = pathsUnder(exportsMap?.["."]);
+    const reactPaths = pathsUnder(exportsMap?.["./react"]);
+    expect(corePaths.length).toBeGreaterThan(0);
+    expect(reactPaths.length).toBeGreaterThan(0);
+
+    // THE PROPERTY: nothing the core entry resolves to lives under `react/`,
+    // and everything the react entry resolves to does.
+    for (const path of corePaths) expect(path).not.toContain("/react/");
+    for (const path of reactPaths) expect(path).toContain("/react/");
   });
 
   it("no source file outside react/ carries the directive", () => {

--- a/packages/nested-collections/core/tsconfig.build.json
+++ b/packages/nested-collections/core/tsconfig.build.json
@@ -1,0 +1,24 @@
+{
+  // DECLARATIONS ONLY. The JavaScript is built by esbuild (see
+  // scripts/build-nested-collections.mjs); `tsc` is here for the `.d.ts` tree
+  // and nothing else, because it is the only thing that can produce one.
+  //
+  // A SEPARATE FILE from ./tsconfig.json rather than CLI overrides, because the
+  // difference is not just `noEmit`: the published surface must not carry
+  // declarations for tests or fixtures, and `include`/`exclude` cannot be
+  // overridden from the command line.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+    // The PACKAGE root, so the emitted tree mirrors the source layout and
+    // `react/`'s declarations can reference `../core/...` exactly as the source
+    // does. Emitting from `core/` alone would flatten that and break the link.
+    "rootDir": "..",
+    "outDir": "../dist/types"
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "tests", "**/*.test.ts", "**/*.stories.tsx", "**/typecheck-fixture-*"]
+}

--- a/packages/nested-collections/package.json
+++ b/packages/nested-collections/package.json
@@ -2,13 +2,27 @@
   "name": "@storyboard/nested-collections",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": "./core/index.ts",
-    "./react": "./react/index.ts"
+    ".": {
+      "types": "./dist/types/core/index.d.ts",
+      "default": "./dist/core/index.js"
+    },
+    "./react": {
+      "types": "./dist/types/react/index.d.ts",
+      "default": "./dist/react/index.js"
+    }
   },
-  "main": "core/index.ts",
-  "types": "core/index.ts",
+  "main": "./dist/core/index.js",
+  "types": "./dist/types/core/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "node ../../scripts/build-nested-collections.mjs",
+    "prepublishOnly": "npm run build"
+  },
   "peerDependencies": {
     "react": "^19.0.0"
   },

--- a/packages/nested-collections/react/tsconfig.build.json
+++ b/packages/nested-collections/react/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  // See core/tsconfig.build.json. Same job, and it must stay a SEPARATE run:
+  // this half compiles with `dom` and `jsx` and the core does not, which is the
+  // distinction the package is built around.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+    "rootDir": "..",
+    "outDir": "../dist/types"
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx", "**/typecheck-fixture-*"]
+}

--- a/scripts/build-nested-collections.mjs
+++ b/scripts/build-nested-collections.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Build `@storyboard/nested-collections` for publication.
+ *
+ * A script rather than a tool config, for the reason `count-loc.mjs` is one:
+ * every decision here has a reason that has to be readable, and two of them are
+ * load-bearing enough that a `tsup.config.ts` with three keys would hide them.
+ *
+ * WHAT IT PRODUCES
+ *
+ *   dist/core/index.js        the engine, bundled, no React anywhere in it
+ *   dist/react/index.js       the bindings, bundled, `"use client"` intact
+ *   dist/types/**             declarations, mirroring the source layout
+ *
+ * WHY BUNDLE AT ALL, when `tsc` could emit the tree directly: the source imports
+ * extensionlessly (`from "../types"`), which `moduleResolution: "bundler"`
+ * permits and Node's ESM resolver does not. `tsc` does not rewrite those, so a
+ * plain declaration-plus-JS emit produces a package that typechecks and cannot
+ * be imported. Bundling resolves them at build time.
+ *
+ * TWO THINGS THIS FILE EXISTS TO GET RIGHT
+ *
+ * 1. `"use client"` MUST SURVIVE onto the React entry, EXACTLY ONCE. Lose it and
+ *    the entry silently becomes a server module — the same failure the boundary
+ *    test guards in the other direction, and just as invisible.
+ *
+ *    This carried a `banner` to re-attach it, on the belief that esbuild drops
+ *    directives when it bundles. MEASURED, building the React entry both ways:
+ *
+ *      banner off -> ["use client";, "", "// ...bindings.tsx"]
+ *      banner on  -> ["use client";, "use client";, ""]
+ *
+ *    esbuild hoists the entry's directive to the top of the output on its own,
+ *    so the banner was not protecting anything — it was emitting a SECOND copy.
+ *    Harmless to bundlers and wrong, and it also meant the guard on the built
+ *    output could not fail: removing the banner changed nothing it could see.
+ *    The guard now asserts the count, which is the assertion that has teeth.
+ *
+ * 2. THE REACT BUNDLE MUST NOT INLINE THE CORE. `engine/defaults.ts` keeps a
+ *    module-level `mintCounter`, documented as "process-wide, not per-engine,
+ *    and that is the point": it is what makes an intra-process id collision
+ *    impossible regardless of what `Math.random` does. Two copies of the core in
+ *    one process means two counters, and that guarantee falls back to the random
+ *    suffix alone. So the React entry IMPORTS the core rather than embedding it,
+ *    which the `externalCore` plugin below enforces by rewriting the specifier.
+ *
+ * Exported rather than only executed, so the build can be verified against its
+ * OUTPUT — see `the-build-preserves-the-client-directive.test.ts`. Checking the
+ * source would prove nothing about either of the two points above.
+ */
+import { rmSync, existsSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { build as esbuild } from "esbuild";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PACKAGE = join(ROOT, "packages", "nested-collections");
+
+/** Shared by both bundles. `neutral` so nothing Node- or browser-specific is
+ *  assumed; the core runs in a route handler, a browser and a bare vitest. */
+const SHARED = {
+  bundle: true,
+  format: "esm",
+  platform: "neutral",
+  target: "es2020",
+  // Bare specifiers stay external — `react` above all, which is an OPTIONAL
+  // peer dependency and must never be inlined into anything.
+  packages: "external",
+  legalComments: "inline",
+};
+
+/**
+ * Rewrite the React half's import of the core into a relative path that is
+ * correct in `dist/`, and mark it external so it is not embedded.
+ *
+ * The source says `../../core` (from `react/src/`). In the output that has to
+ * become `../core/index.js`, because `dist/react/index.js` and
+ * `dist/core/index.js` are siblings. Matching on the RESOLVED path rather than
+ * the specifier text means a file that reaches the core by some other relative
+ * depth is caught too.
+ */
+const externalCore = {
+  name: "external-core",
+  setup(pluginBuild) {
+    pluginBuild.onResolve({ filter: /.*/ }, (args) => {
+      if (args.kind === "entry-point") return null;
+      if (!args.path.startsWith(".")) return null;
+      const resolved = resolve(args.resolveDir, args.path);
+      const coreDir = join(PACKAGE, "core") + sep;
+      if (resolved === join(PACKAGE, "core") || resolved.startsWith(coreDir)) {
+        return { path: "../core/index.js", external: true };
+      }
+      return null;
+    });
+  },
+};
+
+/** `tsc` twice, because the two halves compile under different `lib`s and that
+ *  difference is the package's central rule. One run would erase it. */
+function emitDeclarations(outDir) {
+  const tsc = join(ROOT, "node_modules", "typescript", "bin", "tsc");
+  for (const half of ["core", "react"]) {
+    const run = spawnSync(
+      process.execPath,
+      [tsc, "-p", "tsconfig.build.json", "--outDir", join(outDir, "types")],
+      { cwd: join(PACKAGE, half), encoding: "utf8" },
+    );
+    if (run.status !== 0) {
+      throw new Error(
+        `declaration emit failed for ${half}:\n${run.stdout ?? ""}${run.stderr ?? ""}`,
+      );
+    }
+  }
+}
+
+/**
+ * Build both entries into `outDir`. Returns the paths written, so a caller can
+ * assert on them without guessing the layout.
+ */
+export async function buildTo(outDir) {
+  rmSync(outDir, { recursive: true, force: true });
+
+  await esbuild({
+    ...SHARED,
+    entryPoints: [join(PACKAGE, "core", "index.ts")],
+    outfile: join(outDir, "core", "index.js"),
+  });
+
+  await esbuild({
+    ...SHARED,
+    entryPoints: [join(PACKAGE, "react", "index.ts")],
+    outfile: join(outDir, "react", "index.js"),
+    plugins: [externalCore],
+    // NO BANNER. esbuild hoists the entry's own `"use client"` to the top of the
+    // output; adding one emits it twice. See the header for the measurement.
+    // What guarantees it is present is the assertion on the built file, not
+    // anything this config does.
+  });
+
+  emitDeclarations(outDir);
+
+  return {
+    core: join(outDir, "core", "index.js"),
+    react: join(outDir, "react", "index.js"),
+    coreTypes: join(outDir, "types", "core", "index.d.ts"),
+    reactTypes: join(outDir, "types", "react", "index.d.ts"),
+  };
+}
+
+async function main() {
+  const outDir = join(PACKAGE, "dist");
+  const written = await buildTo(outDir);
+  for (const [label, file] of Object.entries(written)) {
+    const ok = existsSync(file);
+    console.log(
+      `${ok ? "ok  " : "MISS"} ${label.padEnd(10)} ${relative(ROOT, file).split(sep).join("/")}`,
+    );
+    if (!ok) process.exitCode = 1;
+  }
+}
+
+// Only when RUN, not when imported — the same rule `count-loc.mjs` states, and
+// here it is what lets the verification test drive `buildTo` into a temp
+// directory without a stray `dist/` appearing as a side effect.
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}


### PR DESCRIPTION
`npm run build` emits what npm would ship:

```
dist/core/index.js    the engine, bundled, no React anywhere in it
dist/react/index.js   the bindings, "use client" intact, importing the core
dist/types/**         declarations, mirroring the source layout
```

esbuild and tsc, both already present, driven by a script rather than a tool config — the reason `count-loc.mjs` is one: the decisions here have reasons that need to be readable, and two are load-bearing enough that three keys in a `tsup.config.ts` would hide them.

**Why bundle at all.** The source imports extensionlessly (`from "../types"`), which `moduleResolution: "bundler"` permits and Node's ESM resolver rejects. `tsc` does not rewrite those, so a plain emit produces a package that typechecks and cannot be imported.

**The React bundle must not inline the core.** `engine/defaults.ts` keeps a module-level `mintCounter`, documented as *"process-wide, not per-engine, and that is the point"* — it is what makes an intra-process id collision impossible regardless of what `Math.random` does. Two copies in one process is two counters. So the React entry imports `../core/index.js`: 7.7 KB against the core's 167 KB.

## Three defects found by testing the output, not reasoning about it

**1. I had esbuild backwards.** This carried a `banner` re-attaching `"use client"`, on the belief that esbuild strips directives when bundling. It does not — it hoists the entry's own directive — so the banner emitted a **second copy**. Measured, building the React entry both ways:

```
banner off -> ["use client";, "", "// ...bindings.tsx"]
banner on  -> ["use client";, "use client";, ""]
```

Caught because deleting the banner *did not fail the guard*, which it should have. Banner removed; the guard now asserts the **count** rather than mere presence — verified failing at 2.

**2. `publishConfig` does not apply at pack time** on npm 11.12.1. The plan was `exports` on source for the workspace, swapped to `dist` for publication. Extracting the tarball's own manifest showed it still pointing at `./core/index.ts` — a file `files: ["dist"]` does not ship, so the published package would resolve to nothing. `exports` now names `dist` directly, with a vitest alias keeping dev resolution pinned to source so types and runtime cannot disagree. Nothing in this repo imports the package by specifier today, so the change costs the workspace nothing.

**3. No `"type": "module"`.** Node was guessing the module system, warning, and reparsing on every import.

## Verified as a consumer, not just as a build

Packed a tarball, installed it into a scratch project, imported by bare specifier and drove the engine end to end (deserialize → dispatch → undo), then resolved the `./react` subpath through the exports map and confirmed both the directive and the external core import. The tarball is `dist` plus the manifest, with **no TypeScript source in it**.

## The guard

`the-build-output-is-publishable` **builds into a temp directory** rather than reading `dist/`. A guard reading a possibly-absent `dist/` would skip and pass forever — the fail-open shape this package has been bitten by twice today. It also asserts the manifest's paths against a fresh build, so what is emitted and what `exports` claims is emitted cannot drift.

The exports assertion in `the-core-entry-cannot-reach-the-react-half` is now shape-agnostic: it read the literal strings of a flat map and broke when `exports` became conditional — which changes *how* the entries resolve, not *whether* they are separate, and separateness is the only thing that file has an opinion about.

## Verification

**7/7** packages typecheck clean · **1618** package tests (up 8) · **1408** app tests · `lint:packages` 0 errors. `dist/` is gitignored.

Remaining before an actual publish, both one-liners: the `@storyboard` scope, and `"private": true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)