### PR TITLE
The remaining four findings from the sixth review round

### DIFF
--- a/packages/nested-collections/core/engine/index.ts
+++ b/packages/nested-collections/core/engine/index.ts
@@ -87,6 +87,7 @@ import {
   commitRedo,
   commitUndo,
   createHistory,
+  DEFAULT_HISTORY_LIMIT,
   peekRedo,
   peekUndo,
   pushHistory,
@@ -111,9 +112,10 @@ export { DEFAULT_INTERACTIVE_NODE_BUDGET } from "./constants";
  * `Result` instead.
  *
  * Defaults: `onUnknownKind` and `onParseFailure` seal, `mintId` a
- * counter-plus-random id, `now` `Date.now`, `historyLimit` unbounded,
- * `foldCacheLimit` `DEFAULT_FOLD_CACHE_LIMIT` (a folds x nodes product — see
- * ./folds), `devChecks` off.
+ * counter-plus-random id, `now` `Date.now`, `historyLimit`
+ * `DEFAULT_HISTORY_LIMIT` (`null` for unbounded), `foldCacheLimit`
+ * `DEFAULT_FOLD_CACHE_LIMIT` (a folds x nodes product — see ./folds),
+ * `devChecks` off.
  */
 export function createEngine<
   const Ts extends readonly WidenedNodeType[],
@@ -184,19 +186,34 @@ export function createEngine<
   //
   // Throws, like the duplicate kind and the duplicate fold key above, for the
   // same reason — a programmer error at module init, before any data has been
-  // read. Omitting the field is still how a consumer asks for unbounded, and
-  // that stays silent.
+  // read.
+  //
+  // OMITTING IT NO LONGER MEANS UNBOUNDED, which is the sentence that used to
+  // end this comment. It now takes `DEFAULT_HISTORY_LIMIT` — see that constant
+  // for the curve — and `null` is the explicit opt-out, matching how
+  // `maxNodeIdLength` spells the same choice. `null` had to become a legal
+  // value for that: giving the field a default without one would have removed
+  // the only way to ask for unbounded, since `0` is refused here and always was.
   const historyLimit = config.historyLimit;
   if (
     historyLimit !== undefined &&
+    historyLimit !== null &&
     (!Number.isInteger(historyLimit) || historyLimit <= 0)
   ) {
     throw new Error(
-      `nested-collections: historyLimit must be a positive integer, received ${String(historyLimit)}. ` +
-        `Omit it entirely for unbounded history — a fractional or non-positive value ` +
+      `nested-collections: historyLimit must be a positive integer or null, received ${String(historyLimit)}. ` +
+        `Pass null for unbounded history — a fractional or non-positive value ` +
         `would silently mean unbounded, which is the opposite of what naming a limit asks for.`,
     );
   }
+  // `undefined` -> the default; `null` -> unbounded, which `createHistory`
+  // spells as `undefined`. Resolved ONCE here rather than at the
+  // `createHistory` call, so the store cannot be built from a different reading
+  // of the same config than the one this door validated.
+  const resolvedHistoryLimit: number | undefined =
+    historyLimit === null
+      ? undefined
+      : (historyLimit ?? DEFAULT_HISTORY_LIMIT);
 
   // THE SAME ARGUMENT, for the two ceilings that were not making it.
   //
@@ -493,7 +510,7 @@ export function createEngine<
 
   const createStore = (initialGraph: Graph<Ts, S>): Store<Ts, S, F> => {
     let graph = initialGraph;
-    let history: History<Ts, S> = createHistory<Ts, S>(config.historyLimit);
+    let history: History<Ts, S> = createHistory<Ts, S>(resolvedHistoryLimit);
 
     /**
      * PER STORE, not per engine.

--- a/packages/nested-collections/core/graph/constants.ts
+++ b/packages/nested-collections/core/graph/constants.ts
@@ -27,8 +27,67 @@ import type { NodeId } from "../types";
 // the caller sees a new identity and re-renders even though nothing changed.
 
 export const NO_IDS: readonly NodeId[] = Object.freeze([]);
-export const NO_PLACEMENTS: ReadonlyMap<string, readonly NodeId[]> = new Map();
-export const NO_OWNERS: ReadonlyMap<string, NodeId> = new Map();
+
+/**
+ * A permanently empty `ReadonlyMap` that REFUSES to be written to.
+ *
+ * `Object.freeze` is the whole answer for `NO_IDS` above and is no answer at
+ * all here: a Map's entries live in an internal slot, so freezing the object
+ * leaves `map.set(...)` working exactly as before. The two constants below were
+ * therefore protected in name only, and the difference was invisible because
+ * the declared type is `ReadonlyMap` and TypeScript will not let a well-behaved
+ * consumer try.
+ *
+ * WHAT THAT COST, measured through the public surface. These are PROCESS-WIDE
+ * singletons and `emptyGraph` hands them out directly, so one cast and one
+ * `.set` reached every graph in the process at once:
+ *
+ *   two independently built empty graphs shared the same map   true
+ *   a write through the ReadonlyMap succeeded                  true
+ *   it was visible in the OTHER graph                          true
+ *
+ * The file header argues these are safe because none is re-exported from
+ * `./index`. That is true of the BINDINGS and false of the VALUES: every empty
+ * graph publishes them as `placementsByContentKey` and `ownerBySourceKey`, and
+ * so does every graph whose registry declares no `contentKey` — which is the
+ * ordinary case, not an edge one. A guard on one door where the hazard has
+ * several is the same shape review 3 kept finding.
+ *
+ * Sharing them is deliberate and stays: `getChildren` and its neighbours are
+ * read once per rendered row per frame, and a fresh empty map per call defeats
+ * every `useMemo` and `Object.is` downstream. So the fix is to make the shared
+ * value genuinely immutable rather than to stop sharing it.
+ *
+ * REFUSES rather than no-ops. A silent no-op would leave a consumer believing a
+ * write landed, which is the failure mode this package refuses everywhere else
+ * — and a throw here can only be reached by code that has already cast away
+ * `ReadonlyMap`, so it cannot surprise a caller who respected the type.
+ */
+function emptyFrozenMap<K, V>(field: string): ReadonlyMap<K, V> {
+  const map = new Map<K, V>();
+  const refuse = (method: string) => (): never => {
+    throw new TypeError(
+      `nested-collections: ${method}() on the shared empty ${field}. This map is a ` +
+        `process-wide singleton published by every graph that has no entries, so writing ` +
+        `to it would change every one of them at once. Build your own Map from it instead.`,
+    );
+  };
+  Object.defineProperties(map, {
+    set: { value: refuse("set") },
+    delete: { value: refuse("delete") },
+    clear: { value: refuse("clear") },
+  });
+  // Belt and braces, and NOT the mechanism: this stops a property being added
+  // or the refusals being swapped back out. The entries are protected by the
+  // three overrides above, because freezing cannot reach the internal slot they
+  // live in.
+  return Object.freeze(map);
+}
+
+export const NO_PLACEMENTS: ReadonlyMap<string, readonly NodeId[]> =
+  emptyFrozenMap("placementsByContentKey");
+export const NO_OWNERS: ReadonlyMap<string, NodeId> =
+  emptyFrozenMap("ownerBySourceKey");
 /**
  * The revision every node is seeded at, and the floor an empty graph carries.
  *

--- a/packages/nested-collections/core/graph/construction.ts
+++ b/packages/nested-collections/core/graph/construction.ts
@@ -66,9 +66,17 @@ export function buildGraph<Ts extends readonly WidenedNodeType[], S>(
     rootIds: readonly NodeId[];
     registry: NodeTypeRegistry;
     subtreeRevs?: ReadonlyMap<NodeId, number>;
-    /** Carried forward when a graph is rebuilt around existing nodes, so a
-     *  rebuild does not forget what has been removed. */
-    deadRevs?: ReadonlyMap<NodeId, number>;
+    // NO `deadRevs`. There was one until now — "carried forward when a graph is
+    // rebuilt around existing nodes, so a rebuild does not forget what has been
+    // removed" — and NOTHING IN THE FUNCTION READ IT. It outlived the per-id
+    // tombstone store that `Graph.revFloor` replaced, so a caller passing the
+    // map it named would have had it accepted, typechecked, and dropped.
+    //
+    // That is the shape worth naming rather than just deleting: an optional
+    // parameter that is silently ignored is a guard that fails OPEN, and it
+    // fails open at precisely the door whose job was to make a rebuild not
+    // forget. `revFloor` is what carries that now, and it is derived below from
+    // the revisions actually present rather than supplied.
   }>,
 ): Graph<Ts, S> {
   const parentById = new Map<NodeId, NodeId | null>();

--- a/packages/nested-collections/core/history/index.ts
+++ b/packages/nested-collections/core/history/index.ts
@@ -45,7 +45,7 @@
 //   scrub     the non-undoable write scrub
 // ---------------------------------------------------------------------------
 
-export { createHistory, pushHistory } from "./stack";
+export { createHistory, pushHistory, DEFAULT_HISTORY_LIMIT } from "./stack";
 export {
   peekUndo, peekRedo, commitUndo, commitRedo, canUndo, canRedo,
 } from "./read";

--- a/packages/nested-collections/core/history/stack.ts
+++ b/packages/nested-collections/core/history/stack.ts
@@ -15,6 +15,57 @@ import { coalesceEntries } from "./coalesce";
 // ---------------------------------------------------------------------------
 
 /**
+ * The default ceiling on undo entries, applied by `createEngine` when
+ * `EngineConfig.historyLimit` is omitted.
+ *
+ * THERE WAS NO DEFAULT, and `historyLimit` was the one field in `EngineConfig`
+ * carrying no doc comment either — the two omissions were the same omission.
+ * Unbounded is a strange default for this particular stack, because undo here
+ * is deliberately built on WHOLE-VALUE before/after pairs (see
+ * `ConsumerDefinedNodeType.invertEdit`: "Undo works from whole-value
+ * before/after pairs, which cannot be wrong"). That choice is right and it
+ * means every entry retains two complete copies of the edited node's `Data`, so
+ * an unbounded stack retains two copies per gesture for the life of the
+ * session.
+ *
+ * IT IS ALSO WHAT MAKES THE PUSH SUPERLINEAR. `pushHistory` returns a new
+ * `History`, so it copies `past` — O(entries) per push, and O(entries^2) over a
+ * session. MEASURED, microseconds per push against a FULL stack, one
+ * `edit-nodes` on one node:
+ *
+ *      limit      us/push          limit          us/push
+ *        100         3.59            2,500           6.61
+ *        250         3.21            5,000          12.89
+ *        500         3.29           10,000          20.56
+ *      1,000         5.07           25,000         239.70
+ *
+ *   unbounded, at  5,000 edits    12.00
+ *   unbounded, at 20,000 edits   135.81
+ *   unbounded, at 50,000 edits   293.21
+ *
+ * Flat to 500, 1.5x the floor at 1,000, and off a cliff past 10,000. The
+ * unbounded rows are the same curve with nothing stopping it: a session simply
+ * walks down the table.
+ *
+ * 1,000, and the binding constraint is RETENTION rather than that curve — 5 us
+ * on a gesture that happens a few times a second is not a cost anybody can
+ * perceive. A thousand gestures of undo is past what a session reaches and well
+ * past what a user will ever walk back, while 2,000 retained `Data` copies is a
+ * number a consumer can multiply by their own value's size and act on.
+ *
+ * A FLOOR ON DEPTH, NOT A BOUND ON MEMORY, and that distinction is
+ * `DEFAULT_FOLD_CACHE_LIMIT`'s: the entry holds the consumer's `Data`, whose
+ * size this package cannot know. A consumer whose nodes carry anything larger
+ * than a scalar should size this against their own value.
+ *
+ * `historyLimit: null` opts out and restores unbounded — the same escape hatch
+ * `maxNodeIdLength` offers, spelled the same way. It is not `0`: that is
+ * refused at `createEngine`, along with every other value that would silently
+ * mean unbounded.
+ */
+export const DEFAULT_HISTORY_LIMIT = 1_000;
+
+/**
  * ONE rule for what a limit means, applied both here and by the trimmer, so a
  * hand-built `History` value cannot be interpreted one way at construction and
  * another way at push time.

--- a/packages/nested-collections/core/index.ts
+++ b/packages/nested-collections/core/index.ts
@@ -217,6 +217,10 @@ export {
   commitRedo,
   commitUndo,
   createHistory,
+  // The fourth ceiling's default, named for the reason the other three are: a
+  // consumer deciding whether to raise `EngineConfig.historyLimit` — or to
+  // clear it with `null` — needs to see what they are moving it from.
+  DEFAULT_HISTORY_LIMIT,
   peekRedo,
   peekUndo,
   pushHistory,

--- a/packages/nested-collections/core/tests/review6-a-node-type-throw-cannot-blow-up-a-refusal-message.test.ts
+++ b/packages/nested-collections/core/tests/review6-a-node-type-throw-cannot-blow-up-a-refusal-message.test.ts
@@ -1,0 +1,258 @@
+// Sixth review round — the third describer was never bounded.
+//
+// `quoteFromWire` and `describeValue` were each written under the heading
+// "every ingress refusal", a round apart. `describeThrown` is the third
+// function in that file and was swept by neither, because both sweeps looked
+// for `JSON.stringify` and it does not call it. MEASURED at the DEFAULT config,
+// a node type whose `contentKey` throws with a 1 MB message:
+//
+//   deserialize(...).error.message      1,000,070 characters
+//
+// against the 169 `quoteFromWire` brought `dangling-child` down to. That string
+// is what a consumer puts in a log line, a toast, or an error report.
+//
+// IT READS AS LOWER RISK THAN IT IS. The throw comes from consumer code rather
+// than off the wire, so the length looks like the consumer's own business — but
+// a node type that echoes the value it choked on into its error message is an
+// ordinary thing to write, and that hands the sender control of the length
+// after all.
+//
+// AND `String(thrown)` IS NOT TOTAL, which was not in the finding and is the
+// worse half. `String(Object.create(null))` throws `TypeError: Cannot convert
+// object to primitive value`, and so does any value whose `toString` throws —
+// both of which a consumer can `throw`. So the function written to describe a
+// failure had a failure mode of its own, at the exact doors that promise a
+// `Result`, which is the rule its own sibling's doc states.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "../types";
+import { createEngine } from "../engine";
+
+const HUGE = "x".repeat(1_000_000);
+
+/** How a node type's `contentKey` fails, chosen per test. */
+let failure: () => never = () => {
+  throw new Error("unset");
+};
+
+type Clip = Readonly<{ title: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const title = ({ ...raw } as Record<string, unknown>)["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { title: edit.title ?? data.title } };
+  },
+  contentKey(): string | null {
+    return failure();
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(): Result<Summary, readonly Issue[]> {
+    return { ok: true, value: { n: 0 } };
+  },
+  serialize(): unknown {
+    return { n: 0 };
+  },
+};
+
+function engine() {
+  return createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+}
+
+const document = {
+  formatVersion: 1 as const,
+  schemaVersions: { folder: 1, clip: 1 },
+  rootIds: ["root"],
+  nodes: [
+    { id: "root", kind: "folder", data: { name: "R" }, children: ["c1"] },
+    { id: "c1", kind: "clip", data: { title: "t" } },
+  ],
+};
+
+/**
+ * Generous, and deliberately not tight. This asserts the ORDER OF MAGNITUDE —
+ * that a megabyte cannot reach a log line — rather than pinning
+ * `DESCRIBE_LIMIT`, which is one number three describers share and should be
+ * movable without editing this file.
+ */
+const SANE = 2_000;
+
+describe("a node-type throw cannot blow up a refusal message", () => {
+  it("bounds an Error message at deserialize, the door a payload reaches", () => {
+    failure = () => {
+      throw new Error(HUGE);
+    };
+    const refused = engine().deserialize(document);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.message.length).toBeLessThan(SANE);
+  });
+
+  it("still names the kind and the hook, which is what the message is FOR", () => {
+    // The bound must not cost the diagnostic. The prefix is built from
+    // engine-controlled text and stays unclamped, so a reader still learns
+    // which node type failed and where.
+    failure = () => {
+      throw new Error(HUGE);
+    };
+    const refused = engine().deserialize(document);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("node-type-threw");
+    expect(refused.error.message).toContain("clip");
+    expect(refused.error.message).toContain("contentKey");
+  });
+
+  it("bounds a thrown non-Error too", () => {
+    // `String(thrown)` is the other arm and carried the same hazard.
+    failure = () => {
+      throw HUGE;
+    };
+    const refused = engine().deserialize(document);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.message.length).toBeLessThan(SANE);
+  });
+
+  it("bounds it on the command path as well as on ingress", () => {
+    // Same describer, different door. `dispatch` promises a `Result` and the
+    // message it carries is relayed from the same place.
+    failure = () => {
+      throw new Error("unset");
+    };
+    const built = engine();
+    const loaded = built.deserialize({
+      formatVersion: 1,
+      schemaVersions: { folder: 1 },
+      rootIds: ["root"],
+      nodes: [{ id: "root", kind: "folder", data: { name: "R" }, children: [] }],
+    });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    const store = built.createStore(loaded.value.graph);
+    failure = () => {
+      throw new Error(HUGE);
+    };
+    const refused = store.dispatch({
+      type: "insert-nodes",
+      toParentId: parseNodeId("root"),
+      toIndex: 0,
+      seeds: [{ kind: "clip", data: { title: "t" } }],
+    });
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("node-type-threw");
+    expect(refused.error.message.length).toBeLessThan(SANE);
+  });
+
+  it("survives a value that cannot be converted to a string at all", () => {
+    // `String(Object.create(null))` throws. A describer that throws while
+    // describing turns a refusable document into a thrown load, at the door
+    // whose entire job is telling a bad payload from an engine bug.
+    failure = () => {
+      throw Object.create(null) as never;
+    };
+    const refused = engine().deserialize(document);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("node-type-threw");
+    expect(refused.error.message.length).toBeLessThan(SANE);
+  });
+
+  it("survives a value whose own toString throws", () => {
+    failure = () => {
+      throw {
+        toString() {
+          throw new Error("nested");
+        },
+      } as never;
+    };
+    const refused = engine().deserialize(document);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("node-type-threw");
+  });
+
+  it("survives an Error whose message getter throws", () => {
+    // `.message` may be a getter, so reading it is a call into consumer code
+    // like any other and sits inside the same guard.
+    failure = () => {
+      const error = new Error();
+      Object.defineProperty(error, "message", {
+        get() {
+          throw new Error("nested");
+        },
+      });
+      throw error;
+    };
+    const refused = engine().deserialize(document);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.code).toBe("node-type-threw");
+  });
+
+  it("leaves an ordinary message untouched", () => {
+    // The bound must not cost the traffic it sits in front of. Real messages
+    // are short, and a clamp that mangled them would be worse than the hazard.
+    const real = "Cannot read properties of undefined (reading 'assetId')";
+    failure = () => {
+      throw new Error(real);
+    };
+    const refused = engine().deserialize(document);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.error.message).toContain(real);
+  });
+});

