### PR TITLE
Publish flags, and a shebang that broke the build guard on Windows

### DIFF
--- a/packages/nested-collections/package.json
+++ b/packages/nested-collections/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyboard/nested-collections",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "type": "module",
   "sideEffects": false,
   "exports": {
@@ -16,6 +16,9 @@
   },
   "main": "./dist/core/index.js",
   "types": "./dist/types/core/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist"
   ],

--- a/scripts/build-nested-collections.mjs
+++ b/scripts/build-nested-collections.mjs
@@ -1,4 +1,14 @@
-#!/usr/bin/env node
+// NO SHEBANG, deliberately, and this is the one line in the file that will look
+// like an oversight. `count-loc.mjs` and both `find-unreachable-*.mjs` carry one
+// and this was copied from them — but none of those is IMPORTED, and this one is:
+// `the-build-output-is-publishable.test.ts` loads it to drive `buildTo`.
+//
+// A shebang on a file vite imports fails to parse when the checkout uses CRLF,
+// with a bare `SyntaxError: Invalid or unexpected token` and no location. CI is
+// Linux and LF, so it passes there and breaks only on a Windows working copy —
+// the "green in CI, broken on the machine" shape, inverted. It is invoked as
+// `node scripts/build-nested-collections.mjs`, never executed directly, so the
+// shebang bought nothing.
 /**
  * Build `@storyboard/nested-collections` for publication.
  *


### PR DESCRIPTION
## The flags

`private: false` and `publishConfig: { access: "public" }`.

The first is the gate npm refuses to publish through. The second is needed because a **scoped** package publishes as restricted by default and fails with a 402 on a free account — and `access` is one of the fields `publishConfig` has always honoured, unlike `exports`, which [#634](https://github.com/josulliv101/storyboard-flow/pull/634) found is *not* applied at pack time.

The name is still `@storyboard/nested-collections`, which has to be a scope you own before any of this matters.

## And a bug that was green in CI and broken on the machine

`build-nested-collections.mjs` opened with `#!/usr/bin/env node`, copied from `count-loc.mjs`. That file is never imported; **this one is** — `the-build-output-is-publishable.test.ts` loads it to drive `buildTo`.

A shebang on a file vite imports **fails to parse when the checkout uses CRLF**, with a bare `SyntaxError: Invalid or unexpected token` and no location.

So it passed on CI — Linux, LF, 8 tests, 7.3s, confirmed in the job log — and failed the moment the merge was pulled back onto a Windows working copy, where git rewrites line endings on checkout. The inverse of this repo's "breaks Vercel only, CI is blind" shape.

## What made it findable was a count, not a failure

The suite reported **1610** passing where it had reported **1618**, and 8 is exactly the size of that file.

Vite reports a failed suite as `Tests  no tests` rather than as failures, so the file **vanished from the run** instead of turning it red. A tail of the summary looks identical either way — same green, eight fewer tests. Without the previous number to compare against, this sits there silently.

That is the third variant of the same shape in this sequence: a guard that stops guarding without anything going red. The first two were path-based guards passing vacuously after a move; this one is a whole file dropping out of collection.

## The fix

Existing practice already encoded the rule: the two `.mjs` files that **are** imported by tests (`aspect-correction`, `render-worker/ffmpeg-plan`) carry no shebang, and all three that do are only ever executed. The omission is now deliberate and says why, so it does not read as an oversight and get "fixed" back in.

## Verification

**7/7** packages typecheck clean · **1618** package tests (the 8 restored) · **1408** app tests · `lint:packages` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)