### PR TITLE
Fix attach_media rejecting live uploads on large projects

### DIFF
--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
@@ -209,6 +209,18 @@ function toAsset(
   };
 }
 
+/**
+ * Pages of 100 to walk before giving up on a listing.
+ *
+ * This is a verification budget, not just a display one: `attachMedia` checks a
+ * freshly uploaded public_id against this listing, so anything past the budget
+ * is indistinguishable from "never uploaded". At 5 pages a project with more
+ * than 500 assets could not attach new media at all. Paired with an explicit
+ * newest-first sort on the video search, which is what actually guarantees a
+ * new upload lands on page one.
+ */
+const ASSET_LIST_MAX_PAGES = 25;
+
 async function listCloudinaryResources(
   config: CloudinaryConfig,
   resourceType: "image" | "video",
@@ -255,7 +267,7 @@ async function listCloudinaryResources(
     );
     nextCursor = body.next_cursor;
     pageCount += 1;
-  } while (nextCursor && pageCount < 5);
+  } while (nextCursor && pageCount < ASSET_LIST_MAX_PAGES);
 
   return assets;
 }
@@ -287,6 +299,14 @@ async function searchCloudinaryVideos(
         body: JSON.stringify({
           expression: `public_id:${folderPrefix}/* AND resource_type:video`,
           max_results: 100,
+          // NEWEST FIRST. Without an explicit sort, Cloudinary's ordering is
+          // not guaranteed to surface a just-uploaded asset inside the page
+          // budget below, and `attachMedia` verifies against exactly this
+          // listing -- so on a project with more videos than the budget, a
+          // file that IS live at its public_id reports as "no uploaded asset"
+          // and the clip can never be attached. Measured on Toon Town, which
+          // holds well over 500 videos in one project folder.
+          sort_by: [{ created_at: "desc" }],
           // Tag lists ride along like duration does — see the function
           // comment for why videos use Search in the first place.
           with_field: "tags",
@@ -308,7 +328,7 @@ async function searchCloudinaryVideos(
     );
     nextCursor = body.next_cursor;
     pageCount += 1;
-  } while (nextCursor && pageCount < 5);
+  } while (nextCursor && pageCount < ASSET_LIST_MAX_PAGES);
 
   return assets;
 }


### PR DESCRIPTION
## The bug

`attachMedia` verifies a freshly uploaded `public_id` against the Cloudinary asset listing. That listing stopped after **5 pages of 100**, and the video search carried **no explicit sort** — so on a project with more assets than the budget, a file that is live at its exact `public_id` reports as *"no uploaded asset"* and can never be attached to a timeline.

## How it showed up

Hit on Toon Town, which holds well over 500 videos in one project folder:

1. `create_upload` minted a ticket
2. The POST to Cloudinary returned 200 with a `public_id` matching the ticket exactly
3. The file served over HTTP (206, correct bytes and duration)
4. `attach_media` still refused it — on every retry, for four separate files

The uploads were fine the whole time. The verification window simply didn't reach them.

## The fix

- **Sort the video search newest-first** (`sort_by: created_at desc`) so a just-uploaded asset is always on page one, regardless of project size. This is the part that actually guarantees correctness.
- **Name the page budget and raise it to 25.** The comment states why it matters: this is a *verification* budget, not only a display one — anything past it is indistinguishable from "never uploaded".

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run lib/mcp/upload.test.ts` — 18 passed

Not covered by a regression test: the existing suite mocks the asset listing, so it never exercises pagination or ordering. Worth adding a case that stubs a listing longer than the budget and asserts a late-page `public_id` still attaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)