--- a/packages/nested-collections/core/tests/review6-the-shared-empty-indexes-refuse-a-write.test.ts
+++ b/packages/nested-collections/core/tests/review6-the-shared-empty-indexes-refuse-a-write.test.ts
@@ -1,0 +1,174 @@
+// Sixth review round — `Object.freeze` on a Map protects nothing.
+//
+// ./graph/constants holds three shared empties so that the hot accessors do not
+// allocate: `getChildren` and its neighbours are read once per rendered row per
+// frame, and a fresh `[]` or `new Map()` per call defeats every `useMemo` and
+// `Object.is` downstream. `NO_IDS` is `Object.freeze([])` and a `.push` on it
+// throws. Its two neighbours were bare `new Map()` — and freezing a Map would
+// not have helped either, because its entries live in an internal slot that
+// `Object.freeze` cannot reach.
+//
+// So they were protected in name only, and the gap was invisible because the
+// declared type is `ReadonlyMap` and TypeScript will not let a well-behaved
+// consumer try. MEASURED through the public surface, before the fix:
+//
+//   two independently built empty graphs shared the same map   true
+//   a write through the ReadonlyMap succeeded                  true
+//   it was visible in the OTHER graph                          true
+//
+// The file header argued these were safe because none is re-exported from
+// `./index`. That is true of the BINDINGS and false of the VALUES: every empty
+// graph publishes them as `placementsByContentKey` and `ownerBySourceKey`, and
+// so does every graph whose registry declares no `contentKey` — the ordinary
+// case, not an edge one. A guard on one door where the hazard has several is the
+// shape review 3 kept finding.
+//
+// Reachable only by code that has already cast away `ReadonlyMap`, so this is
+// defence in depth rather than a live bug. It is worth closing because the
+// sibling constant already delivers it, and a rule that holds for two of three
+// shared empties is the kind that gets relied on for the third.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  type NodeId,
+  defineNodeType,
+} from "../types";
+import { createEngine } from "../engine";
+import { emptyGraph } from "../graph";
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(): Result<Summary, readonly Issue[]> {
+    return { ok: true, value: { n: 0 } };
+  },
+  serialize(): unknown {
+    return { n: 0 };
+  },
+};
+
+const engine = createEngine<Types, Summary, {}>({ types, summary, folds: {} });
+
+/** Through the PUBLIC graph, not the module constant: the values are what
+ *  escape, and the door is what the finding was about. */
+function emptyIndexes() {
+  const graph = emptyGraph<Types, Summary>(engine.engineId);
+  return {
+    placements: graph.placementsByContentKey,
+    owners: graph.ownerBySourceKey,
+  };
+}
+
+/** What a consumer who cast away `ReadonlyMap` is holding. */
+function asMutable<K, V>(map: ReadonlyMap<K, V>): Map<K, V> {
+  return map as Map<K, V>;
+}
+
+describe("the shared empty indexes refuse a write", () => {
+  it("refuses set, delete and clear on placementsByContentKey", () => {
+    const { placements } = emptyIndexes();
+    const mutable = asMutable(placements);
+    expect(() => mutable.set("k", [])).toThrow(TypeError);
+    expect(() => mutable.delete("k")).toThrow(TypeError);
+    expect(() => mutable.clear()).toThrow(TypeError);
+  });
+
+  it("refuses set, delete and clear on ownerBySourceKey", () => {
+    const { owners } = emptyIndexes();
+    const mutable = asMutable(owners);
+    expect(() => mutable.set("k", "n" as NodeId)).toThrow(TypeError);
+    expect(() => mutable.delete("k")).toThrow(TypeError);
+    expect(() => mutable.clear()).toThrow(TypeError);
+  });
+
+  it("names the field, so the message says which singleton was written to", () => {
+    // Two constants share one helper, and "you wrote to a shared empty map" is
+    // not enough to find the call site.
+    let message = "";
+    try {
+      asMutable(emptyIndexes().placements).set("k", []);
+    } catch (thrown) {
+      message = thrown instanceof Error ? thrown.message : String(thrown);
+    }
+    expect(message).toContain("placementsByContentKey");
+  });
+
+  it("leaves nothing behind in another graph when a write is attempted", () => {
+    // The reason this matters at all: these are process-wide singletons, so a
+    // write was never local to the graph it went through.
+    const first = emptyIndexes();
+    try {
+      asMutable(first.placements).set("poisoned", []);
+    } catch {
+      // Expected.
+    }
+    const second = emptyIndexes();
+    expect(second.placements.has("poisoned")).toBe(false);
+    expect(second.placements.size).toBe(0);
+  });
+
+  it("still SHARES them, which is the whole reason they exist", () => {
+    // The fix must not be "stop sharing": a fresh empty map per call is what
+    // defeats the identity comparisons these constants exist to preserve.
+    const first = emptyIndexes();
+    const second = emptyIndexes();
+    expect(first.placements).toBe(second.placements);
+    expect(first.owners).toBe(second.owners);
+  });
+
+  it("still reads like an ordinary empty map", () => {
+    // A refusal that broke reading would be a worse bug than the one it closes.
+    const { placements } = emptyIndexes();
+    expect(placements.size).toBe(0);
+    expect(placements.get("anything")).toBeUndefined();
+    expect(placements.has("anything")).toBe(false);
+    expect([...placements.keys()]).toEqual([]);
+    expect([...placements.entries()]).toEqual([]);
+    // And copying out of one — the sanctioned way to change an index — still
+    // works, which is what every incremental updater in ./graph does.
+    const copy = new Map(placements);
+    copy.set("k", []);
+    expect(copy.size).toBe(1);
+    expect(placements.size).toBe(0);
+  });
+
+  it("keeps NO_IDS' protection too, so all three shared empties agree", () => {
+    // The rule this file is about is "a shared empty refuses a write". It held
+    // for the array and not for the two maps; asserting all three together is
+    // what stops them drifting apart again.
+    const graph = emptyGraph<Types, Summary>(engine.engineId);
+    expect(() => (graph.rootIds as NodeId[]).push("x" as NodeId)).toThrow(
+      TypeError,
+    );
+  });
+});

