### PR TITLE
Fix attach_media verifying against an empty asset listing

### DIFF
--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
@@ -386,7 +386,21 @@ export function cloudinaryUserPrefix(userId: string) {
   return `${getCloudinaryConfig().folder}/${userId}/`;
 }
 
-export async function listCloudinaryAssets(userId: string, projectId?: string) {
+/**
+ * `wait: true` removes the cold-start timeout below.
+ *
+ * That timeout resolves to an EMPTY LIST when the real fetch loses the race,
+ * which is safe for rendering (an empty list just means "nothing to heal") and
+ * WRONG for verification: `attachMedia` reads a missing public_id as "never
+ * uploaded" and refuses a file that is live at that exact id. On a project with
+ * a few hundred assets the listing takes seconds, so the 400ms bound lost every
+ * time and no upload could ever be attached.
+ */
+export async function listCloudinaryAssets(
+  userId: string,
+  projectId?: string,
+  options?: { wait?: boolean },
+) {
   const key = assetListCacheKey(userId, projectId);
   const cached = assetListCache.get(key);
   if (cached && Date.now() - cached.at < ASSET_LIST_TTL_MS) return cached.promise;
@@ -413,7 +427,10 @@ export async function listCloudinaryAssets(userId: string, projectId?: string) {
 
   // COLD: nothing to serve, so wait — but not indefinitely. Losing the race
   // yields an empty list, which `healTimelineDocument` treats as "nothing to
-  // repair against" and passes the document through untouched.
+  // repair against" and passes the document through untouched. A caller that
+  // cannot tell "empty" from "not ready" — verification — opts out with `wait`.
+  if (options?.wait) return promise;
+
   let timer: ReturnType<typeof setTimeout> | undefined;
   const bounded = new Promise<CloudinaryAsset[]>((resolve) => {
     timer = setTimeout(() => resolve([]), COLD_ASSET_LIST_WAIT_MS);

--- a/apps/timeline-gstudio001/lib/mcp/upload.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.ts
@@ -143,7 +143,10 @@ export async function attachMedia(
   // nothing invalidated it, because the bytes went straight to Cloudinary
   // without passing through this server.
   forgetCloudinaryAssetList(requesterUid);
-  const assets = await listCloudinaryAssets(requesterUid, projectId);
+  // `wait: true` — the cold-listing timeout resolves to an EMPTY list, and an
+  // empty list here is indistinguishable from "the upload never happened". A
+  // render can afford that; a verification cannot.
+  const assets = await listCloudinaryAssets(requesterUid, projectId, { wait: true });
   const byPathname = new Map(assets.map((asset) => [asset.pathname, asset]));
 
   // EVERY missing id, not just the first. A batch that reports one failure per


### PR DESCRIPTION
## The real cause

My previous PR (#646) guessed pagination. It was wrong — the fix deployed and `attach_media` still refused live uploads. Here is what actually happens:

1. `attachMedia` calls `forgetCloudinaryAssetList()` — deliberately, so verification sees fresh data. This guarantees the next read takes the **cold** path.
2. The cold path races the real Cloudinary fetch against a **400 ms** timer.
3. The loser resolves to an **empty array**.
4. On a project with a few hundred assets the fetch loses every time — the code's own comment records **1844 ms for 311 assets**.
5. Every `public_id` reads as missing → *"No uploaded asset … Upload the file using the ticket from create_upload first"* — about a file that is live at that exact id and serving over HTTP 206.

Worse, #646 raised the page budget 5 → 25, which makes the listing slower and the race **more** likely to fire.

## The fix

The 400 ms bound is right for its documented purpose: don't block a page render to heal thumbnails, where an empty list harmlessly means "nothing to repair". It is wrong for verification, where an empty list is a false negative.

- `listCloudinaryAssets` takes `{ wait }` to opt out of the cold-start timeout
- `attachMedia` passes it, because it cannot distinguish "empty" from "not ready"

Nothing else changes: the cache, its TTL, and the render path keep the bound.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run lib/mcp/upload.test.ts` — 18 passed

Still not covered by a test: the suite mocks the listing, so neither the race nor the empty-list path is exercised. A case that resolves the listing slower than the bound and asserts `attachMedia` still succeeds would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)