### PR TITLE
media monster, with a space, and copy that says what it is

### DIFF
--- a/apps/media-monster/app/page.tsx
+++ b/apps/media-monster/app/page.tsx
@@ -16,27 +16,24 @@ import { toast } from "@/components/core/sonner";
  */
 export default function Home() {
   return (
-    <div className="flex min-h-[80vh] flex-col items-center justify-center gap-10">
+    <div className="flex min-h-[80vh] flex-col items-center justify-center gap-8">
       <div className="flex items-center gap-3">
         <MediaMonsterMark scale={2.4} />
         <span
           className="font-bold text-4xl"
           style={{ fontFamily: "var(--font-grandstander)" }}
         >
-          media<span className="text-blue-400">monster</span>
+          media <span className="text-blue-400">monster</span>
         </span>
       </div>
 
-      <p className="max-w-md text-center text-sm text-zinc-400">
-        The shell is up. Components come over from{" "}
-        <code className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-300">
-          timeline-gstudio001
-        </code>{" "}
-        one at a time, onto the{" "}
-        <code className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-300">
-          nested-collections
-        </code>{" "}
-        engine.
+      <p className="text-xl text-zinc-200">Tame the slop.</p>
+
+      <p className="max-w-lg text-center text-sm leading-relaxed text-zinc-400">
+        You asked a model for one shot and got forty back. Somewhere in that
+        pile is the one you actually wanted. Media Monster is where you herd
+        AI-generated clips into collections — nested as deep as you like — and
+        keep rearranging until the pile turns into a cut.
       </p>
 
       <button


### PR DESCRIPTION
Follows #643. Two changes to the placeholder page.

## The wordmark gains a space

`mediamonster` → `media monster`. The accent still splits at the same seam, so "monster" stays blue.

## The copy now describes the product

It was a note to ourselves about where components are coming from — true, and not what a landing page is for.

> ### Tame the slop.
>
> You asked a model for one shot and got forty back. Somewhere in that pile is the one you actually wanted. Media Monster is where you herd AI-generated clips into collections — nested as deep as you like — and keep rearranging until the pile turns into a cut.

"Herd" and "tame" are doing the creature's work: the monster is the thing that gets the pile under control, and nesting collections inside collections is literally what the engine underneath does.

The em dashes are real U+2014 and the file decodes as strict UTF-8 — checked rather than assumed, because this repo double-encoded 28 of them two commits ago (#641).

## The toaster button stays

It is now the one thing on the page that looks out of place. It is also the only check that the toast surface is actually mounted, which is why the page has it at all — it goes when a real view arrives with a real reason to toast. Happy to pull it sooner if you would rather the page read clean.

## Verified

Renders correctly in the browser with no console errors. `eslint`, `tsc --noEmit` and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