--- a/packages/nested-collections/core/tests/review6-the-undo-stack-has-a-ceiling-like-every-other.test.ts
+++ b/packages/nested-collections/core/tests/review6-the-undo-stack-has-a-ceiling-like-every-other.test.ts
@@ -1,0 +1,263 @@
+// Sixth review round — the fourth ceiling had no default and no doc.
+//
+// `EngineConfig` documents `maxNodes` in twenty lines, `maxDepth` in fifteen and
+// `maxNodeIdLength` in twenty-five. `historyLimit?: number;` had NO doc comment
+// at all and no default — the two omissions were the same omission.
+//
+// Unbounded is a strange default for this stack in particular. Undo is
+// deliberately built on WHOLE-VALUE before/after pairs, and that is the right
+// call — `ConsumerDefinedNodeType.invertEdit` argues it: "Undo works from
+// whole-value before/after pairs, which cannot be wrong; a wrong inverse
+// corrupts silently N undos later". The price is that every entry retains two
+// complete copies of the edited node's `Data`, so an unbounded stack retains two
+// per gesture for the life of the session.
+//
+// It is also what made the push superlinear: `pushHistory` returns a new
+// `History`, so it copies `past` every time. MEASURED, microseconds per push
+// against a full stack, with an interleaved control rather than two runs an
+// hour apart:
+//
+//      limit      us/push          limit          us/push
+//        100         3.59            2,500           6.61
+//        250         3.21            5,000          12.89
+//        500         3.29           10,000          20.56
+//      1,000         5.07           25,000         239.70
+//
+//   unbounded, at  5,000 edits    12.00
+//   unbounded, at 20,000 edits   135.81
+//   unbounded, at 50,000 edits   293.21
+//
+// The unbounded rows are the same curve with nothing stopping it: a session
+// walks down the table. Bounded, the cost is flat.
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsumerDefinedSummaryType,
+  type Issue,
+  type Result,
+  defineNodeType,
+  parseNodeId,
+} from "../types";
+import { createEngine, DEFAULT_HISTORY_LIMIT } from "../index";
+
+type Clip = Readonly<{ title: string }>;
+type ClipEdit = Readonly<{ title?: string }>;
+
+const clipType = defineNodeType<Clip, ClipEdit>()({
+  kind: "clip",
+  container: false,
+  schemaVersion: 1,
+  parse(raw): Result<Clip, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const title = ({ ...raw } as Record<string, unknown>)["title"];
+    if (typeof title !== "string") {
+      return { ok: false, error: [{ path: "$.title", message: "title" }] };
+    }
+    return { ok: true, value: { title } };
+  },
+  serialize(data): unknown {
+    return { title: data.title };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { title: edit.title ?? data.title } };
+  },
+});
+
+type Folder = Readonly<{ name: string }>;
+type FolderEdit = Readonly<{ name?: string }>;
+
+const folderType = defineNodeType<Folder, FolderEdit>()({
+  kind: "folder",
+  container: true,
+  schemaVersion: 1,
+  parse(raw): Result<Folder, readonly Issue[]> {
+    if (typeof raw !== "object" || raw === null) {
+      return { ok: false, error: [{ path: "$", message: "not an object" }] };
+    }
+    const name = ({ ...raw } as Record<string, unknown>)["name"];
+    if (typeof name !== "string") {
+      return { ok: false, error: [{ path: "$.name", message: "name" }] };
+    }
+    return { ok: true, value: { name } };
+  },
+  serialize(data): unknown {
+    return { name: data.name };
+  },
+  applyEdit(data, edit) {
+    return { ok: true, value: { name: edit.name ?? data.name } };
+  },
+});
+
+const types = [clipType, folderType] as const;
+type Types = typeof types;
+type Summary = Readonly<{ n: number }>;
+
+const summary: ConsumerDefinedSummaryType<Summary> = {
+  parse(): Result<Summary, readonly Issue[]> {
+    return { ok: true, value: { n: 0 } };
+  },
+  serialize(): unknown {
+    return { n: 0 };
+  },
+};
+
+const clipId = parseNodeId("c1");
+
+function storeWith(historyLimit?: number | null) {
+  const engine = createEngine<Types, Summary, {}>({
+    types,
+    summary,
+    folds: {},
+    ...(historyLimit === undefined ? {} : { historyLimit }),
+  });
+  const loaded = engine.deserialize({
+    formatVersion: 1,
+    schemaVersions: { folder: 1, clip: 1 },
+    rootIds: ["root"],
+    nodes: [
+      { id: "root", kind: "folder", data: { name: "R" }, children: ["c1"] },
+      { id: "c1", kind: "clip", data: { title: "t0" } },
+    ],
+  });
+  if (!loaded.ok) throw new Error("fixture failed to load");
+  return engine.createStore(loaded.value.graph);
+}
+
+/**
+ * How many entries the stack actually retained.
+ *
+ * Counted by undoing rather than read off a field: `History` is not on the
+ * public store surface, and the number that matters to a user is how many times
+ * Ctrl-Z does something — which is the same question and the one a regression
+ * here would actually change.
+ */
+function retainedEntries(store: ReturnType<typeof storeWith>): number {
+  let undone = 0;
+  while (store.canUndo()) {
+    const result = store.undo();
+    if (!result.ok) break;
+    undone += 1;
+    // A runaway guard, not the measurement: an unbounded stack under test is
+    // seeded with a known number of edits, so this can only be reached if
+    // `canUndo` and `undo` disagree.
+    if (undone > 100_000) throw new Error("undo did not terminate");
+  }
+  return undone;
+}
+
+function edit(store: ReturnType<typeof storeWith>, times: number): void {
+  for (let i = 0; i < times; i += 1) {
+    const result = store.dispatch({
+      type: "edit-nodes",
+      edits: [{ nodeId: clipId, kind: "clip", edit: { title: `t${i + 1}` } }],
+    });
+    if (!result.ok) throw new Error(`edit ${i} refused: ${result.error.code}`);
+  }
+}
+
+describe("the undo stack has a ceiling like every other", () => {
+  it("bounds an omitted historyLimit at the default", () => {
+    const store = storeWith();
+    edit(store, DEFAULT_HISTORY_LIMIT + 50);
+    expect(retainedEntries(store)).toBe(DEFAULT_HISTORY_LIMIT);
+  }, 30_000);
+
+  it("drops the OLDEST entries, not the newest", () => {
+    // `trimPast` takes from the front. The entry a user is most likely to want
+    // back is the one they just made, so a ceiling that discarded the newest
+    // would be worse than no ceiling.
+    const store = storeWith(3);
+    edit(store, 6);
+    // Six edits, a ceiling of three: undoing to the bottom must land on the
+    // value the third edit produced, not the original.
+    while (store.canUndo()) store.undo();
+    const node = store.getGraph().nodesById.get(clipId);
+    expect(node?.sealed).toBe(false);
+    if (node === undefined || node.sealed || node.container) return;
+    // Narrowed on `kind` as well as on the two discriminants: `LeafNode<Ts>`
+    // spans every leaf kind in the registry, so `data` is the UNION of their
+    // Data types until the kind is pinned.
+    if (node.kind !== "clip") return;
+    expect(node.data.title).toBe("t3");
+  });
+
+  it("takes a consumer's number over the default, above it as well as below", () => {
+    // The rule `maxNodes` states — "a consumer who names a ceiling has named
+    // THE ceiling, including one above the default. The default is what applies
+    // when nobody chose, not a cap on choosing."
+    const small = storeWith(5);
+    edit(small, 40);
+    expect(retainedEntries(small)).toBe(5);
+
+    const large = storeWith(DEFAULT_HISTORY_LIMIT + 200);
+    edit(large, DEFAULT_HISTORY_LIMIT + 100);
+    expect(retainedEntries(large)).toBe(DEFAULT_HISTORY_LIMIT + 100);
+  }, 30_000);
+
+  it("restores unbounded with an explicit null", () => {
+    // Giving the field a default would have REMOVED the only way to ask for
+    // unbounded, because omission was that way and `0` is refused. `null` is
+    // the replacement, spelled the way `maxNodeIdLength` spells the same
+    // choice.
+    const store = storeWith(null);
+    edit(store, DEFAULT_HISTORY_LIMIT + 100);
+    expect(retainedEntries(store)).toBe(DEFAULT_HISTORY_LIMIT + 100);
+  }, 30_000);
+
+  it("refuses every value that would silently mean unbounded", () => {
+    // Each of these maps to Infinity in `effectiveLimit`, so accepting one
+    // would give a consumer who asked to bound memory no bound at all —
+    // failure in the unsafe direction, which is the whole reason this door
+    // throws instead of reinterpreting. `NaN` arrives for free from
+    // `Number(fromEnv)`.
+    for (const bad of [0, -1, 2.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() =>
+        createEngine<Types, Summary, {}>({
+          types,
+          summary,
+          folds: {},
+          historyLimit: bad,
+        }),
+      ).toThrow(/historyLimit must be a positive integer or null/);
+    }
+  });
+
+  it("points at null in the refusal, since that is now the escape hatch", () => {
+    // The message used to say "omit it entirely for unbounded history", which
+    // stopped being true the moment omission started meaning the default. A
+    // refusal that names the wrong escape hatch is worse than one that names
+    // none.
+    let message = "";
+    try {
+      createEngine<Types, Summary, {}>({
+        types,
+        summary,
+        folds: {},
+        historyLimit: 0,
+      });
+    } catch (thrown) {
+      message = thrown instanceof Error ? thrown.message : String(thrown);
+    }
+    expect(message).toContain("null");
+    expect(message).not.toContain("Omit it entirely");
+  });
+
+  it("keeps redo working across a trim", () => {
+    // Trimming rewrites `past`, and `pushHistory` clears `future` on every
+    // push. Undo/redo has to stay coherent across both.
+    const store = storeWith(3);
+    edit(store, 5);
+    expect(store.undo().ok).toBe(true);
+    expect(store.canRedo()).toBe(true);
+    expect(store.redo().ok).toBe(true);
+    const node = store.getGraph().nodesById.get(clipId);
+    if (node === undefined || node.sealed || node.container) return;
+    // Narrowed on `kind` as well as on the two discriminants: `LeafNode<Ts>`
+    // spans every leaf kind in the registry, so `data` is the UNION of their
+    // Data types until the kind is pinned.
+    if (node.kind !== "clip") return;
+    expect(node.data.title).toBe("t5");
+  });
+});

