### PR TITLE
selection.has is proved structurally, not timed

### DIFF
--- a/packages/nested-collections/core/tests/performance.test.ts
+++ b/packages/nested-collections/core/tests/performance.test.ts
@@ -1016,31 +1016,6 @@ function expectSubQuadraticRatio(ratio: number, what: string): void {
   ).toBeLessThan(ceiling);
 }
 
-/**
- * A STRONGER time claim than sub-quadratic: this cost does not track the size at
- * all.
- *
- * `expectSubQuadraticRatio` is the right gate for work that IS linear and must
- * not become quadratic. It is the wrong gate for work that should be constant —
- * a regression from O(1) to O(n) lands around the linear reference (~15x), sails
- * under a ceiling of 40, and ships. This one sits a third of the way up the
- * reference instead: far above the noise a genuinely constant operation
- * produces (~1x), far below what linear would.
- *
- * Floored at 4 so a machine whose reference measures unusually low cannot make
- * the gate tighter than measurement noise.
- */
-function expectConstantTime(ratio: number, what: string): void {
-  const reference = measureLinearReferenceGrowth();
-  observedReferences.push(reference);
-  const ceiling = Math.max(4, reference / 3);
-  expect(
-    ratio,
-    `${what}: 10x the size made it ${ratio.toFixed(1)}x slower, and it should ` +
-      `not have moved at all. A linear reference, timed immediately afterwards, ` +
-      `moved ${reference.toFixed(1)}x, so the ceiling was ${ceiling.toFixed(1)}x.`,
-  ).toBeLessThan(ceiling);
-}
 
 /**
  * The strongest claim this file can make, and the only one that survives being
@@ -1344,57 +1319,89 @@ describe("mutations", () => {
    * frames on every selection change, on a board the engine is explicitly built
    * to handle.
    *
-   * Gated as CONSTANT rather than sub-quadratic on purpose: the regression this
-   * guards against is a return to a linear scan, which a sub-quadratic ceiling
-   * would happily let through.
+   * PROVED STRUCTURALLY, NOT BY TIMING, and that is a deliberate replacement.
+   * This used to select 1,000 then 10,000 nodes, time `has` at each size, and
+   * assert the ratio was flat against a calibrated ceiling. It failed CI on an
+   * unrelated pull request — "10x the size made it 5.9x slower ... the ceiling
+   * was 4.4x" — passed on an immediate re-run of the identical commit, and
+   * passed 3/3 locally. The fourth wall-clock gate in this repo to be disproved
+   * by the machine it runs on rather than by the code it guards.
+   *
+   * It could not have been otherwise. `Set.has` on a string takes nanoseconds,
+   * so the measurement is mostly loop overhead and whatever else the runner is
+   * doing, and a ratio of two such numbers is a ratio of noise. Calibrating the
+   * ceiling against a linear reference — which this did — does not help when
+   * the noise moves between the two measurements.
+   *
+   * The regression being guarded is exact and discrete: `has` going back to
+   * reading the ORDERED ARRAY instead of the membership index. The store keeps
+   * both — `selectedIds` for order and identity-stable `get()`, `selectedSet`
+   * for membership — and they are written together in the two places selection
+   * is assigned. So desynchronise them and ask `has` which one it believes.
+   * That answers the question the timing was a proxy for, in microseconds and
+   * with no ceiling to calibrate.
+   *
+   * This is the same move `expectIndependentOfGraphSize` argues for one screen
+   * up — "the only [claim] that survives being run on somebody else's
+   * hardware" — applied to an operation that has nothing to count.
    */
