### PR TITLE
The publishable package takes the josulliv101 scope

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -10,7 +10,7 @@
     "test:dnd-collections:coverage": "vitest --run --coverage ../../packages/ui/dnd-collections --coverage.reportsDirectory=coverage/dnd-collections --testNamePattern=\"^(?!.*Render Efficiency During Drag).*$\" && vitest --project=storybook --run ../../packages/ui/dnd-collections/DndCollections.stories.tsx --testNamePattern=\"Render Efficiency During Drag\""
   },
   "dependencies": {
-    "@storyboard/nested-collections": "*",
+    "@josulliv101/nested-collections": "*",
     "@storyboard/ui": "*",
     "next": "^16.3.1",
     "react": "^19.2.1",

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -15,8 +15,8 @@
     "baseUrl": ".",
     "paths": {
       "@gstudio/*": ["../timeline-gstudio001/*"],
-      "@storyboard/nested-collections": ["../../packages/nested-collections/core"],
-      "@storyboard/nested-collections/react": ["../../packages/nested-collections/react"],
+      "@josulliv101/nested-collections": ["../../packages/nested-collections/core"],
+      "@josulliv101/nested-collections/react": ["../../packages/nested-collections/react"],
       "@storyboard/ui": ["../../packages/ui"],
       "@storyboard/ui/*": ["../../packages/ui/*"]
     }

--- a/apps/storybook/vitest.config.ts
+++ b/apps/storybook/vitest.config.ts
@@ -20,10 +20,10 @@ export default defineConfig({
   // place here.
   resolve: {
     alias: {
-      "@storyboard/nested-collections/react": fileURLToPath(
+      "@josulliv101/nested-collections/react": fileURLToPath(
         new URL("../../packages/nested-collections/react/index.ts", import.meta.url),
       ),
-      "@storyboard/nested-collections": fileURLToPath(
+      "@josulliv101/nested-collections": fileURLToPath(
         new URL("../../packages/nested-collections/core/index.ts", import.meta.url),
       ),
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
       "name": "@storyboard/storybook",
       "version": "0.1.0",
       "dependencies": {
-        "@storyboard/nested-collections": "*",
+        "@josulliv101/nested-collections": "*",
         "@storyboard/ui": "*",
         "next": "^16.3.1",
         "react": "^19.2.1",
@@ -6138,6 +6138,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@josulliv101/nested-collections": {
+      "resolved": "packages/nested-collections",
+      "link": true
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -9664,10 +9668,6 @@
     },
     "node_modules/@storyboard/collections-core": {
       "resolved": "packages/collections-core",
-      "link": true
-    },
-    "node_modules/@storyboard/nested-collections": {
-      "resolved": "packages/nested-collections",
       "link": true
     },
     "node_modules/@storyboard/storybook": {
@@ -26472,7 +26472,7 @@
       }
     },
     "packages/nested-collections": {
-      "name": "@storyboard/nested-collections",
+      "name": "@josulliv101/nested-collections",
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^20",

--- a/packages/nested-collections/core/index.ts
+++ b/packages/nested-collections/core/index.ts
@@ -8,7 +8,7 @@
 //
 // PURE. No React, no DOM, no "use client" anywhere below this file. The React
 // bindings live at `./react` — published as
-// `@storyboard/nested-collections/react` — and they take a finished engine.
+// `@josulliv101/nested-collections/react` — and they take a finished engine.
 // Keeping them behind their own entry point is what lets a route handler call
 // `engine.deserialize` without importing a client module that typechecks clean
 // and 500s at request time.

--- a/packages/nested-collections/core/tests/review3-consumers-go-through-the-accessors.test.ts
+++ b/packages/nested-collections/core/tests/review3-consumers-go-through-the-accessors.test.ts
@@ -184,7 +184,7 @@ function scan(): Readonly<{ checked: readonly string[]; violations: readonly Vio
     // package; the React half is INSIDE it and reaches the core by relative
     // path, so no specifier to match on — it qualifies by location instead.
     const importsTheEngine =
-      text.includes("@storyboard/nested-collections") || file.startsWith(reactDir);
+      text.includes("@josulliv101/nested-collections") || file.startsWith(reactDir);
     if (!importsTheEngine) continue;
     checked.push(relative(root, file).split(sep).join("/"));
 

--- a/packages/nested-collections/package.json
+++ b/packages/nested-collections/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@storyboard/nested-collections",
+  "name": "@josulliv101/nested-collections",
   "version": "0.1.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/nested-collections/react/index.ts
+++ b/packages/nested-collections/react/index.ts
@@ -19,8 +19,8 @@
 // `engine.deserialize` without dragging a client module into a server bundle,
 // which typechecks clean and 500s at request time.
 //
-// THIS IS THE `./react` ENTRY of `@storyboard/nested-collections`, reached as
-// `@storyboard/nested-collections/react`. One package, two entry points: the
+// THIS IS THE `./react` ENTRY of `@josulliv101/nested-collections`, reached as
+// `@josulliv101/nested-collections/react`. One package, two entry points: the
 // core's barrel has no route to anything under this folder, which is what keeps
 // the sentence above true now that the two are shipped together.
 

--- a/scripts/build-nested-collections.mjs
+++ b/scripts/build-nested-collections.mjs
@@ -10,7 +10,7 @@
 // `node scripts/build-nested-collections.mjs`, never executed directly, so the
 // shebang bought nothing.
 /**
- * Build `@storyboard/nested-collections` for publication.
+ * Build `@josulliv101/nested-collections` for publication.
  *
  * A script rather than a tool config, for the reason `count-loc.mjs` is one:
  * every decision here has a reason that has to be readable, and two of them are


### PR DESCRIPTION
`@storyboard/nested-collections` becomes `@josulliv101/nested-collections`.

An npm scope maps to an account, and `@storyboard` is not one. Publishing under a scope you do not own fails with a **404 that reads like the package is missing** rather than like a permissions problem — a confusing way to find out.

## Eleven references, eight files

The specifier is named in more places than the manifest: the workspace dependency, the tsconfig `paths`, the vitest aliases added with the build step, prose in both barrels, the build script's own header — and the one a careless rename leaves behind:

```ts
// review3-consumers-go-through-the-accessors.test.ts
const importsTheEngine =
  text.includes("@storyboard/nested-collections") || file.startsWith(reactDir);
```

That line decides **which files the guard scans**. A stale specifier there does not fail — it silently narrows the scan. Third instance of that fail-open shape in a day.

## Still private

`private: true` stays for now, so `npm publish` refuses:

```
npm warn publish Skipping workspace @josulliv101/nested-collections, marked as private
```

Verified. Everything else is ready — the scope resolves to a real account, `publishConfig.access` is `public` so a scoped publish does not 402, and `prepublishOnly` builds. Publishing is one word away and stays a **decision rather than a step**, because it burns version `0.1.0` permanently and makes the name effectively unchangeable.

## Two scopes, deliberately

| package | scope | private |
|---|---|---|
| `nested-collections` | `@josulliv101` | false → **true** |
| `collections-core`, `timeline-domain`, `timeline-model`, `timeline-widget`, `ui` | `@storyboard` | true |

The other five are internal and consumed by nobody outside this workspace. Only the package that will actually be published needs a name resolving to a real npm account; renaming the rest is churn for a symmetry that buys nothing.

## Verified as a consumer, not as a diff

Packed the tarball, installed it into a scratch project alongside React, imported `@josulliv101/nested-collections` by bare specifier and drove the engine (deserialize → dispatch), then resolved `@josulliv101/nested-collections/react` through the exports map and confirmed the `"use client"` directive survived.

**7/7** packages typecheck clean · **1618** package tests · `lint:packages` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)