--- a/packages/nested-collections/core/types/describe.ts
+++ b/packages/nested-collections/core/types/describe.ts
@@ -4,25 +4,13 @@
 // Describing a throw
 // ---------------------------------------------------------------------------
 
-/**
- * The message to put in an `Issue` when consumer code threw instead of
- * returning.
- *
- * It lives HERE, in the module that imports nothing, because all four modules
- * that call into consumer code need it — ./serialize wraps `parse` and the
- * summary type, ./commands wraps `applyEdit` and `serialize`, ./patches wraps
- * the `serialize` pair that replay verification compares on. One
- * implementation, so the three cannot drift into describing the same throw
- * three different ways.
- *
- * NOT re-exported from ./index: a consumer never calls this, it only ever reads
- * the strings it produces.
- *
- * `String(thrown)` rather than `JSON.stringify`: a thrown value is arbitrary,
- * `stringify` is recursive and can itself throw on a cycle or a BigInt, and a
- * helper whose whole job is to describe a failure must not have a failure mode
- * of its own.
- */
+// `describeThrown`'s doc used to sit HERE, immediately above `describeValue`'s
+// and therefore bound to nothing — two JSDoc blocks in a row, so an editor
+// showed the second one on hover and the first was prose in the middle of a
+// file. It has moved down onto the function it describes. Worth a line rather
+// than a silent deletion: the two functions are siblings and a reader who
+// remembers the block being up here should know where it went.
+
 /**
  * `describeThrown`'s sibling, for an untrusted VALUE rather than a thrown one.
  *
@@ -106,7 +94,62 @@ export function quoteFromWire(value: string): string {
   return JSON.stringify(clamp(value));
 }
 
+/**
+ * The message to put in an `Issue` when consumer code threw instead of
+ * returning.
+ *
+ * It lives HERE, in the module that imports nothing, because all four modules
+ * that call into consumer code need it — ./serialize wraps `parse` and the
+ * summary type, ./commands wraps `applyEdit` and `serialize`, ./patches wraps
+ * the `serialize` pair that replay verification compares on. One
+ * implementation, so the three cannot drift into describing the same throw
+ * three different ways.
+ *
+ * NOT re-exported from ./index: a consumer never calls this, it only ever reads
+ * the strings it produces.
+ *
+ * CLAMPED, which is the third and last describer in this file to be. The other
+ * two were bounded a round apart, each time under the heading "every ingress
+ * refusal" — and this one was neither swept, because the sweeps looked for
+ * `JSON.stringify` and this function does not call it. MEASURED at the DEFAULT
+ * config, a node type whose `contentKey` throws with a 1 MB message:
+ *
+ *   deserialize(...).error.message      1,000,070 characters
+ *
+ * against the 169 `quoteFromWire` brought the `dangling-child` refusal down to.
+ * `KeyHookFailure` embeds this string and every ingress and command door relays
+ * it, so a consumer logs the megabyte. The throw is consumer code rather than
+ * wire data, which is why it reads as lower risk than it is: a node type that
+ * echoes the value it choked on into its own error message — an ordinary thing
+ * to write — hands the sender control of the length after all.
+ *
+ * The lesson `quoteFromWire` already records applies unchanged: A BOUND BELONGS
+ * WHERE THE MESSAGE IS BUILT. The prefix around this string names the kind and
+ * the hook and is built from engine-controlled text, so it stays unclamped and
+ * the reader still learns which node type failed.
+ *
+ * `String(thrown)` rather than `JSON.stringify`: a thrown value is arbitrary,
+ * `stringify` is recursive and can itself throw on a cycle or a BigInt, and a
+ * helper whose whole job is to describe a failure must not have a failure mode
+ * of its own.
+ *
+ * TOTAL, which is the second defect and was not in the finding. `String(thrown)`
+ * is not safe on arbitrary input: `String(Object.create(null))` throws
+ * `TypeError: Cannot convert object to primitive value`, and so does any value
+ * whose `toString` throws — both of which a consumer can `throw`. The doc on
+ * `describeValue` states the rule this broke: "a helper whose whole job is to
+ * describe a failure must not have a failure mode of its own." Reading
+ * `.message` off an `Error` can throw for the same reason, since it may be a
+ * getter, so both reads sit inside the guard.
+ */
 export function describeThrown(thrown: unknown): string {
-  if (thrown instanceof Error) return thrown.message;
-  return String(thrown);
+  try {
+    if (thrown instanceof Error) return clamp(thrown.message);
+    return clamp(String(thrown));
+  } catch {
+    // The value cannot describe itself. Its shape is all that can be said
+    // safely, and saying it beats propagating a second throw out of the
+    // handler for the first.
+    return thrown === null ? "null" : `[unprintable ${typeof thrown}]`;
+  }
 }

