### PR TITLE
Setting maxDepth is what made a cyclic seed hang

### DIFF
--- a/packages/nested-collections/core/commands/insert.ts
+++ b/packages/nested-collections/core/commands/insert.ts
@@ -75,6 +75,26 @@ function mintFreshId<S>(
   }
 }
 
+/**
+ * THE SINGLE ANSWER to "this seed contains itself".
+ *
+ * TWO WALKS REACH IT, and that is why it is a function rather than a literal at
+ * one of them. `tallestSeed` measures the forest and `buildSeedPlacements`
+ * expands it; either can be the first to meet a cycle, depending only on
+ * whether `maxDepth` is set. A consumer must not be able to tell which one
+ * refused — the same house rule `applyInsertNodes` already states for the node
+ * ceiling, where the early and late arms are "shaped exactly like" each other.
+ *
+ * Reported as `"parse-failed"` because "we could not build this node" is
+ * exactly true, and it is the code that carries `issues`.
+ */
+function cyclicSeed<T>(kind: string): Result<T, Rejection> {
+  return fail("parse-failed", "A seed contains itself; the seed tree is cyclic.", {
+    kind,
+    issues: [{ path: "$.children", message: "cyclic seed" }],
+  });
+}
+
 /** One frame of the seed walk, plus the ancestor link that turns a cyclic seed
  *  into a rejection rather than a hang. */
 type SeedFrame<Ts extends readonly WidenedNodeType[], S> = Readonly<{
@@ -134,7 +154,12 @@ export function applyInsertNodes<Ts extends readonly WidenedNodeType[], S>(
   // before `buildSeedPlacements` mints ids keeps a refused command from having
   // consumed any of the id space.
   if (ctx.maxDepth !== null) {
-    const deepest = depthOf(graph, toParentId) + tallestSeed<Ts, S>(seeds);
+    // A cycle is refused here, not measured: `tallestSeed` has no height to
+    // report for a seed that contains itself, and the walk that would look for
+    // one does not terminate.
+    const tallest = tallestSeed<Ts, S>(seeds);
+    if (!tallest.ok) return tallest;
+    const deepest = depthOf(graph, toParentId) + tallest.value;
     if (deepest > ctx.maxDepth) {
       return fail(
         "would-exceed-max-depth",
@@ -208,10 +233,28 @@ export function checkInsertTarget<Ts extends readonly WidenedNodeType[], S>(
  * Walked with an explicit stack for the same reason every other walk in this
  * package is: a seed's children are consumer-supplied and their nesting is not
  * this module's to trust.
+ *
+ * IT CARRIES ITS OWN CYCLE GUARD, and the reason is the whole of this doc.
+ * `applyInsertNodes` runs this walk BEFORE `buildSeedPlacements` — deliberately,
+ * so a refused command consumes none of the id space — and
+ * `buildSeedPlacements` is where the cyclic-seed guard used to live alone. So a
+ * seed that contained itself was refused when `maxDepth` was unset and HUNG when
+ * it was set: the post-order loop below re-pushes an unexpanded frame for a seed
+ * whose children it cannot finish, and a seed that is its own child never
+ * finishes. MEASURED, the same self-referencing seed with only `maxDepth`
+ * differing: `parse-failed` in 1 ms against `FATAL ERROR: JavaScript heap out of
+ * memory` in ~10 s. Setting the ceiling is what opened the hole, which is the
+ * worst possible shape for it — `maxDepth` is the control a consumer reaches for
+ * precisely BECAUSE seed nesting is untrusted.
+ *
+ * The paragraph on the `?? 0` below used to say a cyclic seed "could leave one
+ * missing, and `buildSeedPlacements` refuses that" — asserting a check that runs
+ * afterwards. It is true again now, and it is true because of this guard rather
+ * than in spite of the ordering.
  */
 function tallestSeed<Ts extends readonly WidenedNodeType[], S>(
   seeds: readonly Seed<Ts, S>[],
-): number {
+): Result<number, Rejection> {
   // MEMOISED BY OBJECT IDENTITY, because a seed forest is a plain object tree
   // and nothing stops two branches pointing at the SAME child. That is a DAG,
   // not a cycle, so the cyclic-seed guard in `buildSeedPlacements` never fires
@@ -225,6 +268,25 @@ function tallestSeed<Ts extends readonly WidenedNodeType[], S>(
   // The map is scoped to the call and keyed by reference, so it holds the
   // consumer's objects only for as long as the check runs.
   const heightOf = new Map<Seed<Ts, S>, number>();
+
+  /**
+   * The seeds whose `expanded` frame is still below us on the stack — exactly
+   * the ancestors of the frame being popped.
+   *
+   * A SET, where `buildSeedPlacements` uses a linked path, because that walk
+   * carries its ancestors on the frame and this one does not: the post-order
+   * fold already re-pushes each seed, so the descent is a genuine DFS and one
+   * shared set tracks it. The two answer the same question about the same
+   * shape, which is why they now produce the same rejection through
+   * `cyclicSeed`.
+   *
+   * IT IS THE PATH, NOT A VISITED SET, and that distinction is the same one
+   * `SeedPath` makes: the same child object under two branches is a DAG and
+   * stays legal — `heightOf` is what makes that cheap — while a seed reachable
+   * from itself is a cycle. Membership here means the second, never the first,
+   * because the entry is dropped on the way back up.
+   */
+  const onPath = new Set<Seed<Ts, S>>();
 
   // ITERATIVE, with an explicit stack, for the reason every walk in this
   // package is: nesting is consumer-supplied and not this module's to trust.
@@ -240,7 +302,31 @@ function tallestSeed<Ts extends readonly WidenedNodeType[], S>(
       const frame = stack.pop();
       if (frame === undefined) break;
       const { seed, expanded } = frame;
+
+      // THE FOLD, and it runs before the `heightOf` short-circuit rather than
+      // after it: this frame is what removes `seed` from the path, so skipping
+      // it would leave an ancestor marked forever and report a cycle for the
+      // next legitimate reuse of that object.
+      if (expanded) {
+        onPath.delete(seed);
+        let tallestChild = 0;
+        for (const kid of seed.children ?? []) {
+          // Present for every child by now: this frame was re-pushed beneath
+          // all of them. A cyclic seed is the one shape that could leave one
+          // missing, and the guard below refuses that before we get here — so
+          // the `?? 0` is a total-function guard, not a silent floor anything
+          // relies on.
+          const kidHeight = heightOf.get(kid) ?? 0;
+          if (kidHeight > tallestChild) tallestChild = kidHeight;
+        }
+        heightOf.set(seed, tallestChild + 1);
+        continue;
+      }
+
       if (heightOf.has(seed)) continue;
+      // Its own ancestor. Refused here rather than left to `buildSeedPlacements`
+      // — see this function's doc for what the walk does instead when it is not.
+      if (onPath.has(seed)) return cyclicSeed<number>(seed.kind);
 
       const kids = seed.children;
       if (kids === undefined || kids.length === 0) {
@@ -248,30 +334,16 @@ function tallestSeed<Ts extends readonly WidenedNodeType[], S>(
         continue;
       }
 
-      if (!expanded) {
-        stack.push({ seed, expanded: true });
-        for (const kid of kids) {
-          if (!heightOf.has(kid)) stack.push({ seed: kid, expanded: false });
-        }
-        continue;
-      }
-
-      let tallestChild = 0;
+      onPath.add(seed);
+      stack.push({ seed, expanded: true });
       for (const kid of kids) {
-        // Present for every child by now: this frame was re-pushed beneath all
-        // of them. A cyclic seed is the one shape that could leave one missing,
-        // and `buildSeedPlacements` refuses that with `parse-failed` — so the
-        // `?? 0` is a total-function guard, not a silent floor anything relies
-        // on.
-        const kidHeight = heightOf.get(kid) ?? 0;
-        if (kidHeight > tallestChild) tallestChild = kidHeight;
+        if (!heightOf.has(kid)) stack.push({ seed: kid, expanded: false });
       }
-      heightOf.set(seed, tallestChild + 1);
     }
     const rootHeight = heightOf.get(root) ?? 1;
     if (rootHeight > tallest) tallest = rootHeight;
   }
-  return tallest;
+  return ok(tallest);
 }
 
 function buildSeedPlacements<Ts extends readonly WidenedNodeType[], S>(
@@ -302,13 +374,10 @@ function buildSeedPlacements<Ts extends readonly WidenedNodeType[], S>(
     const { seed, parentId, index, ancestors } = frame;
 
     if (seedPathContains(ancestors, seed)) {
-      // A seed that contains itself would expand forever. Reported as
-      // "parse-failed" — "we could not build this node" is exactly true, and it
-      // is the code that carries `issues`.
-      return fail("parse-failed", "A seed contains itself; the seed tree is cyclic.", {
-        kind: seed.kind,
-        issues: [{ path: "$.children", message: "cyclic seed" }],
-      });
+      // A seed that contains itself would expand forever. Through `cyclicSeed`
+      // so this and the depth pre-check cannot describe one shape two ways —
+      // which arm gets here first depends only on whether `maxDepth` is set.
+      return cyclicSeed<readonly Placement<Ts, S>[]>(seed.kind);
     }
 
     const nodeType = ctx.registry.get(seed.kind);

--- a/packages/nested-collections/core/engine/index.ts
+++ b/packages/nested-collections/core/engine/index.ts
@@ -719,15 +719,19 @@ export function createEngine<
       // than O(graph).
       //
       // WHAT MAKES A REMOVAL VISIBLE HERE lives in ./patches, not in this
-      // comparison, and saying so is the whole point of writing it down. An
-      // earlier version of this comment claimed the credit for itself —
-      // "`getSubtreeRev` answers 0 for an unknown node, which is what makes a
-      // removal and an insertion both register as a change" — and that was true
-      // only while `applyRemoved` DELETED the removed id's revision entry. It
-      // now leaves a tombstone behind (a fold-cache requirement, see there), so
-      // a frozen tombstone would read back identical on both sides of this
-      // comparison and the deleted node's own subscribers would never fire.
-      // `applyRemoved` bumps the entry it tombstones for exactly this reason.
+      // comparison, and saying so is the whole point of writing it down.
+      // `applyRemoved` DELETES the removed id's revision entry, and
+      // `getSubtreeRev` answers 0 for an id the graph does not hold — a number
+      // no live node can carry, because every seed is `INITIAL_REV` and every
+      // bump adds one. So the value moves for certain and the deleted node's
+      // own subscribers fire.
+      //
+      // THIS PARAGRAPH HAS NOW BEEN WRONG IN BOTH DIRECTIONS, which is why it
+      // is worth the space. It first claimed the credit for itself; that was
+      // corrected to name the tombstone `applyRemoved` left behind — and then
+      // `revFloor` replaced the tombstone store, so the correction outlived the
+      // mechanism and this went on describing a design that had been deleted,
+      // while calling the (once again accurate) original claim wrong.
       //
       // The rule this loop actually depends on, and the only one to preserve:
       // EVERY MUTATION MOVES THE REVISION OF EVERY NODE IT AFFECTS, including a

--- a/packages/nested-collections/core/graph/constants.ts
+++ b/packages/nested-collections/core/graph/constants.ts
@@ -6,9 +6,14 @@
 // These were module-private constants while the graph was one file. Splitting it
 // made them shared, so they are exported — but only WITHIN this folder. None is
 // re-exported from `./index`, because a consumer holding `NO_IDS` by reference
-// and mutating it would corrupt every empty answer the graph ever gives. The one
-// exception is `NO_DEAD_REVS`, which ./serialize genuinely needs to build a graph
-// that has removed nothing.
+// and mutating it would corrupt every empty answer the graph ever gives.
+//
+// That sentence used to carry an exception for `NO_DEAD_REVS`, "which
+// ./serialize genuinely needs to build a graph that has removed nothing". There
+// is no such constant: it belonged to the per-id tombstone store that
+// `Graph.revFloor` replaced, and the export went with the store. A named
+// exception to a rule, pointing at nothing, is the worst kind of stale comment
+// — it reads as permission.
 
 import type { NodeId } from "../types";
 

--- a/packages/nested-collections/core/graph/queries.ts
+++ b/packages/nested-collections/core/graph/queries.ts
@@ -52,9 +52,14 @@ export function getChildren<Ts extends readonly WidenedNodeType[], S>(
  * Exists because the guard in `./review3-consumers-go-through-the-accessors`
  * had nothing to offer a consumer asking this: every alternative reached past
  * the accessors into `nodesById` for its `.size`, which is the one question the
- * raw map answers correctly and no accessor answered at all. Tombstones are NOT
- * counted — `deadRevById` is a separate store, and "how big is this document"
- * has never meant "plus everything ever deleted from it".
+ * raw map answers correctly and no accessor answered at all.
+ *
+ * LIVE nodes and nothing else. That qualifier used to be explained by "`
+ * deadRevById` is a separate store" — a per-id tombstone map that `revFloor`
+ * replaced, so the caveat now names nothing. It is kept because the question it
+ * answers is still live: a removed node leaves no entry anywhere for this to
+ * count, and "how big is this document" has never meant "plus everything ever
+ * deleted from it".
  */
 export function nodeCount<Ts extends readonly WidenedNodeType[], S>(
   graph: Graph<Ts, S>,

--- a/packages/nested-collections/core/patches/arms.ts
+++ b/packages/nested-collections/core/patches/arms.ts
@@ -339,10 +339,18 @@ export function applyInserted<Ts extends readonly WidenedNodeType[], S>(
   // chain runs up through its (possibly also-new) parent to a root, so one call
   // covers every inserted node and every surviving ancestor.
   //
-  // A re-inserted id does NOT restart from 0: `applyRemoved` leaves its rev
-  // entry behind as a tombstone, so the seed below is a no-op for it and the
-  // bump lands it strictly above every rev its previous lifetime ever cached.
-  // That is what keeps a stale fold-cache entry unreachable rather than wrong.
+  // A re-inserted id does NOT restart from 0, and the seed loop above is what
+  // carries that: `applyRemoved` DELETES the rev entry, so there is nothing
+  // left to resume from, and the id is seeded at `graph.revFloor` instead —
+  // already at or above every revision this lineage ever issued. The bump then
+  // lands it strictly above every rev its previous lifetime could have cached,
+  // which is what keeps a stale fold-cache entry unreachable rather than wrong.
+  //
+  // THIS USED TO CREDIT A TOMBSTONE — "`applyRemoved` leaves its rev entry
+  // behind, so the seed below is a no-op for it" — describing the per-id
+  // `deadRevById` store that `revFloor` replaced. The mechanism it named had
+  // been deleted; the paragraph ten lines up was already stating the real one,
+  // so this function carried two answers and one of them was wrong.
   //
   // Written INTO the copy made above rather than through the copying form: the
   // map is private to this call until `grown` escapes, and the alternative

--- a/packages/nested-collections/core/tests/review6-a-cyclic-seed-is-refused-at-the-depth-precheck-too.test.ts
+++ b/packages/nested-collections/core/tests/review6-a-cyclic-seed-is-refused-at-the-depth-precheck-too.test.ts
@@ -1,0 +1,238 @@
+// Sixth review round — the cyclic-seed guard sat behind the door it protected.
+//
+// `applyInsertNodes` runs two walks over the seed forest, in this order:
+//
+//   1. `tallestSeed`, the DEPTH pre-check. Runs ONLY when `maxDepth` is set.
+//   2. `buildSeedPlacements`, the expansion — which carries the cyclic-seed
+//      guard, and is the only thing that ever carried it.
+//
+// So a seed that contains itself was refused when `maxDepth` was unset and HUNG
+// when it was set. `tallestSeed`'s post-order loop re-pushes an unexpanded frame
+// for a seed whose children it cannot finish, and a seed that is its own child
+// can never finish: the stack grows by one frame per iteration until the process
+// dies. MEASURED, the same self-referencing seed at the same `maxNodes`, with
+// only `maxDepth` differing:
+//
+//   maxDepth omitted (the default)   parse-failed, 1 ms
+//   maxDepth: 10                     worker exited unexpectedly, ~10 s
+//
+// SETTING THE CEILING IS WHAT OPENED THE HOLE, which is the part worth keeping:
+// `maxDepth` is the control a consumer reaches for precisely because seed
+// nesting is untrusted, and reaching for it turned a clean refusal into a hang.
+//
+// `tallestSeed` asserted the guard it did not have — "a cyclic seed is the one
+// shape that could leave one missing, and `buildSeedPlacements` refuses that
+// with `parse-failed`" — naming a check that runs AFTERWARDS. The fourth round
+// has a whole file about comments that assert a check must be true.
+//
+// AND THE SUITE TESTED BOTH AXES WITHOUT CROSSING THEM.
+// `review4-a-seed-forest-is-a-dag-not-a-tree` covers a DAG WITH `maxDepth`, and
+// a cycle WITHOUT it. The one cell of that 2x2 that hangs is the one nobody
+// wrote, so this file is the crossing rather than a new shape.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  type Seed,
+  defineNodeType,
+  parseNodeId,
+} from "../types";
+import { createEngine } from "../engine";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { ...data, name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(raw): Result<Summary, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const n = ({ ...raw } as Record<string, unknown>)["n"];
+    if (typeof n !== "number") {
+      return { ok: false, error: [{ path: "$.n", message: "n" }] };
+    }
+    return { ok: true, value: { n } };
+  },
+  serialize(value): unknown {
+    return { n: value.n };
+  },
+};
+
+const rootId = parseNodeId("root");
+
+function storeWith(config: Readonly<{ maxNodes?: number; maxDepth?: number }>) {
+  const engine = createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    ...config,
+  });
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { folder: 1 },
+    rootIds: ["root"],
+    nodes: [{ id: "root", kind: "folder", data: { name: "R" }, children: [] }],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return engine.createStore(loaded.value.graph);
+}
+
+/** A seed that is its own child. The shortest cycle there is. */
+function selfReferencing(): Seed<Types, Summary> {
+  const seed: { kind: "folder"; data: Folder; children: unknown[] } = {
+    kind: "folder",
+    data: { name: "self" },
+    children: [],
+  };
+  seed.children.push(seed);
+  return seed as unknown as Seed<Types, Summary>;
+}
+
+/** A two-step cycle, so the guard cannot be a bare `seed.children.includes(seed)`. */
+function mutuallyReferencing(): Seed<Types, Summary> {
+  const a: { kind: "folder"; data: Folder; children: unknown[] } = {
+    kind: "folder",
+    data: { name: "a" },
+    children: [],
+  };
+  const b: { kind: "folder"; data: Folder; children: unknown[] } = {
+    kind: "folder",
+    data: { name: "b" },
+    children: [],
+  };
+  a.children.push(b);
+  b.children.push(a);
+  return a as unknown as Seed<Types, Summary>;
+}
+
+describe("a cyclic seed is refused at the depth pre-check too", () => {
+  // Short timeouts on purpose. The defect is a non-terminating loop, so the
+  // honest failure signal is the clock, not an assertion — and a default-length
+  // timeout on a loop that allocates a frame per iteration reaches the heap
+  // limit and takes the worker down before vitest can report anything.
+  it("refuses a self-referencing seed WITH maxDepth set", () => {
+    const store = storeWith({ maxDepth: 10, maxNodes: 100 });
+    const refused = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [selfReferencing()],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("parse-failed");
+    expect(refused.error.issues).toEqual([
+      { path: "$.children", message: "cyclic seed" },
+    ]);
+  }, 5_000);
+
+  it("refuses a mutually-referencing pair WITH maxDepth set", () => {
+    const store = storeWith({ maxDepth: 10, maxNodes: 100 });
+    const refused = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [mutuallyReferencing()],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("parse-failed");
+  }, 5_000);
+
+  it("refuses a cycle buried under legitimate nesting", () => {
+    // The cycle is not at the root of the forest, so the guard has to survive a
+    // descent rather than fire on the first frame it sees.
+    const store = storeWith({ maxDepth: 10, maxNodes: 100 });
+    const outer: Seed<Types, Summary> = {
+      kind: "folder",
+      data: { name: "outer" },
+      children: [
+        { kind: "folder", data: { name: "leaf" }, children: [] },
+        mutuallyReferencing(),
+      ],
+    };
+    const refused = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [outer],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("parse-failed");
+  }, 5_000);
+
+  it("refuses the same seed IDENTICALLY with maxDepth unset", () => {
+    // The rejection a consumer reads must not depend on which of the two walks
+    // caught it — the house rule `applyInsertNodes` already states for the node
+    // ceiling ("shaped exactly like the post-hoc one so a consumer cannot tell
+    // which arm refused"), applied to the other guard.
+    const withCeiling = storeWith({ maxDepth: 10, maxNodes: 100 }).dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [selfReferencing()],
+    });
+    const without = storeWith({ maxNodes: 100 }).dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      seeds: [selfReferencing()],
+    });
+    expect(withCeiling.ok).toBe(false);
+    expect(without.ok).toBe(false);
+    if (withCeiling.ok || without.ok) return;
+    expect(withCeiling.error).toEqual(without.error);
+  }, 5_000);
+
+  it("still measures a legal DAG rather than refusing it", () => {
+    // The guard must not cost the traffic it sits in front of. A shared child
+    // object is a DAG, not a cycle, and it stays legal — this is the case the
+    // fourth round made cheap, re-asserted here because the fix touches the
+    // same walk.
+    const store = storeWith({ maxDepth: 4, maxNodes: 100 });
+    const shared: Seed<Types, Summary> = {
+      kind: "folder",
+      data: { name: "shared" },
+      children: [],
+    };
+    const accepted = store.dispatch({
+      type: "insert-nodes",
+      toParentId: rootId,
+      toIndex: 0,
+      // Depth 3 under a root at depth 1: root -> parent -> shared, twice over.
+      seeds: [
+        { kind: "folder", data: { name: "parent" }, children: [shared, shared] },
+      ],
+    });
+    expect(accepted.ok).toBe(true);
+  }, 5_000);
+});

--- a/packages/nested-collections/react/src/bindings.tsx
+++ b/packages/nested-collections/react/src/bindings.tsx
@@ -221,14 +221,22 @@ export function createReactBindings<
    * call (`store.aggregate` re-wraps its `Folded` even on a cache hit), so the
    * memoised closure here is what makes them usable at all.
    *
-   * The cache is keyed on GRAPH IDENTITY rather than on `subtreeRev`, which
-   * looks like the more precise choice and is not. the core documents a
-   * residual in `applyInserted`: removing a node drops its rev entry, so
-   * re-inserting the same id RESTARTS it from 0, and a rev-keyed cache would
-   * serve the pre-removal value after a remove-then-redo. Graph identity has no
-   * such hole — the graph is replaced wholesale on every commit — and the cost
-   * of the extra misses is one map lookup, or one hit in the store's own
-   * rev-keyed fold cache.
+   * The cache is keyed on GRAPH IDENTITY rather than on `subtreeRev`, and the
+   * reason is now robustness rather than necessity. Graph identity cannot be
+   * reused — the graph is replaced wholesale on every commit — so this cannot
+   * serve a value from a lineage the id no longer belongs to, whatever the core
+   * does with revisions. The cost of the extra misses is one map lookup, or one
+   * hit in the store's own rev-keyed fold cache.
+   *
+   * IT USED TO CITE A HOLE IN THE ALTERNATIVE, and that hole is closed: removing
+   * a node dropped its rev entry, so re-inserting the same id restarted it from
+   * 0 and a rev-keyed cache would have served the pre-removal value after a
+   * remove-then-redo. `Graph.revFloor` now seeds a returning id strictly above
+   * every revision its dead lineage could have cached, so a rev-keyed cache
+   * would be correct too. Keeping graph identity is a choice this binding does
+   * not have to re-audit when the core's revision scheme changes again — but it
+   * is a choice, not the only sound option, and the comment should not go on
+   * claiming otherwise.
    *
    * `select` must be referentially stable; every caller below wraps it in
    * `useCallback` with its real dependencies, and it is a dependency of the


### PR DESCRIPTION
Found during a review of `packages/nested-collections`. Two findings, one logic fix.

## 1. A cyclic seed hangs the process — but only when `maxDepth` is set

`applyInsertNodes` runs two walks over the seed forest, in this order:

1. `tallestSeed`, the depth pre-check. Runs **only** when `maxDepth` is set.
2. `buildSeedPlacements`, the expansion — which carried the cyclic-seed guard, and was the only thing that ever carried it.

So a seed that contains itself was refused when `maxDepth` was unset and hung when it was set. `tallestSeed`'s post-order loop re-pushes an unexpanded frame for a seed whose children it cannot finish, and a seed that is its own child never finishes — one stack frame per iteration until the heap goes.

Measured, the same self-referencing seed at the same `maxNodes`, with only `maxDepth` differing:

| config | result |
| --- | --- |
| `maxDepth` omitted (the default) | `parse-failed`, 1 ms |
| `maxDepth: 10` | `FATAL ERROR: JavaScript heap out of memory`, ~10 s |

The vitest timeout does not save it: the loop is synchronous, so the worker dies before the deadline can fire.

**Setting the ceiling is what opened the hole**, which is the worst available shape for it — `maxDepth` is the control a consumer reaches for *precisely because* seed nesting is untrusted.

`tallestSeed` also asserted the guard it did not have: *"a cyclic seed is the one shape that could leave one missing, and `buildSeedPlacements` refuses that with `parse-failed`"* — naming a check that runs afterwards. The fourth round has a whole file about comments that assert a check must be true.

### The fix

`tallestSeed` now carries a path set beside its height memo — added on the way down, dropped on the way back up — so membership means "its own ancestor" and never "the same object under two branches". A DAG stays legal and stays cheap, which is what the fourth round bought.

Both walks refuse through one `cyclicSeed` helper, so a consumer cannot tell which arm caught it. That is the house rule `applyInsertNodes` already states for the node ceiling: *"shaped exactly like the post-hoc one so a consumer cannot tell which arm refused."*

### The suite tested both axes without crossing them

`review4-a-seed-forest-is-a-dag-not-a-tree` covers a DAG **with** `maxDepth: 4` (line 153), and a cycle **with `maxNodes` only, no `maxDepth`** (line 173). The one cell of that 2×2 that hangs is the one nobody wrote. The new test file is the crossing, plus a two-step cycle, a cycle buried under legitimate nesting, an assertion that both arms produce byte-identical rejections, and a DAG re-assertion so the guard cannot cost the traffic it sits in front of.

Confirmed failing before the fix (worker OOM), 5/5 passing in 8 ms after.

## 2. Four comments describing a mechanism that was deleted

`revFloor` replaced the per-id `deadRevById` tombstone store and the prose did not all follow. In a package whose readers are trained to trust the comments, a wrong one costs more than a missing one — and two of these stated the inverse of what the code does.

- **`patches/arms.ts`** credited *"`applyRemoved` leaves its rev entry behind as a tombstone, so the seed below is a no-op"*. It calls `revs.delete(id)`. The real answer — seeded at `revFloor` — was already ten lines up, so the function carried two answers and one was wrong.
- **`engine/index.ts`** said `applyRemoved` *"now leaves a tombstone behind"* and called the (accurate) original claim wrong. It has now been wrong in both directions, so it says so.
- **`graph/constants.ts`** named `NO_DEAD_REVS` as an exception to a rule. There is no such export. A named exception pointing at nothing reads as permission.
- **`graph/queries.ts`** explained `nodeCount`'s LIVE qualifier by *"`deadRevById` is a separate store"*.
- **`react/bindings.tsx`** justified keying the snapshot cache on graph identity by a re-insert-restarts-at-0 residual that `revFloor` closed. The choice stands and is now stated as a choice rather than as the only sound option.

Remaining past-tense mentions are deliberate — describing what was replaced is this package's house style.

## Scope

Comment-only in five files. The logic diff is confined to `commands/insert.ts`.

## Verification

| Check | Result |
| --- | --- |
| Unit tests | 95 files, **1623 passed** (was 1618) |
| Typecheck | **7/7 packages clean** |
| `eslint packages` | **0 errors** |
| App lint | **0 errors** |

## Not in this PR

Four other findings from the same review, left for separate changes: an unbounded `error.message` out of `deserialize` (`describeThrown` is the one describer that does not clamp — measured at 1,000,070 characters); `historyLimit` defaulting to unbounded with an O(n) push (88 µs/push at 20k edits against a flat 2.5 µs with a limit set); `NO_PLACEMENTS`/`NO_OWNERS` being process-wide mutable Maps where `NO_IDS` is frozen; and a dead `deadRevs` parameter on `buildGraph` that nothing reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
