### PR TITLE
Em dashes that had been through a CP1252 round trip

### DIFF
--- a/apps/timeline-gstudio001/next.config.ts
+++ b/apps/timeline-gstudio001/next.config.ts
@@ -102,7 +102,7 @@ const nextConfig: NextConfig = {
    */
   webpack: (config, { dev }) => {
     // HMR is disabled in AI Studio via DISABLE_HMR env var.
-    // Do not modifyâfile watching is disabled to prevent flickering during agent edits.
+    // Do not modify—file watching is disabled to prevent flickering during agent edits.
     if (dev && process.env.DISABLE_HMR === 'true') {
       config.watchOptions = {
         ignored: /.*/,

--- a/packages/collections-core/commands.ts
+++ b/packages/collections-core/commands.ts
@@ -337,7 +337,7 @@ export function applyCommand(
   const insertAt = Math.max(0, Math.min(toIndex, baseLength));
 
   // Index each affected source collection once. Calling `indexOf` per moved
-  // node turns a large same-parent selection into O(m Ã— n); this stays
+  // node turns a large same-parent selection into O(m × n); this stays
   // O(total children in affected parents + m).
   const sourceIndexById = new Map<NodeId, number>();
   const indexedParents = new Set(parentByMovingId.values());

--- a/packages/nested-collections/core/patches/predicates.ts
+++ b/packages/nested-collections/core/patches/predicates.ts
@@ -25,7 +25,7 @@ export function containerChildrenState<Ts extends readonly WidenedNodeType[], S>
   return null;
 }
 
-/** `true` when this node owns a `childrenById` entry â€” i.e. it is a `loaded`
+/** `true` when this node owns a `childrenById` entry — i.e. it is a `loaded`
  *  container. Exactly one state has an entry; the other three have none. */
 export function isLoadedContainer<Ts extends readonly WidenedNodeType[], S>(
   node: GraphNode<Ts, S>,
@@ -53,21 +53,21 @@ export function deepEqual(a: unknown, b: unknown): boolean {
    * Object pairs this walk has already taken on, so a cyclic value terminates.
    *
    * WITHOUT THIS THE PROCESS DIES, and not slowly. Two DISTINCT values that
-   * each hold a back-reference â€” `out.self = out` from either side of the
-   * comparison below â€” make the walk push two frames for every one it pops, so
+   * each hold a back-reference — `out.self = out` from either side of the
+   * comparison below — make the walk push two frames for every one it pops, so
    * the stack grows without bound. Measured: heap exhaustion at 4 GB and a
    * killed process in 23 seconds. `Object.is` is no help, because the two
    * `serialize` calls return two different objects.
    *
    * A PARSED value may legitimately hold a back-pointer, and this compares
-   * `serialize` OUTPUT rather than parsed data â€” so reaching it takes a node
+   * `serialize` OUTPUT rather than parsed data — so reaching it takes a node
    * type whose `serialize` returns a cycle, which is a consumer bug on the same
    * footing as the throwing `serialize` the caller already wraps. Wire data
    * cannot carry one; an in-memory `raw` handed to `deserialize` can.
    *
    * NOT A STEP BUDGET, and that distinction is the whole design. ./types argues
    * that `verifyPatchApplies` needs a comparator that CANNOT abstain, because a
-   * budget bail surfaces as a spurious `data-mismatch` â€” a legitimate undo
+   * budget bail surfaces as a spurious `data-mismatch` — a legitimate undo
    * refused for being large. That argument is right, and a budget would have
    * broken exactly the case it was meant to protect: a clip with a few hundred
    * keyframes is big, not cyclic. A memo changes no verdict on any acyclic
@@ -77,8 +77,8 @@ export function deepEqual(a: unknown, b: unknown): boolean {
    * definite: a pair already under comparison is ASSUMED equal. The assumption
    * costs nothing, because any concrete disagreement anywhere in the walk
    * returns `false` immediately, and `true` is only reached once every pair has
-   * been discharged. `a.self = a` against `b.self = b` compares equal â€” which is
-   * correct, they are structurally identical â€” while `a.self = a` against
+   * been discharged. `a.self = a` against `b.self = b` compares equal — which is
+   * correct, they are structurally identical — while `a.self = a` against
    * `b.self = {}` still returns `false` on the key-count check.
    *
    * Allocated lazily and only for object-vs-object pairs, so a comparison that
@@ -137,7 +137,7 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   return true;
 }
 
-/** A type predicate rather than a cast â€” the core's only sanctioned casts live
+/** A type predicate rather than a cast — the core's only sanctioned casts live
  *  in the four boundary constructors in ./types, and this needs none. */
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/nested-collections/core/patches/splicing.ts
+++ b/packages/nested-collections/core/patches/splicing.ts
@@ -9,7 +9,7 @@ import {
 import { EMPTY_IDS } from "./constants";
 
 /** Group arrivals by destination parent, PRESERVING patch order within each
- *  parent â€” which is the order their indices are expressed in. */
+ *  parent — which is the order their indices are expressed in. */
 export function groupArrivalsByParent(
   entries: readonly Readonly<{ parentId: NodeId; index: number; nodeId: NodeId }>[],
 ): ReadonlyMap<NodeId, readonly Arrival[]> {
@@ -34,13 +34,13 @@ export function groupByParent(
   return byParent;
 }
 /**
- * Copy-on-write insertion of MANY ids into one parent â€” ONE pass per parent
+ * Copy-on-write insertion of MANY ids into one parent — ONE pass per parent
  * instead of one per arriving node.
  *
  * THE MIRROR OF `spliceOutMany`, and it should have shipped with it. That one
  * fixed removal, which was three O(siblings) passes per id; insertion kept
- * doing exactly the same thing â€” `slice()` the whole destination array, splice
- * one id in, store it â€” once per node. So the removal half went linear and the
+ * doing exactly the same thing — `slice()` the whole destination array, splice
+ * one id in, store it — once per node. So the removal half went linear and the
  * insertion half stayed O(K x N), and undo of a bulk delete inverts to an
  * `inserted` patch and paid in full the cost the delete no longer did.
  *
@@ -54,7 +54,7 @@ export function groupByParent(
  *  32,000      76.3 ms           6,759 ms                10,018 ms
  *
  * Delete grows 6x for 8x the nodes. Undo of the same delete grows 152x. At
- * 32,000 a select-all/Delete costs 76 ms and Ctrl-Z on it costs 6.8 SECONDS â€”
+ * 32,000 a select-all/Delete costs 76 ms and Ctrl-Z on it costs 6.8 SECONDS —
  * the same nodes, the same parent, 89x apart.
  *
  * WHY INSERTION CANNOT JUST BE GROUPED AND SORTED, which is what makes this
@@ -68,12 +68,12 @@ export function groupByParent(
  * The single pass below reproduces the sequential result exactly, by building
  * the output left to right and emitting an arrival the moment the output length
  * REACHES its index. That is equivalent to sequential splicing whenever a
- * parent's indices are strictly ascending and in range â€” which is every patch
+ * parent's indices are strictly ascending and in range — which is every patch
  * this engine builds: `buildSeedPlacements` and `buildMoves` both emit
  * `toIndex + offset`, and a removal patch records document order, so inverting
  * one yields ascending indices too.
  *
- * It DECLINES rather than guessing when it cannot reach an index â€” equal
+ * It DECLINES rather than guessing when it cannot reach an index — equal
  * indices (where sequential splicing puts the LATER arrival first), descending
  * indices, or an index out of range. None of those are reachable from the
  * reducer; a hand-built patch can produce all three. The caller then falls back
@@ -87,7 +87,7 @@ export function spliceInMany(
   byParent: ReadonlyMap<NodeId, readonly Arrival[]>,
 ): void {
   for (const [parentId, arrivals] of byParent) {
-    // `?? EMPTY_IDS` cannot fire for a verified patch â€” the parent is either a
+    // `?? EMPTY_IDS` cannot fire for a verified patch — the parent is either a
     // loaded container in the graph or one this patch seeded earlier. It is
     // here so a hand-built patch produces a wrong array rather than a crash,
     // exactly as `spliceIn` does.
@@ -103,7 +103,7 @@ export function spliceInMany(
       while (next.length < arrival.index && read < current.length) {
         const id = current[read];
         read += 1;
-        // `noUncheckedIndexedAccess` â€” a real check, not a `!`. The loop bounds
+        // `noUncheckedIndexedAccess` — a real check, not a `!`. The loop bounds
         // make this unreachable; TypeScript cannot see that and neither should
         // a reader.
         if (id !== undefined) next.push(id);
@@ -114,7 +114,7 @@ export function spliceInMany(
     }
 
     if (placed !== arrivals.length) {
-      // DECLINED â€” nothing written yet, so the fallback starts from the
+      // DECLINED — nothing written yet, so the fallback starts from the
       // untouched array and the two paths cannot interleave.
       for (const arrival of arrivals) {
         spliceIn(children, parentId, arrival.index, arrival.nodeId);
@@ -130,16 +130,16 @@ export function spliceInMany(
   }
 }
 /**
- * Copy-on-write removal for MANY ids at once â€” ONE pass per parent instead of
+ * Copy-on-write removal for MANY ids at once — ONE pass per parent instead of
  * one per removed node.
  *
  * WHAT THIS REPLACED, because the reasoning is the whole justification for the
- * shape. The per-id predecessor was three O(siblings) passes â€” `indexOf`,
- * `slice`, `splice` â€” allocating a fresh array every call, so removing K of N
+ * shape. The per-id predecessor was three O(siblings) passes — `indexOf`,
+ * `slice`, `splice` — allocating a fresh array every call, so removing K of N
  * siblings cost O(K x N). The constant is a memcpy, which is why it stayed
  * invisible: free below a thousand siblings, and 5.2 SECONDS measured for
  * select-all-then-Delete on a 40,000-item strip. Both arms that remove in bulk
- * â€” `applyRemoved` and `applyMoved` â€” go through here.
+ * — `applyRemoved` and `applyMoved` — go through here.
  *
  * That predecessor, `spliceOut`, SAT HERE UNREFERENCED until lint reached this
  * package for the first time and reported it. Two of the sentences above used
@@ -160,7 +160,7 @@ export function spliceOutMany(
 ): void {
   for (const [parentId, ids] of byParent) {
     const current = children.get(parentId);
-    // Absent when the parent is itself being removed in this same patch â€” its
+    // Absent when the parent is itself being removed in this same patch — its
     // whole entry is gone, so there is no array left to maintain.
     if (current === undefined) continue;
     const remaining = new Set<NodeId>(ids);
@@ -174,7 +174,7 @@ export function spliceOutMany(
 }
 
 /** One id arriving at one position. `index` is in the coordinates of the array
- *  AS IT STANDS when this entry is applied â€” the same contract `spliceIn` has,
+ *  AS IT STANDS when this entry is applied — the same contract `spliceIn` has,
  *  and the reason these cannot simply be sorted. */
 export type Arrival = Readonly<{ index: number; nodeId: NodeId }>;
 /** Copy-on-write splice into a parent's children array. */
@@ -184,7 +184,7 @@ export function spliceIn(
   index: number,
   id: NodeId,
 ): void {
-  // `?? EMPTY_IDS` cannot fire for a verified patch â€” the parent is either a
+  // `?? EMPTY_IDS` cannot fire for a verified patch — the parent is either a
   // loaded container in the graph or a loaded container this patch seeded two
   // steps earlier. It is here so a hand-built patch produces a wrong array
   // rather than a crash.


### PR DESCRIPTION
Closes the last cosmetic item from the review of `nested-collections` (after #638, #639, #640).

Twenty-eight characters across four files, all one defect: a UTF-8 byte sequence read back as CP1252 (or Latin-1) and re-encoded as UTF-8, so `—` became `â€”` and `×` became `Ã—`. It comes from a tool writing the file rather than from anyone typing it, which is why it lands mid-sentence in otherwise untouched prose.

**Comment-only**, and verified rather than asserted — every changed line in the diff starts with a comment marker, so nothing here can reach a string literal.

## What was actually there

My first pass at this assumed em dashes and counted with `grep -c`, which counts **lines**. It reported 17 for `splicing.ts` where there are 18, because one line carries two. The sweep behind this PR decodes each sequence and prints the code points instead:

| file | count | sequence | decodes to |
| --- | ---: | --- | --- |
| `nested-collections/core/patches/predicates.ts` | 8 | `â€”` `[U+00E2 U+20AC U+201D]` | `—` |
| `nested-collections/core/patches/splicing.ts` | 18 | `â€”` `[U+00E2 U+20AC U+201D]` | `—` |
| `collections-core/commands.ts` | 1 | `Ã—` `[U+00C3 U+2014]` | `×` |
| `timeline-gstudio001/next.config.ts` | 1 | `â` `[U+00E2 U+0080 U+0094]` | `—` |

**Two flavours of the same mistake**, and worth noticing because a fix written for one would have missed the other:

- The first three went through **CP1252**, where `€` *is* byte `0x80` and `"` *is* byte `0x94`.
- The fourth went through **Latin-1**, which leaves `0x80`–`0x9F` as raw C1 control characters — so it renders as a single stray `â` followed by two invisible characters, and a grep for `â€` does not find it at all.

The `×` is complexity notation (`O(m × n)`), so the decode was checked against what the sentence needs rather than accepted because it parsed.

## Scope

The review named `predicates.ts` and `splicing.ts`. Running the decoder over every text source in the repo turned up two more of the identical defect, one character each, in `packages/collections-core` and the app's `next.config.ts`. Both are fixed here — same corruption, same sweep, and leaving a known instance behind to keep a commit tidy is how it comes back.

Deliberately **not** touched:

- Two hits in `apps/storybook/coverage/**.html` — generated output, gitignored, regenerated from the sources this PR fixes.
- Hits in a `.jpeg` and a `.png` — binary false positives from scanning without an extension filter, and the reason the final sweep has one.

## Verification

| Check | Result |
| --- | --- |
| Re-scan (packages, apps, scripts, docs) | **0 remaining** |
| Strict UTF-8 decode, all 132 source files | clean |
| Unit tests | 98 files, **1647 passed** |
| Typecheck | **7/7 packages clean** |
| `eslint packages` / app lint | **0 errors** |

## Worth considering separately

Nothing in the toolchain would catch this recurring — it is invisible in review, survives every build, typecheck and lint, and comes back whenever a tool rewrites a file. A ~15-line test that decodes each source file and asserts no double-encoded sequences would close it permanently. Not included here to keep this PR to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