--- a/packages/nested-collections/core/types/engine.ts
+++ b/packages/nested-collections/core/types/engine.ts
@@ -251,7 +251,33 @@ export type EngineConfig<
   mintId?(): string;
   /** Injectable so tests get deterministic `HistoryEntry.at`. Defaults to `Date.now`. */
   now?(): number;
-  historyLimit?: number;
+  /**
+   * Ceiling on undo entries, or `null` for unbounded. Defaults to
+   * `DEFAULT_HISTORY_LIMIT`.
+   *
+   * THE FOURTH CEILING, and until now the only one with no default and no doc
+   * comment — in a type where `maxNodes` gets twenty lines. The two omissions
+   * were the same omission, and unbounded is a strange default for this stack
+   * in particular: undo is built on WHOLE-VALUE before/after pairs (see
+   * `ConsumerDefinedNodeType.invertEdit` for why, and it is the right call), so
+   * every entry retains two complete copies of the edited node's `Data`. An
+   * unbounded stack retains two per gesture for the life of the session, and
+   * `pushHistory` copies `past` on every push, which makes the cost quadratic
+   * in the session rather than in the document. Measured at
+   * `DEFAULT_HISTORY_LIMIT`.
+   *
+   * REFUSES rather than reinterprets. `0`, a negative, a fraction, `NaN` and
+   * `Infinity` all throw at `createEngine`: each would silently mean unbounded,
+   * which is the opposite of what naming a limit asks for. `null` is the one
+   * spelling of "unbounded", and it is explicit — the same escape hatch
+   * `maxNodeIdLength` offers, spelled the same way.
+   *
+   * A DEPTH, NOT A MEMORY BOUND. The entry holds the consumer's `Data`, whose
+   * size this package cannot know, so a consumer whose nodes carry more than a
+   * scalar should size this against their own value rather than take the
+   * default and assume it bounds anything in bytes.
+   */
+  historyLimit?: number | null;
   /**
    * Ceiling on how many nodes ONE document may present to `deserialize`.
    * Defaults to `DEFAULT_MAX_NODES`.


### PR DESCRIPTION
Follow-up to #638. Each of these is a rule this package already applies somewhere, not applied everywhere it holds.

## 1. A node-type throw could blow up a refusal message

`quoteFromWire` and `describeValue` were bounded a round apart, each under the heading "every ingress refusal". `describeThrown` is the third describer in that file and was swept by neither — both sweeps looked for `JSON.stringify`, and it does not call it.

Measured at the **default** config, a node type whose `contentKey` throws with a 1 MB message:

| | length of `error.message` |
| --- | --- |
| `deserialize(...)` | **1,000,070 characters** |
| (`dangling-child`, after `quoteFromWire`) | 169 |

The throw is consumer code rather than wire data, which is why it reads as lower risk than it is: a node type that echoes the value it choked on into its own error message is an ordinary thing to write, and that hands the sender control of the length after all. The lesson `quoteFromWire` already records applies unchanged — **a bound belongs where the message is BUILT**. The prefix naming the kind and the hook is engine-controlled and stays unclamped, so the diagnostic survives.

### And `String(thrown)` was not total

Not in the original finding, and the worse half. All three of these are things a consumer can `throw`, and all three escaped `deserialize` and `dispatch` as exceptions out of doors that promise a `Result`:

```
Object.create(null)                 String() THREW: TypeError: Cannot convert object to primitive value
{ toString() { throw ... } }        String() THREW
new Error() with a throwing getter  .message THREW
```

That is the rule the sibling's own doc states: *a helper whose whole job is to describe a failure must not have a failure mode of its own.* Both reads now sit inside a guard.

Also removes a `describeThrown` doc block that had been sitting immediately above `describeValue`'s — two JSDoc blocks in a row, so it bound to nothing.

## 2. The undo stack had no ceiling and no doc

`historyLimit?: number;` was the one field in `EngineConfig` with no doc comment, and the one ceiling with no default. The two omissions were the same omission.

Unbounded is a strange default for *this* stack: undo is built on whole-value before/after pairs — the right call, and `invertEdit` argues it — so every entry retains two complete copies of the edited node's `Data`. It is also what made the push superlinear, since `pushHistory` copies `past`.

Measured, µs/push against a full stack, with an interleaved control:

| limit | µs/push | limit | µs/push |
| ---: | ---: | ---: | ---: |
| 100 | 3.59 | 2,500 | 6.61 |
| 250 | 3.21 | 5,000 | 12.89 |
| 500 | 3.29 | 10,000 | 20.56 |
| 1,000 | 5.07 | 25,000 | 239.70 |

| unbounded, at | µs/push |
| ---: | ---: |
| 5,000 edits | 12.00 |
| 20,000 edits | 135.81 |
| 50,000 edits | 293.21 |

The unbounded rows are the same curve with nothing stopping it: a session walks down the table.

`DEFAULT_HISTORY_LIMIT` is **1,000**, chosen on *retention* rather than that curve — 5 µs on a gesture happening a few times a second is imperceptible, while 2,000 retained `Data` copies is a number a consumer can multiply by their own value's size and act on. Documented as a depth, not a memory bound, the same caveat `DEFAULT_FOLD_CACHE_LIMIT` carries.

**`historyLimit: null` opts out.** `null` had to become legal: omission was the only way to ask for unbounded and `0` is refused, so adding a default without a new escape hatch would have removed the old one. The refusal message now names `null` instead of telling the consumer to omit the field, which stopped being true.

⚠️ This changes a default. A consumer relying on unbounded undo now gets 1,000 entries unless they pass `null`.

## 3. The shared empty indexes accepted a write

`Object.freeze` is the whole answer for `NO_IDS` and no answer at all for a `Map`, whose entries live in an internal slot freezing cannot reach. So `NO_PLACEMENTS` and `NO_OWNERS` were protected in name only, and the gap was invisible because the declared type is `ReadonlyMap`.

Measured through the public surface:

```
two independently built empty graphs shared the same map   true
a write through the ReadonlyMap succeeded                  true
it was visible in the OTHER graph                          true
```

The file header argued these were safe because none is re-exported from `./index`. True of the **bindings**, false of the **values**: every empty graph publishes them, and so does every graph whose registry declares no `contentKey` — the ordinary case, not an edge one.

Reachable only after casting away `ReadonlyMap`, so this is defence in depth rather than a live bug. Worth closing because the sibling constant already delivers it, and a rule that holds for two of three shared empties is the kind that gets relied on for the third. Sharing is preserved — that is the entire point of the constants, and a fresh map per call would defeat the identity comparisons they exist for.

## 4. `buildGraph` took a parameter nothing read

`deadRevs`, documented as *"carried forward when a graph is rebuilt around existing nodes, so a rebuild does not forget what has been removed"* — with zero readers anywhere in the package. It outlived the tombstone store `revFloor` replaced, so a caller passing it got it accepted, typechecked, and dropped. An optional parameter that is silently ignored is a guard that fails **open**, at exactly the door whose job was to make a rebuild not forget.

## Verification

Three new test files, 27 tests. Confirmed against the unfixed source first — **16 fail**, with the predicted errors: 1,000,059-character messages, `TypeError: Cannot convert object to primitive value`, writes that should have thrown and did not, `historyLimit: null` refused. The 11 that pass pre-fix are the must-not-regress guards (sharing preserved, ordinary messages untouched, `NO_IDS` still frozen, oldest-dropped, redo across a trim).

| Check | Result |
| --- | --- |
| Unit tests | 98 files, **1645 passed** (was 1623) |
| Typecheck | **7/7 packages clean** |
| `eslint packages` | **0 errors** |
| App lint | **0 errors** |

`tsc` caught two under-narrowed `node.data` reads in my own test that vitest ran happily — `LeafNode<Ts>` spans every leaf kind, so `data` is the union until `kind` is pinned.

## Still open from the review

Not defects, so not in scope here: no README or LICENSE for a package carrying `publishConfig.access: "public"`; mojibake in `patches/predicates.ts` (8) and `patches/splicing.ts` (17); and `exactOptionalPropertyTypes` being off despite `NodeDraft` deliberately depending on absent-vs-`undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