-  it("selection membership does not depend on how much is selected", () => {
-    const samples: number[] = [];
-
-    for (const size of [1_000, 10_000] as const) {
-      const childIds: string[] = [];
-      const nodes: SerializedNode[] = [];
-      for (let i = 0; i < size; i += 1) childIds.push(`sel-${i}`);
-      nodes.push({
-        id: "root",
-        kind: "folder",
-        data: { name: "root" },
-        children: childIds,
-      });
-      for (const id of childIds) {
-        nodes.push({ id, kind: "clip", data: { title: id, seconds: 1 } });
-      }
-      const loaded = engine.deserialize({
-        formatVersion: 1,
-        schemaVersions: { folder: 1, clip: 1 },
-        rootIds: ["root"],
-        nodes,
-      });
-      expect(loaded.ok).toBe(true);
-      if (!loaded.ok) return;
-
-      const store = engine.createStore(loaded.value.graph);
-      const ids = childIds.map((id) => parseNodeId(id));
-      store.selection.set(ids);
-      expect(store.selection.get().length).toBe(size);
-
-      // The LAST id, which is where a linear scan costs the most — a probe near
-      // the front would hide the very regression this is written to catch.
-      const probe = at(ids, size - 1, "selection probe");
-      expect(store.selection.has(probe)).toBe(true);
-
-      samples.push(
-        measure("selection.has", `sel${size}`, size + 1, () => {
-          store.selection.has(probe);
-        }),
-      );
+  it("selection membership reads the index, not the ordered list", () => {
+    const size = 10_000;
+    const childIds: string[] = [];
+    const nodes: SerializedNode[] = [];
+    for (let i = 0; i < size; i += 1) childIds.push(`sel-${i}`);
+    nodes.push({
+      id: "root",
+      kind: "folder",
+      data: { name: "root" },
+      children: childIds,
+    });
+    for (const id of childIds) {
+      nodes.push({ id, kind: "clip", data: { title: id, seconds: 1 } });
     }
+    const loaded = engine.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1, clip: 1 },
+      rootIds: ["root"],
+      nodes,
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
 
-    const small = samples[0];
-    const large = samples[1];
-    expect(small !== undefined && large !== undefined && small > 0).toBe(true);
-    if (small === undefined || large === undefined || small <= 0) return;
-    expectConstantTime(large / small, "selection.has");
+    const store = engine.createStore(loaded.value.graph);
+    const ids = childIds.map((id) => parseNodeId(id));
+    store.selection.set(ids);
+    // The fixture is real: a scan over this would be 10,000 comparisons, which
+    // is the cost the index exists to remove.
+    expect(store.selection.get().length).toBe(size);
+
+    // The LIVE array, by reference. `get()` handing back an identity-stable list
+    // is part of its contract — the React binding memoises on it — which is what
+    // makes this possible at all. Mutating it here is deliberate and local: it
+    // is the only way to make the two structures disagree, and every assertion
+    // below restores what it changed.
+    const live = store.selection.get() as NodeId[];
+
+    // ONE: the ARRAY claims a member the index does not. A scan answers true.
+    const stranger = parseNodeId("sel-not-in-this-selection");
+    expect(store.selection.has(stranger)).toBe(false);
+    live.push(stranger);
+    expect(store.selection.has(stranger)).toBe(false);
+    live.pop();
+
+    // TWO: the INDEX claims a member the array does not. A scan answers false.
+    // Both directions, because either one alone passes for the wrong reason —
+    // an implementation that always returned `false` would satisfy the first.
+    const first = at(ids, 0, "selection probe");
+    const last = at(ids, size - 1, "selection probe");
+    live.splice(0, 1);
+    expect(store.selection.has(first)).toBe(true);
+    live.unshift(first);
+
+    // And the last id specifically, which is where a scan costs the most and so
+    // is where a regression would be least likely to be noticed by hand.
+    expect(store.selection.has(last)).toBe(true);
+    expect(store.selection.get().length).toBe(size);
   }, 120_000);
 
   it("a content edit consults exactly one node type, whatever the graph size", () => {

--- a/packages/nested-collections/core/tests/performance.test.ts
+++ b/packages/nested-collections/core/tests/performance.test.ts
@@ -2058,9 +2058,15 @@ describe("depth", () => {
 // 12. Why there is no section 12
 // ---------------------------------------------------------------------------
 //
-// Three wall-clock cost gates were written for this round's findings and all
-// three were deleted. Recording that here so a fourth starts from the evidence
+// FOUR wall-clock cost gates were written for this round's findings and all
+// four were deleted. Recording that here so a fifth starts from the evidence
 // rather than from scratch.
+//
+// This section said THREE for two days, while the fourth sat 700 lines above it
+// in this same file, added in the same commit. So the first lesson is about the
+// record and not the gates: a warning does not inspect the code around it. When
+// this is next updated, GREP THE FILE for the shape before believing the count
+// — a ratio of two timings, a tuned ceiling, `measureLinearReferenceGrowth`.
 //
 //   UNDO OF A BULK INSERT (quadratic `indexOf` in the verify overlay). A
 //   2K-vs-K growth ratio separates the implementations 2.19 to 1.0 — but only
@@ -2082,14 +2088,40 @@ describe("depth", () => {
 //   INSIDE the broken range. No threshold separates them, so the gate was not
 //   mistuned, it was unsound. It had been flaking main since it landed.
 //
+//   SELECTION MEMBERSHIP AT 1K vs 10K, against a linear reference measured
+//   immediately afterwards. Blocked #635, an unrelated pull request, at 5.93
+//   against a 4.36 ceiling ON THE FIXED BUILD, then passed on an immediate
+//   re-run of the identical commit. It could not have worked: `Set.has` on a
+//   string is nanoseconds, so the measurement was mostly loop overhead, and a
+//   ratio of two such numbers is a ratio of noise. CALIBRATING THE CEILING
+//   AGAINST A LINEAR REFERENCE — which this gate did, and which is the most
+//   defensible version of the idea — does not rescue it: the noise moves
+//   between the reference and the subject too.
+//
 // THE COMMON FAILURE is not noise, and widening thresholds is not the fix. Each
 // gate assumed two measurements were comparable when the work behind them was
 // not, and a shared CI runner exposes that where a quiet laptop hides it. The
-// gates in sections 1-11 above survive because they count OPERATIONS —
-// `countOnce`, `noteCount`, the `Counters` harness — which is exact and
-// machine-independent. That is the shape a fourth attempt should take: give the
-// hot path a counter, assert the count. It costs an instrumentation hook in
-// production code, which is a real decision, not a drive-by.
+// TWO SHAPES SURVIVE, and a fifth attempt should reach for them in this order.
+//
+//   COUNT OPERATIONS. The gates in sections 1-11 above survive because they
+//   count — `countOnce`, `noteCount`, the `Counters` harness — which is exact
+//   and machine-independent. It costs an instrumentation hook in production
+//   code, which is a real decision, not a drive-by.
+//
+//   OR DESYNCHRONISE THE REDUNDANT STRUCTURES AND ASK WHICH ONE IS READ. Where
+//   a fast path exists BECAUSE a second structure mirrors a slow one, the mirror
+//   is the test surface, and nothing needs timing at all. That is what replaced
+//   the fourth gate: selection keeps `selectedIds` for order and `selectedSet`
+//   for membership, and `get()` hands back the live array, so the test can put a
+//   stranger into the array that the index does not have, and take a member out
+//   of the array that the index still holds. A scan and an index give OPPOSITE
+//   answers to both, which is why both directions are asserted — an
+//   implementation that always returned false would satisfy the first alone.
+//   Reverting `has` to `.includes()` fails it in 41ms, on any hardware.
+//
+//   The second is the STRONGER claim, not merely the steadier one: the timed
+//   version could only infer a scan from a ratio, and would have missed it
+//   outright on a fast enough runner.
 //
 // The measurements themselves are not lost. Each fix carries its numbers in the
 // file that owns it, where anyone can re-run them.


### PR DESCRIPTION
`selection membership does not depend on how much is selected` selected 1,000 then 10,000 nodes, timed `has` at each size, and asserted the ratio was flat against a ceiling calibrated from a linear reference measured immediately afterwards.

It failed CI on [#635](https://github.com/josulliv101/storyboard-flow/pull/635), an unrelated pull request:

```
selection.has: 10x the size made it 5.9x slower, and it should not have moved at all.
A linear reference, timed immediately afterwards, moved 13.1x, so the ceiling was 4.4x.
expected 5.927584098437762 to be less than 4.3573002317340395
```

It passed on an immediate re-run of the identical commit, and 3/3 locally. That is the **fourth** wall-clock gate in this repo disproved by the machine it runs on rather than by the code it guards.

**It could not have been otherwise.** `Set.has` on a string takes nanoseconds, so the measurement is mostly loop overhead and whatever else the runner is doing, and a ratio of two such numbers is a ratio of noise. Calibrating the ceiling against a linear reference — which this did — does not help when the noise moves between the two measurements.

## The regression is discrete, so the test can be

What must never come back is `has` reading the **ordered array** instead of the membership index. The store keeps both — `selectedIds` for order and an identity-stable `get()`, `selectedSet` for membership — written together in the two places selection is assigned.

So the test desynchronises them and asks `has` which one it believes:

| | a scan answers | the index answers |
|---|---|---|
| the **array** claims a member the index does not | `true` ✗ | `false` ✓ |
| the **index** claims a member the array does not | `false` ✗ | `true` ✓ |

Both directions, because either alone passes for the wrong reason — an implementation that always returned `false` would satisfy the first.

## Verified against the regression itself

Reverting `has` to `selectedIds.includes(id)` fails it in **41ms** with `expected true to be false`.

That makes this not merely more stable but a **stronger claim**: the timing version could only *infer* a scan from a ratio, and would have missed it outright on a fast enough runner. Five consecutive local runs, 15/15 each.

## Scope

`expectConstantTime` is removed with it — this was its only caller. `measureLinearReferenceGrowth` stays, because `expectSubQuadraticRatio` still calibrates against it; that gate times a genuinely expensive operation where the signal is large enough to survive a noisy runner, and is left alone.

This is the move `expectIndependentOfGraphSize` argues for one screen up in the same file — *"the only [claim] that survives being run on somebody else's hardware"* — applied to an operation that has nothing to count.

**7/7** packages typecheck clean · **1618** package tests · `lint:packages` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Second commit: the record was wrong in the same way

Section 12 of this file (*"Why there is no section 12"*) is its post-mortem of every wall-clock gate written for this round and deleted. It said **three**, and signed off by telling a fourth attempt to start from the evidence.

A fourth already existed — added in **the same commit**, 801c286, 700 lines further up the same file. The gate this PR removes *is* that fourth one.

The record now carries four post-mortems and states that the miscount happened, because that is the more useful lesson than the count: **a warning does not inspect the code around it.** Whoever updates it next is told to grep the file for the shape — a ratio of two timings, a tuned ceiling, `measureLinearReferenceGrowth` — before believing the number.

It also names **two** surviving shapes now instead of one. Counting operations stays first. The second is the technique above, generalised: where a fast path exists *because* a second structure mirrors a slow one, the mirror is the test surface.

Comment-only — 39 added, 7 removed, no executable line touched, still 15 tests in the file.
